### PR TITLE
Add global options for highcharts

### DIFF
--- a/static/js/highcharts-global-options.js
+++ b/static/js/highcharts-global-options.js
@@ -1,0 +1,157 @@
+// Highcharts global options
+Highcharts.setOptions({
+    credits: {
+      enabled: true,
+      href: 'https://beaconcha.in',
+      text: 'beaconcha.in',
+      style: {
+        color: 'var(--body-color)'
+      },
+    },
+    exporting: {
+      scale: 1
+    },
+    title: {
+      style: {
+        color: 'var(--font-color)'
+      }
+    },
+    subtitle: {
+      style: {
+        color: 'var(--font-color)'
+      }
+    },
+    chart: {
+      animation: false,
+      style: {
+        fontFamily: 'Helvetica Neue", Helvetica, Arial, sans-serif',
+        color: 'var(--body-color)',
+        fontSize: '12px'
+      },
+      backgroundColor: 'var(--bg-color)'
+    },
+    colors: ["#7cb5ec", "#90ed7d", "#f7a35c", "#8085e9", "#f15c80", "#e4d354", "#2b908f", "#f45b5b", "#91e8e1"],
+    legend: {
+      enabled: true,
+      layout: 'horizontal',
+      align: 'center',
+      verticalAlign: 'bottom',
+      borderWidth: 0,
+      itemStyle: {
+        color: 'var(--body-color)',
+        'font-size': '0.8rem',
+        // 'font-weight': 'lighter'
+      },
+      itemHoverStyle: {
+        color: 'var(--primary)',
+      }
+    },
+    xAxis: {
+      labels: {
+        style: {
+          color: 'var(--body-color)'
+        }
+      },
+    },
+    yAxis: {
+      title: {
+        style: {
+          color: 'var(--body-color)',
+          'font-size': '0.8rem'
+        }
+      },
+      labels: {
+        style: {
+          color: 'var(--body-color)',
+          'font-size': '0.8rem'
+        }
+      },
+      gridLineColor: 'var(--border-color-transparent)',
+    },
+    navigation: {
+      menuStyle: {
+        "border": "1px solid var(--border-color-transparent)",
+        "background": "var(--bg-color-nav)",
+        "padding": "1px 0",
+        "box-shadow": "var(--bg-color-nav) 2px 2px 5px"
+      },
+      buttonOptions: {
+        symbolStroke: 'var(--body-color)',
+        symbolFill: 'var(--body-color)',
+        theme: {
+          fill: 'var(--bg-color)',
+          states: {
+            hover: {
+              fill: 'var(--primary)'
+            },
+            select: {
+              fill: 'var(--primary)'
+            }
+          }
+        }
+      },
+      menuItemStyle: {
+        "padding": "0.5em 1em",
+        "color": "var(--transparent-font-color)",
+        "background": "none",
+        "fontSize": "11px/14px",
+        "transition": "background 250ms, color 250ms"
+      },
+      menuItemHoverStyle: {"background": "var(--primary)", "color": "var(--font-color)"}
+    },
+    navigator: {
+      enabled: true,
+      maskFill: 'var(--mask-fill-color)',
+      outlineColor: 'var(--border-color)',
+      handles: {
+        backgroundColor: 'var(--bg-color-nav)',
+        borderColor: 'var(--transparent-font-color)',
+      },
+      xAxis: {
+        gridLineColor: 'var(--border-color)',
+      },
+    },
+    scrollbar: {
+      barBackgroundColor: 'var(--bg-color-nav)',
+      barBorderWidth: 0,
+      buttonArrowColor: 'var(--font-color)',
+      rifleColor: 'var(--dark)',
+      buttonBackgroundColor: 'var(--bg-color-nav)',
+      buttonBorderColor: 'var(--bg-color-transparent)',
+      trackBackgroundColor: 'var(--bg-color)',
+      trackBorderColor: 'var(--border-color-transparent)',
+    },
+    responsive: {
+      rules: [
+        {
+          condition: {
+            maxWidth: 760
+          },
+          chartOptions: {
+            chart: {
+              marginRight: 45
+            },
+            yAxis: [
+              {
+                title: {
+                  text: null
+                }
+              },
+              {
+                title: {
+                  text: null
+                }
+              }
+            ]
+          }
+        }
+      ]
+    },
+    plotOptions: {
+      line: {
+        animation: false,
+        lineWidth: 2.5
+      }
+    }
+  })
+  

