### PR TITLE
Populate version and build-info into binary and display in frontend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,10 @@
+GITCOMMIT=`git describe --always`
+VERSION=$$(git describe 2>/dev/null || echo "0.0.0-${GITCOMMIT}")
+GITDATE=`TZ=UTC git show -s --date=iso-strict-local --format=%cd HEAD`
+BUILDDATE=`date -u +"%Y-%m-%dT%H:%M:%S%:z"`
+PACKAGE=eth2-exporter
+LDFLAGS="-X ${PACKAGE}/version.Version=${VERSION} -X ${PACKAGE}/version.BuildDate=${BUILDDATE} -X ${PACKAGE}/version.GitCommit=${GITCOMMIT} -X ${PACKAGE}/version.GitDate=${GITDATE}"
+
 all: explorer
 
 lint:
@@ -8,5 +15,5 @@ explorer:
 	mkdir -p bin/templates/
 	cp -r templates/ bin/
 	cp -r static/ bin/static
-	go build -o bin/explorer cmd/explorer/main.go
+	go build --ldflags=${LDFLAGS} -o bin/explorer cmd/explorer/main.go
 

--- a/handlers/block.go
+++ b/handlers/block.go
@@ -6,12 +6,14 @@ import (
 	"eth2-exporter/services"
 	"eth2-exporter/types"
 	"eth2-exporter/utils"
+	"eth2-exporter/version"
 	"fmt"
-	"github.com/gorilla/mux"
 	"html/template"
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/gorilla/mux"
 )
 
 var blockTemplate = template.Must(template.New("block").Funcs(utils.GetTemplateFuncs()).ParseFiles("templates/layout.html", "templates/block.html"))
