### PR TITLE
Lint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ docker/
 templates/imprint.html
 config.yml
 config-lighthouse.yml
+.*swp

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 all: explorer
 
+lint:
+	golint ./...
+
 explorer:
 	rm -rf bin/
 	mkdir -p bin/templates/

--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ We currently do not provide any pre-built binaries of the explorer. Docker image
 - Copy the config-example.yml file an adapt it to your environment
 - Start the explorer binary and pass the path to the config file as argument
 
+## Development
+Install golint. (see https://github.com/golang/lint)
+
 ## Commercial usage
 The explorer uses Highsoft charts which are not free for commercial and governmental use. If you plan to use the explorer for commercial purposes you currently need to purchase an appropriate HighSoft license.
 We are planning to switch out the Highsoft chart library with a less restrictive charting library (suggestions are welcome).

--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -20,6 +20,7 @@ var logger = logrus.New().WithField("module", "exporter")
 // to not be archived properly (see https://github.com/prysmaticlabs/prysm/issues/4165)
 var epochBlacklist = make(map[uint64]uint64)
 
+// Start will start the export of data from rpc into the database
 func Start(client rpc.RpcClient) error {
 
 	if utils.Config.Indexer.FullIndexOnStartup {
@@ -274,6 +275,7 @@ func Start(client rpc.RpcClient) error {
 	return nil
 }
 
+// MarkOrphanedBlocks will mark the orphaned blocks in the database
 func MarkOrphanedBlocks(startEpoch, endEpoch uint64, blocks []*types.MinimalBlock) error {
 	blocksMap := make(map[string]bool)
 
@@ -303,6 +305,7 @@ func MarkOrphanedBlocks(startEpoch, endEpoch uint64, blocks []*types.MinimalBloc
 	return db.UpdateCanonicalBlocks(startEpoch, endEpoch, orphanedBlocks)
 }
 
+// GetLastBlocks will get all blocks for a range of epochs
 func GetLastBlocks(startEpoch, endEpoch uint64, client rpc.RpcClient) ([]*types.MinimalBlock, error) {
 	wrappedBlocks := make([]*types.MinimalBlock, 0)
 
@@ -331,6 +334,7 @@ func GetLastBlocks(startEpoch, endEpoch uint64, client rpc.RpcClient) ([]*types.
 	return wrappedBlocks, nil
 }
 
+// ExportEpoch will export an epoch from rpc into the database
 func ExportEpoch(epoch uint64, client rpc.RpcClient) error {
 	start := time.Now()
 

--- a/handlers/block.go
+++ b/handlers/block.go
@@ -17,6 +17,7 @@ import (
 var blockTemplate = template.Must(template.New("block").Funcs(utils.GetTemplateFuncs()).ParseFiles("templates/layout.html", "templates/block.html"))
 var blockNotFoundTemplate = template.Must(template.New("blocknotfound").ParseFiles("templates/layout.html", "templates/blocknotfound.html"))
 
+// Block will return the data for a block
 func Block(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/html")
 

--- a/handlers/blocks.go
+++ b/handlers/blocks.go
@@ -15,6 +15,7 @@ import (
 
 var blocksTemplate = template.Must(template.New("blocks").Funcs(utils.GetTemplateFuncs()).ParseFiles("templates/layout.html", "templates/blocks.html"))
 
+// Blocks will return information about blocks using a go template
 func Blocks(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "text/html")
@@ -37,6 +38,7 @@ func Blocks(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// BlocksData will return information about blocks
 func BlocksData(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 

--- a/handlers/charts.go
+++ b/handlers/charts.go
@@ -14,6 +14,7 @@ import (
 var chartsTemplate = template.Must(template.New("charts").Funcs(utils.GetTemplateFuncs()).ParseFiles("templates/layout.html", "templates/charts.html"))
 var genericChartTemplate = template.Must(template.New("chart").Funcs(utils.GetTemplateFuncs()).ParseFiles("templates/layout.html", "templates/genericchart.html"))
 
+// Charts uses a go template for presenting the page to show charts
 func Charts(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "text/html")
@@ -36,6 +37,7 @@ func Charts(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// BlocksChart will show the history of daily blocks proposed chart
 func BlocksChart(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/html")
 
@@ -125,6 +127,7 @@ func BlocksChart(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// ActiveValidatorChart will show the Active Validators Chart
 func ActiveValidatorChart(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/html")
 
@@ -183,6 +186,7 @@ func ActiveValidatorChart(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// StakedEtherChart will show the Staked Ether Chart
 func StakedEtherChart(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/html")
 
@@ -242,6 +246,7 @@ func StakedEtherChart(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// AverageBalanceChart will show the Average Validator Balance Chart
 func AverageBalanceChart(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/html")
 

--- a/handlers/epoch.go
+++ b/handlers/epoch.go
@@ -17,6 +17,7 @@ import (
 var epochTemplate = template.Must(template.New("epoch").Funcs(template.FuncMap{"formatBlockStatus": utils.FormatBlockStatus}).ParseFiles("templates/layout.html", "templates/epoch.html"))
 var epochNotFoundTemplate = template.Must(template.New("epochnotfound").ParseFiles("templates/layout.html", "templates/epochnotfound.html"))
 
+// Epoch will show the epoch using a go template
 func Epoch(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/html")
 

--- a/handlers/epochs.go
+++ b/handlers/epochs.go
@@ -15,6 +15,7 @@ import (
 
 var epochsTemplate = template.Must(template.New("epochs").ParseFiles("templates/layout.html", "templates/epochs.html"))
 
+// Epochs will return the epochs using a go template
 func Epochs(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "text/html")
@@ -37,6 +38,7 @@ func Epochs(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// EpochsData will return the epoch data using a go template
 func EpochsData(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 

--- a/handlers/faq.go
+++ b/handlers/faq.go
@@ -12,6 +12,7 @@ import (
 
 var faqTemplate = template.Must(template.ParseFiles("templates/layout.html", "templates/faq.html"))
 
+// Faq will return the data from the frequently asked questions (FAQ) using a go template
 func Faq(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/html")
 

--- a/handlers/imprint.go
+++ b/handlers/imprint.go
@@ -10,6 +10,7 @@ import (
 	"time"
 )
 
+// Imprint will show the imprint data using a go template
 func Imprint(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/html")
 

--- a/handlers/index.go
+++ b/handlers/index.go
@@ -13,6 +13,7 @@ import (
 
 var indexTemplate = template.Must(template.New("index").Funcs(utils.GetTemplateFuncs()).ParseFiles("templates/layout.html", "templates/index.html"))
 
+// Index will return the main "index" page using a go template
 func Index(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/html")
 
@@ -34,6 +35,7 @@ func Index(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// IndexPageData will show the main "index" page in json format
 func IndexPageData(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 

--- a/handlers/search.go
+++ b/handlers/search.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gorilla/mux"
 )
 
+// Search handles search requests
 func Search(w http.ResponseWriter, r *http.Request) {
 
 	search := r.FormValue("search")

--- a/handlers/validator.go
+++ b/handlers/validator.go
@@ -20,6 +20,7 @@ import (
 var validatorTemplate = template.Must(template.New("validator").ParseFiles("templates/layout.html", "templates/validator.html"))
 var validatorNotFoundTemplate = template.Must(template.New("validatornotfound").ParseFiles("templates/layout.html", "templates/validatornotfound.html"))
 
+// Validator returns validator data using a go template
 func Validator(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/html")
 
@@ -250,6 +251,7 @@ func Validator(w http.ResponseWriter, r *http.Request) {
 
 }
 
+// ValidatorProposedBlocks returns a validator's proposed blocks in json
 func ValidatorProposedBlocks(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 
@@ -345,6 +347,7 @@ func ValidatorProposedBlocks(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// ValidatorAttestations returns a validators attestations in json
 func ValidatorAttestations(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 

--- a/handlers/validators.go
+++ b/handlers/validators.go
@@ -16,6 +16,7 @@ import (
 
 var validatorsTemplate = template.Must(template.New("validators").ParseFiles("templates/layout.html", "templates/validators.html"))
 
+// Validators returns the validators using a go template
 func Validators(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/html")
 
@@ -64,6 +65,7 @@ func Validators(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// ValidatorsDataPending returns the validators that have data pending in json
 func ValidatorsDataPending(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 
@@ -152,6 +154,7 @@ func ValidatorsDataPending(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// ValidatorsDataActive will return the validators with active data in json
 func ValidatorsDataActive(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 
@@ -248,6 +251,7 @@ func ValidatorsDataActive(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// ValidatorsDataEjected returns the validators that have data ejected in json
 func ValidatorsDataEjected(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 

--- a/handlers/vis.go
+++ b/handlers/vis.go
@@ -16,6 +16,7 @@ import (
 var visTemplate = template.Must(template.New("vis").ParseFiles("templates/layout.html", "templates/vis.html"))
 var visVotesTemplate = template.Must(template.New("vis").ParseFiles("templates/layout.html", "templates/vis_votes.html"))
 
+// Vis returns the visualizations using a go template
 func Vis(w http.ResponseWriter, r *http.Request) {
 
 	var err error
@@ -40,6 +41,7 @@ func Vis(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// VisBlocks returns the visualizations in json
 func VisBlocks(w http.ResponseWriter, r *http.Request) {
 	var err error
 
@@ -86,6 +88,7 @@ func VisBlocks(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// VisVotes shows the votes visualizations using a go template
 func VisVotes(w http.ResponseWriter, r *http.Request) {
 	var err error
 

--- a/rpc/prysm.go
+++ b/rpc/prysm.go
@@ -16,6 +16,7 @@ import (
 	ptypes "github.com/golang/protobuf/ptypes/empty"
 )
 
+// PrysmClient holds information about the Prysm Client
 type PrysmClient struct {
 	client              ethpb.BeaconChainClient
 	conn                *grpc.ClientConn
@@ -23,6 +24,7 @@ type PrysmClient struct {
 	assignmentsCacheMux *sync.Mutex
 }
 
+// NewPrysmClient is used for a new Prysm client connection
 func NewPrysmClient(endpoint string) (*PrysmClient, error) {
 	dialOpt := grpc.WithInsecure()
 	conn, err := grpc.Dial(endpoint, dialOpt)
@@ -44,12 +46,14 @@ func NewPrysmClient(endpoint string) (*PrysmClient, error) {
 	return client, nil
 }
 
-func (self *PrysmClient) Close() {
-	self.conn.Close()
+// Close will close a Prysm client connection
+func (pc *PrysmClient) Close() {
+	pc.conn.Close()
 }
 
-func (self *PrysmClient) GetChainHead() (*types.ChainHead, error) {
-	headResponse, err := self.client.GetChainHead(context.Background(), &ptypes.Empty{})
+// GetChainHead will get the chain head from a Prysm client
+func (pc *PrysmClient) GetChainHead() (*types.ChainHead, error) {
+	headResponse, err := pc.client.GetChainHead(context.Background(), &ptypes.Empty{})
 
 	if err != nil {
 		return nil, err
@@ -71,14 +75,15 @@ func (self *PrysmClient) GetChainHead() (*types.ChainHead, error) {
 	}, nil
 }
 
-func (self *PrysmClient) GetValidatorQueue() (*types.ValidatorQueue, map[string]uint64, error) {
+// GetValidatorQueue will get the validator queue from a Prysm client
+func (pc *PrysmClient) GetValidatorQueue() (*types.ValidatorQueue, map[string]uint64, error) {
 	var err error
 
 	validatorIndices := make(map[string]uint64)
 
 	validatorBalancesResponse := &ethpb.ValidatorBalances{}
 	for {
-		validatorBalancesResponse, err = self.client.ListValidatorBalances(context.Background(), &ethpb.ListValidatorBalancesRequest{PageToken: validatorBalancesResponse.NextPageToken, PageSize: utils.PageSize})
+		validatorBalancesResponse, err = pc.client.ListValidatorBalances(context.Background(), &ethpb.ListValidatorBalancesRequest{PageToken: validatorBalancesResponse.NextPageToken, PageSize: utils.PageSize})
 		if err != nil {
 			return nil, nil, fmt.Errorf("error retrieving validator balances response: %v", err)
 		}
@@ -95,7 +100,7 @@ func (self *PrysmClient) GetValidatorQueue() (*types.ValidatorQueue, map[string]
 		}
 	}
 
-	validators, err := self.client.GetValidatorQueue(context.Background(), &ptypes.Empty{})
+	validators, err := pc.client.GetValidatorQueue(context.Background(), &ptypes.Empty{})
 
 	if err != nil {
 		return nil, nil, fmt.Errorf("error retrieving validator queue data: %v", err)
@@ -108,8 +113,9 @@ func (self *PrysmClient) GetValidatorQueue() (*types.ValidatorQueue, map[string]
 	}, validatorIndices, nil
 }
 
-func (self *PrysmClient) GetAttestationPool() ([]*types.Attestation, error) {
-	attestationsResponse, err := self.client.AttestationPool(context.Background(), &ptypes.Empty{})
+// GetAttestationPool will get the attestation pool from a Prysm client
+func (pc *PrysmClient) GetAttestationPool() ([]*types.Attestation, error) {
+	attestationsResponse, err := pc.client.AttestationPool(context.Background(), &ptypes.Empty{})
 
 	if err != nil {
 		return nil, fmt.Errorf("error retrieving attestation pool data: %v", err)
@@ -140,14 +146,15 @@ func (self *PrysmClient) GetAttestationPool() ([]*types.Attestation, error) {
 	return attestations, nil
 }
 
-func (self *PrysmClient) GetEpochAssignments(epoch uint64) (*types.EpochAssignments, error) {
+// GetEpochAssignments will get the epoch assignments from a Prysm client
+func (pc *PrysmClient) GetEpochAssignments(epoch uint64) (*types.EpochAssignments, error) {
 
-	self.assignmentsCacheMux.Lock()
-	defer self.assignmentsCacheMux.Unlock()
+	pc.assignmentsCacheMux.Lock()
+	defer pc.assignmentsCacheMux.Unlock()
 
 	var err error
 
-	cachedValue, found := self.assignmentsCache.Get(epoch)
+	cachedValue, found := pc.assignmentsCache.Get(epoch)
 	if found {
 		return cachedValue.(*types.EpochAssignments), nil
 	}
@@ -162,7 +169,7 @@ func (self *PrysmClient) GetEpochAssignments(epoch uint64) (*types.EpochAssignme
 
 	validatorBalancesResponse := &ethpb.ValidatorBalances{}
 	for {
-		validatorBalancesResponse, err = self.client.ListValidatorBalances(context.Background(), &ethpb.ListValidatorBalancesRequest{PageToken: validatorBalancesResponse.NextPageToken, PageSize: utils.PageSize, QueryFilter: &ethpb.ListValidatorBalancesRequest_Epoch{Epoch: epoch}})
+		validatorBalancesResponse, err = pc.client.ListValidatorBalances(context.Background(), &ethpb.ListValidatorBalancesRequest{PageToken: validatorBalancesResponse.NextPageToken, PageSize: utils.PageSize, QueryFilter: &ethpb.ListValidatorBalancesRequest_Epoch{Epoch: epoch}})
 		if err != nil {
 			logger.Printf("error retrieving validator balances response: %v", err)
 			break
@@ -186,7 +193,7 @@ func (self *PrysmClient) GetEpochAssignments(epoch uint64) (*types.EpochAssignme
 	validatorAssignmentResponse := &ethpb.ValidatorAssignments{}
 
 	for validatorAssignmentResponse.NextPageToken == "" || len(validatorAssignmentes) < int(validatorAssignmentResponse.TotalSize) {
-		validatorAssignmentResponse, err = self.client.ListValidatorAssignments(context.Background(), &ethpb.ListValidatorAssignmentsRequest{PageToken: validatorAssignmentResponse.NextPageToken, PageSize: utils.PageSize, QueryFilter: &ethpb.ListValidatorAssignmentsRequest_Epoch{Epoch: epoch}})
+		validatorAssignmentResponse, err = pc.client.ListValidatorAssignments(context.Background(), &ethpb.ListValidatorAssignmentsRequest{PageToken: validatorAssignmentResponse.NextPageToken, PageSize: utils.PageSize, QueryFilter: &ethpb.ListValidatorAssignmentsRequest_Epoch{Epoch: epoch}})
 		if err != nil {
 			return nil, fmt.Errorf("error retrieving validator assignment response for caching: %v", err)
 		}
@@ -213,13 +220,14 @@ func (self *PrysmClient) GetEpochAssignments(epoch uint64) (*types.EpochAssignme
 	}
 
 	if len(assignments.AttestorAssignments) > 0 && len(assignments.ProposerAssignments) > 0 {
-		self.assignmentsCache.Add(epoch, assignments)
+		pc.assignmentsCache.Add(epoch, assignments)
 	}
 
 	return assignments, nil
 }
 
-func (self *PrysmClient) GetEpochData(epoch uint64) (*types.EpochData, error) {
+// GetEpochData will get the epoch data from a Prysm client
+func (pc *PrysmClient) GetEpochData(epoch uint64) (*types.EpochData, error) {
 	var err error
 
 	data := &types.EpochData{}
@@ -231,7 +239,7 @@ func (self *PrysmClient) GetEpochData(epoch uint64) (*types.EpochData, error) {
 
 	validatorBalancesResponse := &ethpb.ValidatorBalances{}
 	for {
-		validatorBalancesResponse, err = self.client.ListValidatorBalances(context.Background(), &ethpb.ListValidatorBalancesRequest{PageToken: validatorBalancesResponse.NextPageToken, PageSize: utils.PageSize, QueryFilter: &ethpb.ListValidatorBalancesRequest_Epoch{Epoch: epoch}})
+		validatorBalancesResponse, err = pc.client.ListValidatorBalances(context.Background(), &ethpb.ListValidatorBalancesRequest{PageToken: validatorBalancesResponse.NextPageToken, PageSize: utils.PageSize, QueryFilter: &ethpb.ListValidatorBalancesRequest_Epoch{Epoch: epoch}})
 		if err != nil {
 			return nil, err
 		}
@@ -254,7 +262,7 @@ func (self *PrysmClient) GetEpochData(epoch uint64) (*types.EpochData, error) {
 	}
 	logger.Printf("Retrieved data for %v validator balances for epoch %v", len(data.ValidatorBalances), epoch)
 
-	data.ValidatorAssignmentes, err = self.GetEpochAssignments(epoch)
+	data.ValidatorAssignmentes, err = pc.GetEpochAssignments(epoch)
 	if err != nil {
 		return nil, fmt.Errorf("error retrieving assignments for epoch %v: %v", epoch, err)
 	}
@@ -269,7 +277,7 @@ func (self *PrysmClient) GetEpochData(epoch uint64) (*types.EpochData, error) {
 			continue
 		}
 
-		blocks, err := self.GetBlocksBySlot(slot)
+		blocks, err := pc.GetBlocksBySlot(slot)
 
 		if err != nil {
 			return nil, err
@@ -331,7 +339,7 @@ func (self *PrysmClient) GetEpochData(epoch uint64) (*types.EpochData, error) {
 	data.Validators = make([]*types.Validator, 0)
 	validatorResponse := &ethpb.Validators{}
 	for {
-		validatorResponse, err = self.client.ListValidators(context.Background(), &ethpb.ListValidatorsRequest{PageToken: validatorResponse.NextPageToken, PageSize: utils.PageSize, QueryFilter: &ethpb.ListValidatorsRequest_Epoch{Epoch: epoch}})
+		validatorResponse, err = pc.client.ListValidators(context.Background(), &ethpb.ListValidatorsRequest{PageToken: validatorResponse.NextPageToken, PageSize: utils.PageSize, QueryFilter: &ethpb.ListValidatorsRequest_Epoch{Epoch: epoch}})
 		if err != nil {
 			logger.Printf("error retrieving validator response: %v", err)
 			break
@@ -362,7 +370,7 @@ func (self *PrysmClient) GetEpochData(epoch uint64) (*types.EpochData, error) {
 	// Retrieve the beacon committees for the epoch
 	data.BeaconCommittees = make(map[uint64][]*types.BeaconCommitteItem)
 	beaconCommitteesResponse := &ethpb.BeaconCommittees{}
-	beaconCommitteesResponse, err = self.client.ListBeaconCommittees(context.Background(), &ethpb.ListCommitteesRequest{QueryFilter: &ethpb.ListCommitteesRequest_Epoch{Epoch: epoch}})
+	beaconCommitteesResponse, err = pc.client.ListBeaconCommittees(context.Background(), &ethpb.ListCommitteesRequest{QueryFilter: &ethpb.ListCommitteesRequest_Epoch{Epoch: epoch}})
 	if err != nil {
 		logger.Printf("error retrieving beacon committees response: %v", err)
 	} else {
@@ -380,7 +388,7 @@ func (self *PrysmClient) GetEpochData(epoch uint64) (*types.EpochData, error) {
 		}
 	}
 
-	data.EpochParticipationStats, err = self.GetValidatorParticipation(epoch)
+	data.EpochParticipationStats, err = pc.GetValidatorParticipation(epoch)
 	if err != nil {
 		return nil, fmt.Errorf("error retrieving epoch participation statistics for epoch %v: %v", epoch, err)
 	}
@@ -388,10 +396,11 @@ func (self *PrysmClient) GetEpochData(epoch uint64) (*types.EpochData, error) {
 	return data, nil
 }
 
-func (self *PrysmClient) GetBlocksBySlot(slot uint64) ([]*types.Block, error) {
+// GetBlocksBySlot will get blocks by slot from a Prysm client
+func (pc *PrysmClient) GetBlocksBySlot(slot uint64) ([]*types.Block, error) {
 
 	blocks := make([]*types.Block, 0)
-	blocksResponse, err := self.client.ListBlocks(context.Background(), &ethpb.ListBlocksRequest{PageSize: utils.PageSize, QueryFilter: &ethpb.ListBlocksRequest_Slot{Slot: slot}, IncludeNoncanonical: true})
+	blocksResponse, err := pc.client.ListBlocks(context.Background(), &ethpb.ListBlocksRequest{PageSize: utils.PageSize, QueryFilter: &ethpb.ListBlocksRequest_Slot{Slot: slot}, IncludeNoncanonical: true})
 	if err != nil {
 		return nil, err
 	}
@@ -514,7 +523,7 @@ func (self *PrysmClient) GetBlocksBySlot(slot uint64) ([]*types.Block, error) {
 			}
 
 			aggregationBits := bitfield.Bitlist(a.AggregationBits)
-			assignments, err := self.GetEpochAssignments(a.Data.Slot / utils.Config.Chain.SlotsPerEpoch)
+			assignments, err := pc.GetEpochAssignments(a.Data.Slot / utils.Config.Chain.SlotsPerEpoch)
 			if err != nil {
 				return nil, fmt.Errorf("error receiving epoch assignment for epoch %v: %v", a.Data.Slot/utils.Config.Chain.SlotsPerEpoch, err)
 			}
@@ -557,8 +566,9 @@ func (self *PrysmClient) GetBlocksBySlot(slot uint64) ([]*types.Block, error) {
 	return blocks, nil
 }
 
-func (self *PrysmClient) GetValidatorParticipation(epoch uint64) (*types.ValidatorParticipation, error) {
-	epochParticipationStatistics, err := self.client.GetValidatorParticipation(context.Background(), &ethpb.GetValidatorParticipationRequest{QueryFilter: &ethpb.GetValidatorParticipationRequest_Epoch{Epoch: epoch}})
+// GetValidatorParticipation will get the validator participation from Prysm client
+func (pc *PrysmClient) GetValidatorParticipation(epoch uint64) (*types.ValidatorParticipation, error) {
+	epochParticipationStatistics, err := pc.client.GetValidatorParticipation(context.Background(), &ethpb.GetValidatorParticipationRequest{QueryFilter: &ethpb.GetValidatorParticipationRequest_Epoch{Epoch: epoch}})
 	if err != nil {
 		logger.Printf("error retrieving epoch participation statistics: %v", err)
 		return &types.ValidatorParticipation{
@@ -568,13 +578,12 @@ func (self *PrysmClient) GetValidatorParticipation(epoch uint64) (*types.Validat
 			VotedEther:              0,
 			EligibleEther:           0,
 		}, nil
-	} else {
-		return &types.ValidatorParticipation{
-			Epoch:                   epoch,
-			Finalized:               epochParticipationStatistics.Finalized,
-			GlobalParticipationRate: epochParticipationStatistics.Participation.GlobalParticipationRate,
-			VotedEther:              epochParticipationStatistics.Participation.VotedEther,
-			EligibleEther:           epochParticipationStatistics.Participation.EligibleEther,
-		}, nil
 	}
+	return &types.ValidatorParticipation{
+		Epoch:                   epoch,
+		Finalized:               epochParticipationStatistics.Finalized,
+		GlobalParticipationRate: epochParticipationStatistics.Participation.GlobalParticipationRate,
+		VotedEther:              epochParticipationStatistics.Participation.VotedEther,
+		EligibleEther:           epochParticipationStatistics.Participation.EligibleEther,
+	}, nil
 }

--- a/rpc/rpc_client.go
+++ b/rpc/rpc_client.go
@@ -5,6 +5,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+// RpcClient provides an interface for RPC clients
 type RpcClient interface {
 	GetChainHead() (*types.ChainHead, error)
 	GetEpochData(epoch uint64) (*types.EpochData, error)

--- a/services/services.go
+++ b/services/services.go
@@ -19,6 +19,7 @@ var ready = sync.WaitGroup{}
 
 var logger = logrus.New().WithField("module", "services")
 
+// Init will initialize the services
 func Init() {
 	ready.Add(2)
 	go epochUpdater()
@@ -160,14 +161,17 @@ func getIndexPageData() (*types.IndexPageData, error) {
 	return data, nil
 }
 
+// LatestEpoch will return the latest epoch
 func LatestEpoch() uint64 {
 	return atomic.LoadUint64(&latestEpoch)
 }
 
+// LatestIndexPageData returns the latest index page data
 func LatestIndexPageData() *types.IndexPageData {
 	return indexPageData.Load().(*types.IndexPageData)
 }
 
+// IsSyncing returns true if the chain is still syncing
 func IsSyncing() bool {
 	return time.Now().Add(time.Minute * -5).After(utils.EpochToTime(LatestEpoch()))
 }

--- a/types/config.go
+++ b/types/config.go
@@ -1,5 +1,6 @@
 package types
 
+// Config is a struct to hold the configuration data
 type Config struct {
 	Database struct {
 		Username string `yaml:"user", envconfig:"DB_USERNAME"`

--- a/types/exporter.go
+++ b/types/exporter.go
@@ -4,6 +4,7 @@ import (
 	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
 )
 
+// ChainHead is a struct to hold chain head data
 type ChainHead struct {
 	HeadSlot                   uint64
 	HeadEpoch                  uint64
@@ -19,6 +20,7 @@ type ChainHead struct {
 	PreviousJustifiedBlockRoot []byte
 }
 
+// EpochData is a struct to hold epoch data
 type EpochData struct {
 	Epoch                   uint64
 	Validators              []*Validator
@@ -30,6 +32,7 @@ type EpochData struct {
 	EpochParticipationStats *ValidatorParticipation
 }
 
+// ValidatorParticipation is a struct to hold validator participation data
 type ValidatorParticipation struct {
 	Epoch                   uint64
 	Finalized               bool
@@ -38,16 +41,19 @@ type ValidatorParticipation struct {
 	EligibleEther           uint64
 }
 
+// ValidatorBalance is a struct to hold validator balance data
 type ValidatorBalance struct {
 	PublicKey []byte
 	Index     uint64
 	Balance   uint64
 }
 
+// BeaconCommitteItem is a struct to hold beacon commitee data
 type BeaconCommitteItem struct {
 	ValidatorIndices []uint64
 }
 
+// Validator is a struct to hold validator data
 type Validator struct {
 	PublicKey                  []byte
 	WithdrawalCredentials      []byte
@@ -59,12 +65,14 @@ type Validator struct {
 	WithdrawableEpoch          uint64
 }
 
+// ValidatorQueue is a struct to hold validator queue data
 type ValidatorQueue struct {
 	ChurnLimit           uint64
 	ActivationPublicKeys [][]byte
 	ExitPublicKeys       [][]byte
 }
 
+// Block is a struct to hold block data
 type Block struct {
 	Status            uint64
 	Proposer          uint64
@@ -84,23 +92,27 @@ type Block struct {
 	VoluntaryExits    []*VoluntaryExit
 }
 
+// Eth1Data is a struct to hold the ETH1 data
 type Eth1Data struct {
 	DepositRoot  []byte
 	DepositCount uint64
 	BlockHash    []byte
 }
 
+// ProposerSlashing is a struct to hold proposer slashing data
 type ProposerSlashing struct {
 	ProposerIndex uint64
 	Header_1      *Block
 	Header_2      *Block
 }
 
+// AttesterSlashing is a struct to hold attester slashing
 type AttesterSlashing struct {
 	Attestation_1 *IndexedAttestation
 	Attestation_2 *IndexedAttestation
 }
 
+// IndexedAttestation is a struct to hold indexed attestation data
 type IndexedAttestation struct {
 	CustodyBit_0Indices []uint64
 	CustodyBit_1Indices []uint64
@@ -108,6 +120,7 @@ type IndexedAttestation struct {
 	Signature           []byte
 }
 
+// Attestation is a struct to hold attestation header data
 type Attestation struct {
 	AggregationBits []byte
 	Attesters       []uint64
@@ -116,6 +129,7 @@ type Attestation struct {
 	Signature       []byte
 }
 
+// AttestationData to hold attestation detail data
 type AttestationData struct {
 	Slot            uint64
 	CommitteeIndex  uint64
@@ -124,11 +138,13 @@ type AttestationData struct {
 	Target          *Checkpoint
 }
 
+// Checkpoint is a struct to hold checkpoint data
 type Checkpoint struct {
 	Epoch uint64
 	Root  []byte
 }
 
+// Deposit is a struct to hold deposit data
 type Deposit struct {
 	Proof                 [][]byte
 	PublicKey             []byte
@@ -137,12 +153,14 @@ type Deposit struct {
 	Signature             []byte
 }
 
+// VoluntaryExit is a struct to hold voluntary exit data
 type VoluntaryExit struct {
 	Epoch          uint64
 	ValidatorIndex uint64
 	Signature      []byte
 }
 
+// BlockContainer is a struct to hold block container data
 type BlockContainer struct {
 	Status   uint64
 	Proposer uint64
@@ -150,6 +168,7 @@ type BlockContainer struct {
 	Block *ethpb.BeaconBlockContainer
 }
 
+// MinimalBlock is a struct to hold minimal block data
 type MinimalBlock struct {
 	Epoch      uint64 `db:"epoch"`
 	Slot       uint64 `db:"slot"`
@@ -157,12 +176,14 @@ type MinimalBlock struct {
 	ParentRoot []byte `db:"parentroot"`
 }
 
+// BlockComparisonContainer is a struct to hold block comparison data
 type BlockComparisonContainer struct {
 	Epoch uint64
 	Db    *MinimalBlock
 	Node  *MinimalBlock
 }
 
+// EpochAssignments is a struct to hold epoch assignment data
 type EpochAssignments struct {
 	ProposerAssignments map[uint64]uint64
 	AttestorAssignments map[string]uint64

--- a/types/templates.go
+++ b/types/templates.go
@@ -7,6 +7,7 @@ import (
 	"github.com/lib/pq"
 )
 
+// PageData is a struct to hold web page data
 type PageData struct {
 	Active             string
 	Meta               *Meta
@@ -14,6 +15,7 @@ type PageData struct {
 	Data               interface{}
 }
 
+// Meta is a struct to hold metadata about the page
 type Meta struct {
 	Title       string
 	Description string
@@ -24,6 +26,7 @@ type Meta struct {
 	Tdata2      string
 }
 
+// IndexPageData is a struct to hold info for the main web page
 type IndexPageData struct {
 	CurrentEpoch              uint64                 `json:"current_epoch"`
 	CurrentFinalizedEpoch     uint64                 `json:"current_finalized_epoch"`
@@ -40,6 +43,7 @@ type IndexPageData struct {
 	Subtitle                  template.HTML          `json:"-"`
 }
 
+// IndexPageDataBlocks is a struct to hold detail data for the main web page
 type IndexPageDataBlocks struct {
 	Epoch              uint64        `json:"epoch"`
 	Slot               uint64        `json:"slot"`
@@ -59,6 +63,7 @@ type IndexPageDataBlocks struct {
 	Votes              uint64        `db:"votes" json:"votes"`
 }
 
+// IndexPageEpochHistory is a struct to hold the epoch history for the main web page
 type IndexPageEpochHistory struct {
 	Epoch           uint64 `db:"epoch"`
 	ValidatorsCount uint64 `db:"validatorscount"`
@@ -66,12 +71,14 @@ type IndexPageEpochHistory struct {
 	Finalized       bool   `db:"finalized"`
 }
 
+// ValidatorsPageData is a struct to hold data about the validators page
 type ValidatorsPageData struct {
 	ActiveCount  uint64
 	PendingCount uint64
 	EjectedCount uint64
 }
 
+// ValidatorsPageDataValidators is a struct to hold data about validators for the validators page
 type ValidatorsPageDataValidators struct {
 	Epoch                      uint64 `db:"epoch"`
 	PublicKey                  []byte `db:"pubkey"`
@@ -86,6 +93,7 @@ type ValidatorsPageDataValidators struct {
 	Status                     string
 }
 
+// ValidatorPageData is a struct to hold data for the validators page
 type ValidatorPageData struct {
 	Epoch                            uint64 `db:"epoch"`
 	ValidatorIndex                   uint64 `db:"validatorindex"`
@@ -114,6 +122,7 @@ type ValidatorPageData struct {
 	EffectiveBalanceHistoryChartData [][]float64
 }
 
+// DailyProposalCount is a struct for the daily proposal count data
 type DailyProposalCount struct {
 	Day      int64
 	Proposed uint
@@ -121,11 +130,13 @@ type DailyProposalCount struct {
 	Orphaned uint
 }
 
+// ValidatorBalanceHistory is a struct for the validator balance history data
 type ValidatorBalanceHistory struct {
 	Epoch   uint64 `db:"epoch"`
 	Balance uint64 `db:"balance"`
 }
 
+// ValidatorAttestation is a struct for the validators attestations data
 type ValidatorAttestation struct {
 	Epoch          uint64 `db:"epoch"`
 	AttesterSlot   uint64 `db:"attesterslot"`
@@ -133,12 +144,14 @@ type ValidatorAttestation struct {
 	Status         uint64 `db:"status"`
 }
 
+// VisPageData is a struct to hold the visualizations page data
 type VisPageData struct {
 	ChartData  []*VisChartData
 	StartEpoch uint64
 	EndEpoch   uint64
 }
 
+// VisChartData is a struct to hold the visualizations chart data
 type VisChartData struct {
 	Slot       uint64 `db:"slot" json:"-"`
 	BlockRoot  []byte `db:"blockroot" json:"-"`
@@ -153,10 +166,12 @@ type VisChartData struct {
 	Difficulty uint64   `json:"difficulty"`
 }
 
+// VisVotesPageData is a struct for the visualization votes page data
 type VisVotesPageData struct {
 	ChartData []*VotesVisChartData
 }
 
+// VotesVisChartData is a struct for the visualization chart data
 type VotesVisChartData struct {
 	Slot       uint64        `db:"slot" json:"slot"`
 	BlockRoot  string        `db:"blockroot" json:"blockRoot"`
@@ -164,6 +179,7 @@ type VotesVisChartData struct {
 	Validators pq.Int64Array `db:"validators" json:"validators"`
 }
 
+// BlockPageData is a struct block data used in the block page
 type BlockPageData struct {
 	Epoch                  uint64 `db:"epoch"`
 	Slot                   uint64 `db:"slot"`
@@ -193,11 +209,13 @@ type BlockPageData struct {
 	Votes        []*BlockPageAttestation // Attestations that voted for that block
 }
 
+// BlockPageMinMaxSlot is a struct to hold min/max slot data
 type BlockPageMinMaxSlot struct {
 	MinSlot uint64
 	MaxSlot uint64
 }
 
+// BlockPageAttestation is a struct to hold attestations on the block page
 type BlockPageAttestation struct {
 	BlockSlot       uint64        `db:"block_slot"`
 	BlockIndex      uint64        `db:"block_index"`
@@ -213,6 +231,7 @@ type BlockPageAttestation struct {
 	TargetRoot      []byte        `db:"target_root"`
 }
 
+// BlockPageDeposit is a struct to hold data for deposits on the block page
 type BlockPageDeposit struct {
 	PublicKey             []byte `db:"publickey"`
 	WithdrawalCredentials []byte `db:"withdrawalcredentials"`
@@ -221,6 +240,7 @@ type BlockPageDeposit struct {
 	Signature             []byte `db:"signature"`
 }
 
+// DataTableResponse is a struct to hold data for data table responses
 type DataTableResponse struct {
 	Draw            uint64          `json:"draw"`
 	RecordsTotal    uint64          `json:"recordsTotal"`
@@ -228,6 +248,7 @@ type DataTableResponse struct {
 	Data            [][]interface{} `json:"data"`
 }
 
+// EpochsPageData is a struct to hold epoch data for the epochs page
 type EpochsPageData struct {
 	Epoch                   uint64  `db:"epoch"`
 	BlocksCount             uint64  `db:"blockscount"`
@@ -244,6 +265,7 @@ type EpochsPageData struct {
 	VotedEther              uint64  `db:"votedether"`
 }
 
+// EpochPageData is a struct to hold detailed epoch data for the epoch page
 type EpochPageData struct {
 	Epoch                            uint64  `db:"epoch"`
 	BlocksCount                      uint64  `db:"blockscount"`
@@ -269,25 +291,30 @@ type EpochPageData struct {
 	PreviousEpoch uint64
 }
 
+// EpochPageMinMaxSlot is a struct for the min/max epoch data
 type EpochPageMinMaxSlot struct {
 	MinEpoch uint64
 	MaxEpoch uint64
 }
 
+// SearchAheadEpochsResult is a struct to hold the search ahead epochs results
 type SearchAheadEpochsResult []struct {
 	Epoch string `db:"epoch" json:"epoch,omitempty"`
 }
 
+// SearchAheadBlocksResult is a struct to hold the search ahead blocks results
 type SearchAheadBlocksResult []struct {
 	Slot string `db:"slot" json:"slot,omitempty"`
 	Root string `db:"blockroot" json:"blockroot,omitempty"`
 }
 
+// SearchAheadValidatorsResult is a struct to hold the search ahead validators results
 type SearchAheadValidatorsResult []struct {
 	Index  string `db:"index" json:"index,omitempty"`
 	Pubkey string `db:"pubkey" json:"pubkey,omitempty"`
 }
 
+// GenericChartData is a struct to hold chart data
 type GenericChartData struct {
 	Title        string                    `json:"title"`
 	Subtitle     string                    `json:"subtitle"`
@@ -297,6 +324,7 @@ type GenericChartData struct {
 	Series       []*GenericChartDataSeries `json:"series"`
 }
 
+// GenericChartDataSeries is a struct to hold chart series data
 type GenericChartDataSeries struct {
 	Name string      `json:"name"`
 	Data [][]float64 `json:"data"`

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -15,11 +15,13 @@ import (
 	"github.com/kelseyhightower/envconfig"
 )
 
+// PageSize is the number of records used when fetching RPC data
 const PageSize = 500
 
-// Global accessible configs
+// Config is the globally accessible configuration
 var Config *types.Config
 
+// GetTemplateFuncs will get the template functions
 func GetTemplateFuncs() template.FuncMap {
 	return template.FuncMap{
 		"formatBlockStatus": FormatBlockStatus,
@@ -27,6 +29,7 @@ func GetTemplateFuncs() template.FuncMap {
 	}
 }
 
+// FormatBlockStatus will return an html status for a block
 func FormatBlockStatus(status uint64) template.HTML {
 	if status == 0 {
 		return "<span class=\"badge badge-light\">Scheduled</span>"
@@ -41,6 +44,7 @@ func FormatBlockStatus(status uint64) template.HTML {
 	}
 }
 
+// FormatAttestationStatus will return a user-friendly attestation for an attestation status number
 func FormatAttestationStatus(status uint64) string {
 	if status == 0 {
 		return "Scheduled"
@@ -53,32 +57,39 @@ func FormatAttestationStatus(status uint64) string {
 	}
 }
 
+// FormatValidator will return html formatted text for a validator
 func FormatValidator(validator uint64) template.HTML {
 	return template.HTML(fmt.Sprintf("<i class=\"fas fa-male\"></i> <a href=\"/validator/%v\">%v</a>", validator, validator))
 }
 
+// SlotToTime will return a time.Time to slot
 func SlotToTime(slot uint64) time.Time {
 	return time.Unix(int64(Config.Chain.GenesisTimestamp+slot*Config.Chain.SecondsPerSlot), 0)
 }
 
+// TimeToSlot will return time to slot in seconds
 func TimeToSlot(timestamp uint64) uint64 {
 	return (timestamp - Config.Chain.GenesisTimestamp) / Config.Chain.SecondsPerSlot
 }
 
+// EpochToTime will return a time.Time for an epoch
 func EpochToTime(epoch uint64) time.Time {
 	return time.Unix(int64(Config.Chain.GenesisTimestamp+epoch*Config.Chain.SecondsPerSlot*Config.Chain.SlotsPerEpoch), 0)
 }
 
+// FormatBalance will return a string for a balance
 func FormatBalance(balance uint64) string {
 	return fmt.Sprintf("%.2f ETH", float64(balance)/float64(1000000000))
 }
 
+// WaitForCtrlC will block/wait until a control-c is pressed
 func WaitForCtrlC() {
 	c := make(chan os.Signal, 1)
 	signal.Notify(c, os.Interrupt)
 	<-c
 }
 
+// ReadConfig will process a configuration
 func ReadConfig(cfg *types.Config, path string) error {
 	err := readConfigFile(cfg, path)
 
@@ -108,14 +119,17 @@ func readConfigEnv(cfg *types.Config) error {
 	return envconfig.Process("", cfg)
 }
 
+// FormatPublicKey will format a public key
 func FormatPublicKey(publicKey []byte) string {
 	return fmt.Sprintf("%x", publicKey)
 }
 
+// FormatAttestorAssignmentKey will format attestor assignment keys
 func FormatAttestorAssignmentKey(AttesterSlot, CommitteeIndex, MemberIndex uint64) string {
 	return fmt.Sprintf("%v-%v-%v", AttesterSlot, CommitteeIndex, MemberIndex)
 }
 
+// MustParseHex will parse a string into hex
 func MustParseHex(hexString string) []byte {
 	data, err := hex.DecodeString(strings.Replace(hexString, "0x", "", -1))
 	if err != nil {


### PR DESCRIPTION
Fix most golint warnings. There are still 12 warnings.

Will need help/input on remaining warnings. (such as "type RpcClient should be RPCClient" or "don't use underscores in Go names; struct field Header_1 should be Header1".