--- a/templates/genericchart.html
+++ b/templates/genericchart.html
@@ -2,156 +2,38 @@
 <script src="https://code.highcharts.com/stock/highstock.js"></script>
 <script src="https://code.highcharts.com/modules/exporting.js"></script>
 <script src="https://code.highcharts.com/modules/offline-exporting.js"></script>
+<script src="/js/highcharts-global-options.js"></script>
 
 <script>
-  Highcharts.stockChart('chart', {
-    exporting: {
-        scale: 1,
+Highcharts.stockChart('chart', {
+    chart: {
+        type: 'column'
     },
-        navigation: {
-        menuStyle: {
-            "border": "1px solid var(--border-color-transparent)",
-            "background": "var(--bg-color-nav)",
-            "padding": "1px 0",
-            "box-shadow": "var(--bg-color-nav) 2px 2px 5px"
-            },
-        buttonOptions: {
-            symbolStroke: 'var(--body-color)',
-            symbolFill: 'var(--body-color)',
-                theme: {
-                fill: 'var(--bg-color)',
-                states: {
-                    hover: {
-                    fill: 'var(--primary)'
-                    },
-                    select: {
-                    fill: 'var(--primary)'
-                    }
-                }
-                }
+    rangeSelector: { 
+        enabled: true
+    },
+    title: {
+        text: {{.Title}}
+    },
+    subtitle: {
+        text: {{.Subtitle}}
+    },
+    plotOptions: {
+        column: {
+            stacking: {{.StackingMode}},
+        }
+    },
+    xAxis: {
+        type: 'datetime'
+    },
+    yAxis: [{
+        title: {
+            text: {{.YAxisTitle}}
         },
-        menuItemStyle: {
-            "padding": "0.5em 1em",
-            "color": "var(--transparent-font-color)",
-            "background": "none",
-            "fontSize": "11px/14px",
-            "transition": "background 250ms, color 250ms"
-        },
-        menuItemHoverStyle: {"background": "var(--primary)", "color": "var(--font-color)"}
-    },
-      chart: {
-          type: 'column',
-          animation: false,
-          style: {
-                fontFamily: 'Helvetica Neue", Helvetica, Arial, sans-serif',
-                color: 'var(--body-color)',
-                fontSize: '12px'
-            },
-          backgroundColor: 'var(--bg-color)',
-      },
-      rangeSelector: {
-        enabled: true,
-
-    },
-      title: {
-          text: {{.Title}},
-          style: {
-              color: 'var(--font-color)',
-              fontSize: '20px'
-          }
-      },
-      subtitle: {
-          text: {{.Subtitle}},
-          style: {
-              color: 'var(--body-color)',
-              fontSize: '14px'
-          }
-      },
-      plotOptions: {
-          column: {
-              stacking: {{.StackingMode}},
-          }
-      },
-      colors: ["#7cb5ec", "#90ed7d", "#f7a35c", "#8085e9", "#f15c80", "#e4d354", "#2b908f", "#f45b5b",
-              "#91e8e1"],
-      navigator: {
-          enabled: true,
-          maskFill: 'var(--mask-fill-color)',
-          outlineColor: 'var(--border-color)',
-          handles: {
-              backgroundColor: 'var(--bg-color-nav)',
-              borderColor: 'var(--transparent-font-color)',
-          },
-          xAxis: {
-              gridLineColor: 'var(--border-color)',
-          },
-      },
-      scrollbar: {
-          barBackgroundColor: 'var(--bg-color-nav)',
-          barBorderWidth: 0,
-          buttonArrowColor: 'var(--font-color)',
-          rifleColor: 'var(--dark)',
-          buttonBackgroundColor: 'var(--bg-color-nav)',
-          buttonBorderColor: 'var(--bg-color-transparent)',
-          trackBackgroundColor: 'var(--bg-color)',
-          trackBorderColor: 'var(--border-color-transparent)',
-      },
-      xAxis: {
-          type: 'datetime',
-          labels: {
-              style: {
-                  color: 'var(--body-color)',
-                  fontSize: '16px'
-              }
-          },
-          gridLineColor: 'var(--border-color)',
-      },
-      yAxis: [{
-          title: {
-              text: {{.YAxisTitle}},
-              style: {
-                    color: 'var(--body-color)',
-                    fontSize: '16px'
-              }
-          }
-      }],
-      series: {{.Series}},
-      credits: {
-          href: "https://www.beaconcha.in",
-          text: "Source: beaconcha.in",
-          style: {
-                color: 'var(--body-color)',
-                fontSize: '15px'
-          },
-          position: {
-              y: 0
-          }
-      },
-      responsive: {
-        rules: [
-            {
-                condition: {
-                    maxWidth: 760
-                },
-                chartOptions: {
-                    chart: {
-                        marginRight: 45
-                    },
-                    yAxis: [
-                        {
-                            title: {
-                                text: null
-                            }
-                        }
-                    ],
-                    rangeSelector: {
-                        enabled: false
-                    }
-                }
-            }
-        ]
-    }
-  });
+        opposite: false
+    }],
+    series: {{.Series}},
+});
 </script>
 {{end}} {{ define "css"}} {{end}} {{ define "content"}}
 <div class="mb-3">

--- a/templates/index.html
+++ b/templates/index.html
@@ -5,6 +5,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/vue"></script>
 <script src="/js/highcharts-vue.min.js"></script>
+<script src="/js/highcharts-global-options.js"></script>
 <script>
   var app = new Vue({
       el: '#app',
@@ -16,123 +17,37 @@
           updateIn: -1,
           page: {{.}},
           chartOptions: {
-              exporting: {
-                  scale: 1,
-              },
-              navigation: {
-                menuStyle: {
-                  "border": "1px solid var(--border-color-transparent)",
-                  "background": "var(--bg-color-nav)",
-                  "padding": "1px 0",
-                  "box-shadow": "var(--bg-color-nav) 2px 2px 5px"
-                  },
-                buttonOptions: {
-                  symbolStroke: 'var(--body-color)',
-                  symbolFill: 'var(--body-color)',
-                      theme: {
-                        fill: 'var(--bg-color)',
-                        states: {
-                          hover: {
-                            fill: 'var(--primary)'
-                          },
-                          select: {
-                            fill: 'var(--primary)'
-                          }
-                        }
-                      }
-                },
-                menuItemStyle: {
-                  "padding": "0.5em 1em",
-                  "color": "var(--transparent-font-color)",
-                  "background": "none",
-                  "fontSize": "11px/14px",
-                  "transition": "background 250ms, color 250ms"
-                },
-                menuItemHoverStyle: {"background": "var(--primary)", "color": "var(--font-color)"}
-              },
-              colors: ["#7cb5ec", "#90ed7d", "#f7a35c", "#8085e9", "#f15c80", "#e4d354", "#2b908f", "#f45b5b",
-              "#91e8e1"],
               rangeSelector: {
                   enabled: false
               },
-              navigator: {
-                  enabled: true,
-                  maskFill: 'var(--mask-fill-color)',
-                  outlineColor: 'var(--border-color)',
-                  handles: {
-                    backgroundColor: 'var(--bg-color-nav)',
-                    borderColor: 'var(--transparent-font-color)',
-                  },
-                  xAxis: {
-                    gridLineColor: 'var(--border-color)',
-                  },
-              },
-              scrollbar: {
-                barBackgroundColor: 'var(--bg-color-nav)',
-                barBorderWidth: 0,
-                buttonArrowColor: 'var(--font-color)',
-                rifleColor: 'var(--dark)',
-                buttonBackgroundColor: 'var(--bg-color-nav)',
-                buttonBorderColor: 'var(--bg-color-transparent)',
-                trackBackgroundColor: 'var(--bg-color)',
-                trackBorderColor: 'var(--border-color-transparent)',
-              },
               chart: {
-                  type: 'line',
-                  animation: false,
-                  style: {
-                      fontFamily: 'Helvetica Neue", Helvetica, Arial, sans-serif',
-                      color: 'var(--body-color)',
-                      fontSize: '12px'
-                  },
-                  backgroundColor: 'var(--bg-color)',
+                  type: 'line'
               },
               title: {
-                  text: 'Network History',
-                  style: {
-                          color: 'var(--font-color)'
-                      }
+                  text: 'Network History'
               },
               subtitle: {},
               xAxis: {
                   type: 'datetime',
-                  labels: {
-                      style: {
-                          color: 'var(--body-color)'
-                      }
-                  },
-                  gridLineColor: 'var(--border-color)',
                   range: 7 * 24 * 60 * 60 * 1000
               },
               yAxis: [{
                   title: {
-                      text: 'Balance [ETH]',
-                      style: {
-                          color: 'var(--body-color)'
-                      }
+                      text: 'Balance [ETH]'
                   },
                   labels: {
                       formatter: function () {
                           return this.value.toFixed(0);
-                      },
-                      style: {
-                          color: 'var(--body-color)'
                       }
                   },
                   opposite: false
               }, {
                   title: {
-                      text: 'Active Validators',
-                      style: {
-                          color: 'var(--body-color)'
-                      }
+                      text: 'Active Validators'
                   },
                   labels: {
                       formatter: function () {
                           return this.value.toFixed(0);
-                      },
-                      style: {
-                          color: 'var(--body-color)'
                       }
                   },
                   opposite: true
@@ -146,27 +61,8 @@
                   yAxis: 1,
                   data: {{.ActiveValidatorsChartData}}
               }],
-              plotOptions: {
-                  line: {
-                      animation: false,
-                      lineWidth: 2.5,
-                  }
-              },
               legend: {
-                  enabled: true,
-                  itemStyle: {
-                      color: 'var(--body-color)'
-                  },
-                  itemHoverStyle: {
-                    color: 'var(--primary)',
-                  }
-              },
-              credits: {
-                  text: 'Source: beaconcha.in',
-                  style: {
-                      color: 'var(--body-color)'
-                  },
-                  href: 'https://www.beaconcha.in'
+                  enabled: true
               }
           }
       },

--- a/templates/validator.html
+++ b/templates/validator.html
@@ -79,91 +79,30 @@
 	<script src="https://code.highcharts.com/stock/highstock.js"></script>
 	<script src="https://code.highcharts.com/modules/exporting.js"></script>
 	<script src="https://code.highcharts.com/modules/offline-exporting.js"></script>
+	<script src="/js/highcharts-global-options.js"></script>
 
 	<script>
 		Highcharts.stockChart('balancechart', {
-			exporting: {
-				scale: 1
-			},
-			navigation: {
-				menuStyle: {
-					"border": "1px solid var(--border-color-transparent)",
-					"background": "var(--bg-color-nav)",
-					"padding": "1px 0",
-					"box-shadow": "var(--bg-color-nav) 2px 2px 5px"
-				},
-				buttonOptions: {
-					symbolStroke: 'var(--body-color)',
-					symbolFill: 'var(--body-color)',
-					theme: {
-						fill: 'var(--bg-color)',
-						states: {
-							hover: {
-								fill: 'var(--primary)'
-							},
-							select: {
-								fill: 'var(--primary)'
-							}
-						}
-					}
-				},
-				menuItemStyle: {
-					"padding": "0.5em 1em",
-					"color": "var(--transparent-font-color)",
-					"background": "none",
-					"fontSize": "11px/14px",
-					"transition": "background 250ms, color 250ms"
-				},
-				menuItemHoverStyle: {"background": "var(--primary)", "color": "var(--font-color)"}
-			},
-			colors: ["#7cb5ec", "#90ed7d", "#f7a35c", "#8085e9", "#f15c80", "#e4d354", "#2b908f", "#f45b5b",
-				"#91e8e1"],
+			colors: ["#7cb5ec", "#90ed7d", "#f7a35c", "#8085e9", "#f15c80", "#e4d354", "#2b908f", "#f45b5b", "#91e8e1"],
 			rangeSelector: {
 				enabled: false
 			},
 			chart: {
-				type: 'line',
-				animation: false,
-				style: {
-					fontFamily: 'Helvetica Neue", Helvetica, Arial, sans-serif',
-					color: 'var(--body-color)',
-					fontSize: '12px'
-				},
-				backgroundColor: 'var(--bg-color)',
+				type: 'line'
 			},
 			title: {
-				text: 'Balance History for Validator {{.Index}}',
-				style: {
-					color: 'var(--font-color)'
-				}
+				text: 'Balance History for Validator {{.Index}}'
 			},
-			subtitle: {
-				text: 'Source: beaconcha.in',
-				style: {
-					color: 'var(--body-color)'
-				}
+			legend: {
+					enabled: true
 			},
 			xAxis: {
 				type: 'datetime',
-				labels: {
-					style: {
-						color: 'var(--body-color)'
-					}
-				},
 				range: 7 * 24 * 60 * 60 * 1000
 			},
 			yAxis: [{
 				title: {
-					text: 'Balance [ETH]',
-					style: {
-						color: 'var(--body-color)',
-						'font-size': '0.8rem'
-					}
-				},
-				labels: {
-					style: {
-						color: 'var(--body-color)'
-					}
+					text: 'Balance [ETH]'
 				},
 				opposite: false
 			}],
@@ -174,77 +113,7 @@
 				name: "Effective Balance",
 				step: true,
 				data: {{.EffectiveBalanceHistoryChartData}}
-			}],
-			plotOptions: {
-				line: {
-					animation: false,
-					lineWidth: 2.5,
-				}
-			},
-			legend: {
-				enabled: true,
-				layout: 'horizontal',
-				align: 'center',
-				verticalAlign: 'bottom',
-				borderWidth: 0,
-				itemStyle: {
-					color: 'var(--body-color)'
-				},
-				itemHoverStyle: {
-					color: 'var(--primary)',
-				}
-			},
-			credits: {
-				enabled: false
-			},
-			navigator: {
-				enabled: true,
-				maskFill: 'var(--mask-fill-color)',
-				outlineColor: 'var(--border-color)',
-				handles: {
-					backgroundColor: 'var(--bg-color-nav)',
-					borderColor: 'var(--transparent-font-color)',
-				},
-				xAxis: {
-					gridLineColor: 'var(--border-color)',
-				},
-			},
-			scrollbar: {
-				barBackgroundColor: 'var(--bg-color-nav)',
-				barBorderWidth: 0,
-				buttonArrowColor: 'var(--font-color)',
-				rifleColor: 'var(--dark)',
-				buttonBackgroundColor: 'var(--bg-color-nav)',
-				buttonBorderColor: 'var(--bg-color-transparent)',
-				trackBackgroundColor: 'var(--bg-color)',
-				trackBorderColor: 'var(--border-color-transparent)',
-			},
-			responsive: {
-				rules: [
-					{
-						condition: {
-							maxWidth: 760
-						},
-						chartOptions: {
-							chart: {
-								marginRight: 45
-							},
-							yAxis: [
-								{
-									title: {
-										text: null
-									}
-								},
-								{
-									title: {
-										text: null
-									}
-								}
-							]
-						}
-					}
-				]
-			}
+			}]
 		});
 	</script>
 	{{if .DailyProposalCount}}