@@ -63,6 +65,7 @@ func Block(w http.ResponseWriter, r *http.Request) {
 		ShowSyncingMessage: services.IsSyncing(),
 		Active:             "blocks",
 		Data:               nil,
+		Version:            version.Version,
 	}
 
 	if err != nil {

--- a/handlers/blocks.go
+++ b/handlers/blocks.go
@@ -6,6 +6,7 @@ import (
 	"eth2-exporter/services"
 	"eth2-exporter/types"
 	"eth2-exporter/utils"
+	"eth2-exporter/version"
 	"fmt"
 	"html/template"
 	"net/http"
@@ -29,6 +30,7 @@ func Blocks(w http.ResponseWriter, r *http.Request) {
 		ShowSyncingMessage: services.IsSyncing(),
 		Active:             "blocks",
 		Data:               nil,
+		Version:            version.Version,
 	}
 
 	err := blocksTemplate.ExecuteTemplate(w, "layout", data)

--- a/handlers/charts.go
+++ b/handlers/charts.go
@@ -5,6 +5,7 @@ import (
 	"eth2-exporter/services"
 	"eth2-exporter/types"
 	"eth2-exporter/utils"
+	"eth2-exporter/version"
 	"fmt"
 	"html/template"
 	"net/http"
@@ -28,6 +29,7 @@ func Charts(w http.ResponseWriter, r *http.Request) {
 		ShowSyncingMessage: services.IsSyncing(),
 		Active:             "charts",
 		Data:               nil,
+		Version:            version.Version,
 	}
 
 	err := chartsTemplate.ExecuteTemplate(w, "layout", data)
@@ -50,6 +52,7 @@ func BlocksChart(w http.ResponseWriter, r *http.Request) {
 		ShowSyncingMessage: services.IsSyncing(),
 		Active:             "charts",
 		Data:               nil,
+		Version:            version.Version,
 	}
 
 	rows := []struct {
@@ -140,6 +143,7 @@ func ActiveValidatorChart(w http.ResponseWriter, r *http.Request) {
 		ShowSyncingMessage: services.IsSyncing(),
 		Active:             "charts",
 		Data:               nil,
+		Version:            version.Version,
 	}
 
 	rows := []struct {
@@ -199,6 +203,7 @@ func StakedEtherChart(w http.ResponseWriter, r *http.Request) {
 		ShowSyncingMessage: services.IsSyncing(),
 		Active:             "charts",
 		Data:               nil,
+		Version:            version.Version,
 	}
 
 	rows := []struct {
@@ -259,6 +264,7 @@ func AverageBalanceChart(w http.ResponseWriter, r *http.Request) {
 		ShowSyncingMessage: services.IsSyncing(),
 		Active:             "charts",
 		Data:               nil,
+		Version:            version.Version,
 	}
 
 	rows := []struct {

--- a/handlers/epoch.go
+++ b/handlers/epoch.go
@@ -5,13 +5,15 @@ import (
 	"eth2-exporter/services"
 	"eth2-exporter/types"
 	"eth2-exporter/utils"
+	"eth2-exporter/version"
 	"fmt"
-	"github.com/gorilla/mux"
 	"html/template"
 	"net/http"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/gorilla/mux"
 )
 
 var epochTemplate = template.Must(template.New("epoch").Funcs(template.FuncMap{"formatBlockStatus": utils.FormatBlockStatus}).ParseFiles("templates/layout.html", "templates/epoch.html"))
@@ -31,6 +33,7 @@ func Epoch(w http.ResponseWriter, r *http.Request) {
 		ShowSyncingMessage: services.IsSyncing(),
 		Active:             "epochs",
 		Data:               nil,
+		Version:            version.Version,
 	}
 
 	epoch, err := strconv.ParseUint(epochString, 10, 64)

--- a/handlers/epochs.go
+++ b/handlers/epochs.go
@@ -6,6 +6,7 @@ import (
 	"eth2-exporter/services"
 	"eth2-exporter/types"
 	"eth2-exporter/utils"
+	"eth2-exporter/version"
 	"fmt"
 	"html/template"
 	"net/http"
@@ -29,6 +30,7 @@ func Epochs(w http.ResponseWriter, r *http.Request) {
 		ShowSyncingMessage: services.IsSyncing(),
 		Active:             "epochs",
 		Data:               nil,
+		Version:            version.Version,
 	}
 
 	err := epochsTemplate.ExecuteTemplate(w, "layout", data)

--- a/handlers/faq.go
+++ b/handlers/faq.go
@@ -4,6 +4,7 @@ import (
 	"eth2-exporter/services"
 	"eth2-exporter/types"
 	"eth2-exporter/utils"
+	"eth2-exporter/version"
 	"fmt"
 	"html/template"
 	"net/http"
@@ -25,6 +26,7 @@ func Faq(w http.ResponseWriter, r *http.Request) {
 		ShowSyncingMessage: services.IsSyncing(),
 		Active:             "faq",
 		Data:               nil,
+		Version:            version.Version,
 	}
 
 	err := faqTemplate.ExecuteTemplate(w, "layout", data)

--- a/handlers/imprint.go
+++ b/handlers/imprint.go
@@ -4,6 +4,7 @@ import (
 	"eth2-exporter/services"
 	"eth2-exporter/types"
 	"eth2-exporter/utils"
+	"eth2-exporter/version"
 	"fmt"
 	"html/template"
 	"net/http"
@@ -31,6 +32,7 @@ func Imprint(w http.ResponseWriter, r *http.Request) {
 		ShowSyncingMessage: services.IsSyncing(),
 		Active:             "imprint",
 		Data:               nil,
+		Version:            version.Version,
 	}
 
 	err = imprintTemplate.ExecuteTemplate(w, "layout", data)

--- a/handlers/index.go
+++ b/handlers/index.go
@@ -5,6 +5,7 @@ import (
 	"eth2-exporter/services"
 	"eth2-exporter/types"
 	"eth2-exporter/utils"
+	"eth2-exporter/version"
 	"fmt"
 	"html/template"
 	"net/http"
@@ -26,6 +27,7 @@ func Index(w http.ResponseWriter, r *http.Request) {
 		ShowSyncingMessage: services.IsSyncing(),
 		Active:             "index",
 		Data:               services.LatestIndexPageData(),
+		Version:            version.Version,
 	}
 
 	err := indexTemplate.ExecuteTemplate(w, "layout", data)

--- a/handlers/validator.go
+++ b/handlers/validator.go
@@ -7,6 +7,7 @@ import (
 	"eth2-exporter/services"
 	"eth2-exporter/types"
 	"eth2-exporter/utils"
+	"eth2-exporter/version"
 	"fmt"
 	"html/template"
 	"net/http"
@@ -38,6 +39,7 @@ func Validator(w http.ResponseWriter, r *http.Request) {
 		ShowSyncingMessage: services.IsSyncing(),
 		Active:             "validators",
 		Data:               nil,
+		Version:            version.Version,
 	}
 
 	if strings.Contains(vars["index"], "0x") || len(vars["index"]) == 96 {

--- a/handlers/validators.go
+++ b/handlers/validators.go
@@ -6,6 +6,7 @@ import (
 	"eth2-exporter/services"
 	"eth2-exporter/types"
 	"eth2-exporter/utils"
+	"eth2-exporter/version"
 	"fmt"
 	"html/template"
 	"net/http"
@@ -56,6 +57,7 @@ func Validators(w http.ResponseWriter, r *http.Request) {
 		ShowSyncingMessage: services.IsSyncing(),
 		Active:             "validators",
 		Data:               validatorsPageData,
+		Version:            version.Version,
 	}
 
 	err = validatorsTemplate.ExecuteTemplate(w, "layout", data)

--- a/handlers/vis.go
+++ b/handlers/vis.go
@@ -6,6 +6,7 @@ import (
 	"eth2-exporter/services"
 	"eth2-exporter/types"
 	"eth2-exporter/utils"
+	"eth2-exporter/version"
 	"fmt"
 	"html/template"
 	"net/http"
@@ -32,6 +33,7 @@ func Vis(w http.ResponseWriter, r *http.Request) {
 		ShowSyncingMessage: services.IsSyncing(),
 		Active:             "vis",
 		Data:               nil,
+		Version:            version.Version,
 	}
 
 	err = visTemplate.ExecuteTemplate(w, "layout", data)

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -151,7 +151,7 @@
                     href="https://github.com/gobitfly/eth2-beaconchain-explorer">
                 <i class="fab fa-github mr-1"></i>Github</a> | <a
                     href="https://gitter.im/gobitfly/beaconchain-explorer"><i class="fab fa-gitter"></i> Gitter Channel</a>
-            | v1.0.0
+            | {{.Version}}
         </footer>
     </div>
 

--- a/types/templates.go
+++ b/types/templates.go
@@ -13,6 +13,7 @@ type PageData struct {
 	Meta               *Meta
 	ShowSyncingMessage bool
 	Data               interface{}
+	Version            string
 }
 
 // Meta is a struct to hold metadata about the page


### PR DESCRIPTION
Populate version and build-info into binary on build and display version in frontend (instead of the currently displayed `1.0.0`).

Note: this will use `0.0.0-<shortCommitSha>` until there is a git-tag in the repository. Once there is a git-tag it will just use the output from `git describe` for `eth2-exporter/version.Version`