### PR TITLE
Make 2nd searchbar also use typeahead

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -166,6 +166,114 @@
     <script>
         $(document).ready(function () {
             $('[data-toggle="tooltip"]').tooltip();
+
+            var bhValidators = new Bloodhound({
+                datumTokenizer: Bloodhound.tokenizers.whitespace,
+                queryTokenizer: Bloodhound.tokenizers.whitespace,
+                identify: function(obj) {
+                    return obj.index;
+                },
+                remote: {
+                    url: '/search/validators/%QUERY',
+                    wildcard: '%QUERY',
+                }
+            });
+
+            var bhBlocks = new Bloodhound({
+                datumTokenizer: Bloodhound.tokenizers.whitespace,
+                queryTokenizer: Bloodhound.tokenizers.whitespace,
+                identify: function(obj) {
+                    return obj.blockroot;
+                },
+                remote: {
+                    url: '/search/blocks/%QUERY',
+                    wildcard: '%QUERY',
+                }
+            });
+
+            var bhEpochs = new Bloodhound({
+                datumTokenizer: Bloodhound.tokenizers.whitespace,
+                queryTokenizer: Bloodhound.tokenizers.whitespace,
+                identify: function(obj) {
+                    return obj.blockroot;
+                },
+                remote: {
+                    url: '/search/epochs/%QUERY',
+                    wildcard: '%QUERY',
+                }
+            });
+
+            $('.typeahead').typeahead({
+                minLength: 1,
+                highlight: true,
+                hint: false,
+                autoselect: false,
+            }, {
+                limit: 5,
+                name: 'validators',
+                source: bhValidators,
+                display: 'pubkey',
+                templates: {
+                    header: '<h3>Validators</h3>',
+                    suggestion: function(data) {
+                        return `<div>${data.index}: ${data.pubkey.substring(0,16)}…</div>`;
+                    }
+                }
+            }, {
+                limit: 5,
+                name: 'blocks',
+                source: bhBlocks,
+                display: 'blockroot',
+                templates: {
+                    header: '<h3>Blocks</h3>',
+                    suggestion: function(data) {
+                        return `<div>${data.slot}: ${data.blockroot.substring(0,16)}…</div>`;
+                    }
+                }
+            }, {
+                limit: 5,
+                name: 'epochs',
+                source: bhEpochs,
+                display: 'epoch',
+                templates: {
+                    header: '<h3>Epochs</h3>',
+                    suggestion: function(data) {
+                        return `<div>${data.epoch}</div>`;
+                    }
+                }
+            });
+
+            $('.typeahead').on('focus', function(event) {
+                if(event.target.value !== '') {
+                    $(this).trigger($.Event('keydown', {
+                        keyCode: 40
+                    }));
+                }
+            });
+
+            $('.typeahead').on('input', function() {
+                $('.tt-suggestion').first().addClass('tt-cursor');
+            });
+
+            $('.tt-menu').on('mouseenter', function() {
+                $('.tt-suggestion').first().removeClass('tt-cursor');
+            });
+
+            $('.tt-menu').on('mouseleave', function() {
+                $('.tt-suggestion').first().addClass('tt-cursor');
+            });
+
+            $('.typeahead').on('typeahead:select', function(ev, sug) {
+                if (sug.blockroot !== undefined) {
+                    window.location = '/block/' + sug.blockroot;
+                } else if (sug.index !== undefined) {
+                    window.location = '/validator/' + sug.index;
+                } else if (sug.epoch !== undefined) {
+                    window.location = '/epoch/' + sug.epoch;
+                } else {
+                    console.log('invalid typeahead-selection', sug);
+                }
+            });
         });
 
         moment.locale((window.navigator.userLanguage || window.navigator.language).toLowerCase());
@@ -183,115 +291,6 @@
                 $(this).text(moment.unix(dt).format(format));
             }
         });
-
-        var bhValidators = new Bloodhound({
-            datumTokenizer: Bloodhound.tokenizers.whitespace,
-            queryTokenizer: Bloodhound.tokenizers.whitespace,
-            identify: function(obj) {
-                return obj.index
-            },
-            remote: {
-                url: '/search/validators/%QUERY',
-                wildcard: '%QUERY',
-            }
-        });
-
-        var bhBlocks = new Bloodhound({
-            datumTokenizer: Bloodhound.tokenizers.whitespace,
-            queryTokenizer: Bloodhound.tokenizers.whitespace,
-            identify: function(obj) {
-                return obj.blockroot
-            },
-            remote: {
-                url: '/search/blocks/%QUERY',
-                wildcard: '%QUERY',
-            }
-        });
-
-        var bhEpochs = new Bloodhound({
-            datumTokenizer: Bloodhound.tokenizers.whitespace,
-            queryTokenizer: Bloodhound.tokenizers.whitespace,
-            identify: function(obj) {
-                return obj.blockroot
-            },
-            remote: {
-                url: '/search/epochs/%QUERY',
-                wildcard: '%QUERY',
-            }
-        });
-
-        $(".typeahead").typeahead({
-            minLength: 1,
-            highlight: true,
-            hint: false,
-            autoselect: false,
-        }, {
-            limit: 5,
-            name: "validators",
-            source: bhValidators,
-            display: 'pubkey',
-            templates: {
-                header: '<h3>Validators</h3>',
-                suggestion: function(data) {
-                    return `<div>${data.index}: ${data.pubkey.substring(0,16)}…</div>`;
-                }
-            }
-        }, {
-            limit: 5,
-            name: "blocks",
-            source: bhBlocks,
-            display: 'blockroot',
-            templates: {
-                header: '<h3>Blocks</h3>',
-                suggestion: function(data) {
-                    return `<div>${data.slot}: ${data.blockroot.substring(0,16)}…</div>`;
-                }
-            }
-        }, {
-            limit: 5,
-            name: "epochs",
-            source: bhEpochs,
-            display: 'epoch',
-            templates: {
-                header: '<h3>Epochs</h3>',
-                suggestion: function(data) {
-                    return `<div>${data.epoch}</div>`;
-                }
-            }
-        });
-
-        $('.typeahead').on('focus', function(event) {
-            if(event.target.value !== '') {
-                $(this).trigger($.Event('keydown', {
-                    keyCode: 40
-                }));
-            }
-        });
-
-        $('.typeahead').on('input', function() {
-            $('.tt-suggestion').first().addClass('tt-cursor');
-        });
-
-        $('.tt-menu').on('mouseenter', function() {
-            $('.tt-suggestion').first().removeClass('tt-cursor');
-        });
-
-        $('.tt-menu').on('mouseleave', function() {
-            $('.tt-suggestion').first().addClass('tt-cursor');
-        });
-
-        $('.typeahead').on('typeahead:select', function(ev, sug) {
-            if (sug.blockroot !== undefined) {
-                window.location = '/block/' + sug.blockroot;
-            } else if (sug.index !== undefined) {
-                window.location = '/validator/' + sug.index;
-            } else if (sug.epoch !== undefined) {
-                window.location = '/epoch/' + sug.epoch;
-            } else {
-                console.log('invalid typeahead-selection', sug);
-            }
-        });
-
     </script>
 
     {{ template "js" .Data }}


### PR DESCRIPTION
Typeahead definitely worked on both search-bars before, not sure what changed that it is not working anymore for the 2nd searchbar.

This puts the typeahead-code inside the `$(document).ready` to make sure we catch all the `.typeahead` elements.