@@ -255,89 +124,27 @@
 			var orphaned = data.map(d => [d.Day * 1000, d.Orphaned]);
 
 			Highcharts.stockChart('proposedChart', {
-				exporting: {
-					scale: 1
-				},
-				navigation: {
-					menuStyle: {
-						"border": "1px solid var(--border-color-transparent)",
-						"background": "var(--bg-color-nav)",
-						"padding": "1px 0",
-						"box-shadow": "var(--bg-color-nav) 2px 2px 5px"
-					},
-					buttonOptions: {
-						symbolStroke: 'var(--body-color)',
-						symbolFill: 'var(--body-color)',
-						theme: {
-							fill: 'var(--bg-color)',
-							states: {
-								hover: {
-									fill: 'var(--primary)'
-								},
-								select: {
-									fill: 'var(--primary)'
-								}
-							}
-						}
-					},
-					menuItemStyle: {
-						"padding": "0.5em 1em",
-						"color": "var(--transparent-font-color)",
-						"background": "none",
-						"fontSize": "11px/14px",
-						"transition": "background 250ms, color 250ms"
-					},
-					menuItemHoverStyle: {"background": "var(--primary)", "color": "var(--font-color)"}
-				},
 				colors: ["#7cb5ec", "#ff835c", "#e4a354", "#2b908f", "#f45b5b",
 					"#91e8e1"],
 				title: {
-					text: 'Proposal History for Validator {{.Index}}',
-					style: {
-						color: 'var(--font-color)'
-					}
-				},
-				subtitle: {
-					text: 'Source: beaconcha.in',
-					style: {
-						color: 'var(--body-color)'
-					}
+					text: 'Proposal History for Validator {{.Index}}'
 				},
 				chart: {
 					type: 'column',
-					animation: false,
-					style: {
-						fontFamily: 'Helvetica Neue", Helvetica, Arial, sans-serif',
-						color: 'var(--body-color)',
-						fontSize: '12px'
-					},
-					backgroundColor: 'var(--bg-color)',
 				},
 				xAxis: {
 					lineWidth: 0,
 					tickColor: '#e5e1e1',
-					labels: {
-						style: {
-							color: 'var(--body-color)'
-						}
-					},
 					range: 7 * 24 * 3600 * 1000
+				},
+				legend: {
+					enabled: true
 				},
 				yAxis: [
 					{
 						title: {
-							text: '# of Possible Proposals',
-							style: {
-								color: 'var(--body-color)',
-								'font-size': '0.8rem'
-							}
+							text: '# of Possible Proposals'
 						},
-						labels: {
-							style: {
-								color: 'var(--body-color)'
-							}
-						},
-						gridLineColor: 'var(--border-color-transparent)',
 						opposite: false
 					}
 				],
@@ -351,21 +158,6 @@
 								['day', [1]]
 							]
 						}
-					}
-				},
-				legend: {
-					enabled: true,
-					layout: 'horizontal',
-					align: 'center',
-					verticalAlign: 'bottom',
-					borderWidth: 0,
-					itemStyle: {
-						color: 'var(--body-color)',
-						'font-size': '0.8rem',
-						'font-weight': 'lighter'
-					},
-					itemHoverStyle: {
-						color: 'var(--primary)'
 					}
 				},
 				series: [
@@ -384,61 +176,6 @@
 				],
 				rangeSelector: {
 					enabled: false
-				},
-				navigator: {
-					maskFill: '#1473e631',
-					outlineColor: '#e5e1e1',
-					handles: {
-						backgroundColor: '#f5f3f3',
-						borderColor: '#26232780'
-					},
-					xAxis: {
-						gridLineColor: '#e5e1e1',
-						labels: {
-							style: {
-								color: '#26232780'
-							}
-						}
-					}
-				},
-				scrollbar: {
-					barBackgroundColor: 'var(--bg-color-nav)',
-					barBorderWidth: 0,
-					buttonArrowColor: 'var(--font-color)',
-					rifleColor: 'var(--dark)',
-					buttonBackgroundColor: 'var(--bg-color-nav)',
-					buttonBorderColor: 'var(--bg-color-transparent)',
-					trackBackgroundColor: 'var(--bg-color)',
-					trackBorderColor: 'var(--border-color-transparent)',
-				},
-				credits: {
-					enabled: false
-				},
-				responsive: {
-					rules: [
-						{
-							condition: {
-								maxWidth: 760
-							},
-							chartOptions: {
-								chart: {
-									marginRight: 45
-								},
-								yAxis: [
-									{
-										title: {
-											text: null
-										}
-									},
-									{
-										title: {
-											text: null
-										}
-									}
-								]
-							}
-						}
-					]
 				}
 			})
 		</script>


### PR DESCRIPTION
Before this PR charts did not look the same everywhere.

This PR introduces a global highcharts-options, which can be used to change the common appearance of our charts.

I tried to find the most common styling of current charts, most notably I have moved all beaconcha.in-source-attribution into the chart-credits (some charts had it in the subtitle).
