### PR TITLE
Display epochs in charts

### DIFF
--- a/handlers/block.go
+++ b/handlers/block.go
@@ -63,10 +63,13 @@ func Block(w http.ResponseWriter, r *http.Request) {
 		Meta: &types.Meta{
 			Description: "beaconcha.in makes the Ethereum 2.0. beacon chain accessible to non-technical end users",
 		},
-		ShowSyncingMessage: services.IsSyncing(),
-		Active:             "blocks",
-		Data:               nil,
-		Version:            version.Version,
+		ShowSyncingMessage:    services.IsSyncing(),
+		Active:                "blocks",
+		Data:                  nil,
+		Version:               version.Version,
+		ChainSlotsPerEpoch:    utils.Config.Chain.SlotsPerEpoch,
+		ChainSecondsPerSlot:   utils.Config.Chain.SecondsPerSlot,
+		ChainGenesisTimestamp: utils.Config.Chain.GenesisTimestamp,
 	}
 
 	if err != nil {

--- a/handlers/blocks.go
+++ b/handlers/blocks.go
@@ -27,10 +27,13 @@ func Blocks(w http.ResponseWriter, r *http.Request) {
 			Description: "beaconcha.in makes the Ethereum 2.0. beacon chain accessible to non-technical end users",
 			Path:        "/blocks",
 		},
-		ShowSyncingMessage: services.IsSyncing(),
-		Active:             "blocks",
-		Data:               nil,
-		Version:            version.Version,
+		ShowSyncingMessage:    services.IsSyncing(),
+		Active:                "blocks",
+		Data:                  nil,
+		Version:               version.Version,
+		ChainSlotsPerEpoch:    utils.Config.Chain.SlotsPerEpoch,
+		ChainSecondsPerSlot:   utils.Config.Chain.SecondsPerSlot,
+		ChainGenesisTimestamp: utils.Config.Chain.GenesisTimestamp,
 	}
 
 	err := blocksTemplate.ExecuteTemplate(w, "layout", data)

--- a/handlers/charts.go
+++ b/handlers/charts.go
@@ -26,10 +26,13 @@ func Charts(w http.ResponseWriter, r *http.Request) {
 			Description: "beaconcha.in makes the Ethereum 2.0. beacon chain accessible to non-technical end users",
 			Path:        "/charts",
 		},
-		ShowSyncingMessage: services.IsSyncing(),
-		Active:             "charts",
-		Data:               nil,
-		Version:            version.Version,
+		ShowSyncingMessage:    services.IsSyncing(),
+		Active:                "charts",
+		Data:                  nil,
+		Version:               version.Version,
+		ChainSlotsPerEpoch:    utils.Config.Chain.SlotsPerEpoch,
+		ChainSecondsPerSlot:   utils.Config.Chain.SecondsPerSlot,
+		ChainGenesisTimestamp: utils.Config.Chain.GenesisTimestamp,
 	}
 
 	err := chartsTemplate.ExecuteTemplate(w, "layout", data)
@@ -51,10 +54,13 @@ func BlocksChart(w http.ResponseWriter, r *http.Request) {
 			Description: "beaconcha.in makes the Ethereum 2.0. beacon chain accessible to non-technical end users",
 			Path:        "/charts",
 		},
-		ShowSyncingMessage: services.IsSyncing(),
-		Active:             "charts",
-		Data:               nil,
-		Version:            version.Version,
+		ShowSyncingMessage:    services.IsSyncing(),
+		Active:                "charts",
+		Data:                  nil,
+		Version:               version.Version,
+		ChainSlotsPerEpoch:    utils.Config.Chain.SlotsPerEpoch,
+		ChainSecondsPerSlot:   utils.Config.Chain.SecondsPerSlot,
+		ChainGenesisTimestamp: utils.Config.Chain.GenesisTimestamp,
 	}
 
 	rows := []struct {
@@ -144,10 +150,13 @@ func ActiveValidatorChart(w http.ResponseWriter, r *http.Request) {
 			Description: "beaconcha.in makes the Ethereum 2.0. beacon chain accessible to non-technical end users",
 			Path:        "/charts",
 		},
-		ShowSyncingMessage: services.IsSyncing(),
-		Active:             "charts",
-		Data:               nil,
-		Version:            version.Version,
+		ShowSyncingMessage:    services.IsSyncing(),
+		Active:                "charts",
+		Data:                  nil,
+		Version:               version.Version,
+		ChainSlotsPerEpoch:    utils.Config.Chain.SlotsPerEpoch,
+		ChainSecondsPerSlot:   utils.Config.Chain.SecondsPerSlot,
+		ChainGenesisTimestamp: utils.Config.Chain.GenesisTimestamp,
 	}
 
 	rows := []struct {
@@ -206,10 +215,13 @@ func StakedEtherChart(w http.ResponseWriter, r *http.Request) {
 			Description: "beaconcha.in makes the Ethereum 2.0. beacon chain accessible to non-technical end users",
 			Path:        "/charts",
 		},
-		ShowSyncingMessage: services.IsSyncing(),
-		Active:             "charts",
-		Data:               nil,
-		Version:            version.Version,
+		ShowSyncingMessage:    services.IsSyncing(),
+		Active:                "charts",
+		Data:                  nil,
+		Version:               version.Version,
+		ChainSlotsPerEpoch:    utils.Config.Chain.SlotsPerEpoch,
+		ChainSecondsPerSlot:   utils.Config.Chain.SecondsPerSlot,
+		ChainGenesisTimestamp: utils.Config.Chain.GenesisTimestamp,
 	}
 
 	rows := []struct {
@@ -269,10 +281,13 @@ func AverageBalanceChart(w http.ResponseWriter, r *http.Request) {
 			Description: "beaconcha.in makes the Ethereum 2.0. beacon chain accessible to non-technical end users",
 			Path:        "/charts",
 		},
-		ShowSyncingMessage: services.IsSyncing(),
-		Active:             "charts",
-		Data:               nil,
-		Version:            version.Version,
+		ShowSyncingMessage:    services.IsSyncing(),
+		Active:                "charts",
+		Data:                  nil,
+		Version:               version.Version,
+		ChainSlotsPerEpoch:    utils.Config.Chain.SlotsPerEpoch,
+		ChainSecondsPerSlot:   utils.Config.Chain.SecondsPerSlot,
+		ChainGenesisTimestamp: utils.Config.Chain.GenesisTimestamp,
 	}
 
 	rows := []struct {

--- a/handlers/dashboard.go
+++ b/handlers/dashboard.go
@@ -62,10 +62,13 @@ func Dashboard(w http.ResponseWriter, r *http.Request) {
 			Description: "beaconcha.in makes the Ethereum 2.0. beacon chain accessible to non-technical end users",
 			Path:        "/dashboard",
 		},
-		ShowSyncingMessage: services.IsSyncing(),
-		Active:             "dashboard",
-		Data:               nil,
-		Version:            version.Version,
+		ShowSyncingMessage:    services.IsSyncing(),
+		Active:                "dashboard",
+		Data:                  nil,
+		Version:               version.Version,
+		ChainSlotsPerEpoch:    utils.Config.Chain.SlotsPerEpoch,
+		ChainSecondsPerSlot:   utils.Config.Chain.SecondsPerSlot,
+		ChainGenesisTimestamp: utils.Config.Chain.GenesisTimestamp,
 	}
 
 	err := dashboardTemplate.ExecuteTemplate(w, "layout", data)

--- a/handlers/epoch.go
+++ b/handlers/epoch.go
@@ -29,10 +29,13 @@ func Epoch(w http.ResponseWriter, r *http.Request) {
 		Meta: &types.Meta{
 			Description: "beaconcha.in makes the Ethereum 2.0. beacon chain accessible to non-technical end users",
 		},
-		ShowSyncingMessage: services.IsSyncing(),
-		Active:             "epochs",
-		Data:               nil,
-		Version:            version.Version,
+		ShowSyncingMessage:    services.IsSyncing(),
+		Active:                "epochs",
+		Data:                  nil,
+		Version:               version.Version,
+		ChainSlotsPerEpoch:    utils.Config.Chain.SlotsPerEpoch,
+		ChainSecondsPerSlot:   utils.Config.Chain.SecondsPerSlot,
+		ChainGenesisTimestamp: utils.Config.Chain.GenesisTimestamp,
 	}
 
 	epoch, err := strconv.ParseUint(epochString, 10, 64)

--- a/handlers/epochs.go
+++ b/handlers/epochs.go
@@ -27,10 +27,13 @@ func Epochs(w http.ResponseWriter, r *http.Request) {
 			Description: "beaconcha.in makes the Ethereum 2.0. beacon chain accessible to non-technical end users",
 			Path:        "/epochs",
 		},
-		ShowSyncingMessage: services.IsSyncing(),
-		Active:             "epochs",
-		Data:               nil,
-		Version:            version.Version,
+		ShowSyncingMessage:    services.IsSyncing(),
+		Active:                "epochs",
+		Data:                  nil,
+		Version:               version.Version,
+		ChainSlotsPerEpoch:    utils.Config.Chain.SlotsPerEpoch,
+		ChainSecondsPerSlot:   utils.Config.Chain.SecondsPerSlot,
+		ChainGenesisTimestamp: utils.Config.Chain.GenesisTimestamp,
 	}
 
 	err := epochsTemplate.ExecuteTemplate(w, "layout", data)

--- a/handlers/faq.go
+++ b/handlers/faq.go
@@ -23,10 +23,13 @@ func Faq(w http.ResponseWriter, r *http.Request) {
 			Description: "beaconcha.in makes the Ethereum 2.0. beacon chain accessible to non-technical end users",
 			Path:        "/faq",
 		},
-		ShowSyncingMessage: services.IsSyncing(),
-		Active:             "faq",
-		Data:               nil,
-		Version:            version.Version,
+		ShowSyncingMessage:    services.IsSyncing(),
+		Active:                "faq",
+		Data:                  nil,
+		Version:               version.Version,
+		ChainSlotsPerEpoch:    utils.Config.Chain.SlotsPerEpoch,
+		ChainSecondsPerSlot:   utils.Config.Chain.SecondsPerSlot,
+		ChainGenesisTimestamp: utils.Config.Chain.GenesisTimestamp,
 	}
 
 	err := faqTemplate.ExecuteTemplate(w, "layout", data)

--- a/handlers/imprint.go
+++ b/handlers/imprint.go
@@ -29,10 +29,13 @@ func Imprint(w http.ResponseWriter, r *http.Request) {
 			Description: "beaconcha.in makes the Ethereum 2.0. beacon chain accessible to non-technical end users",
 			Path:        "/imprint",
 		},
-		ShowSyncingMessage: services.IsSyncing(),
-		Active:             "imprint",
-		Data:               nil,
-		Version:            version.Version,
+		ShowSyncingMessage:    services.IsSyncing(),
+		Active:                "imprint",
+		Data:                  nil,
+		Version:               version.Version,
+		ChainSlotsPerEpoch:    utils.Config.Chain.SlotsPerEpoch,
+		ChainSecondsPerSlot:   utils.Config.Chain.SecondsPerSlot,
+		ChainGenesisTimestamp: utils.Config.Chain.GenesisTimestamp,
 	}
 
 	err = imprintTemplate.ExecuteTemplate(w, "layout", data)

--- a/handlers/index.go
+++ b/handlers/index.go
@@ -24,10 +24,13 @@ func Index(w http.ResponseWriter, r *http.Request) {
 			Description: "beaconcha.in makes the Ethereum 2.0. beacon chain accessible to non-technical end users",
 			Path:        "",
 		},
-		ShowSyncingMessage: services.IsSyncing(),
-		Active:             "index",
-		Data:               services.LatestIndexPageData(),
-		Version:            version.Version,
+		ShowSyncingMessage:    services.IsSyncing(),
+		Active:                "index",
+		Data:                  services.LatestIndexPageData(),
+		Version:               version.Version,
+		ChainSlotsPerEpoch:    utils.Config.Chain.SlotsPerEpoch,
+		ChainSecondsPerSlot:   utils.Config.Chain.SecondsPerSlot,
+		ChainGenesisTimestamp: utils.Config.Chain.GenesisTimestamp,
 	}
 
 	err := indexTemplate.ExecuteTemplate(w, "layout", data)

--- a/handlers/validator.go
+++ b/handlers/validator.go
@@ -34,10 +34,13 @@ func Validator(w http.ResponseWriter, r *http.Request) {
 		Meta: &types.Meta{
 			Description: "beaconcha.in makes the Ethereum 2.0. beacon chain accessible to non-technical end users",
 		},
-		ShowSyncingMessage: services.IsSyncing(),
-		Active:             "validators",
-		Data:               nil,
-		Version:            version.Version,
+		ShowSyncingMessage:    services.IsSyncing(),
+		Active:                "validators",
+		Data:                  nil,
+		Version:               version.Version,
+		ChainSlotsPerEpoch:    utils.Config.Chain.SlotsPerEpoch,
+		ChainSecondsPerSlot:   utils.Config.Chain.SecondsPerSlot,
+		ChainGenesisTimestamp: utils.Config.Chain.GenesisTimestamp,
 	}
 
 	if strings.Contains(vars["index"], "0x") || len(vars["index"]) == 96 {

--- a/handlers/validators.go
+++ b/handlers/validators.go
@@ -73,10 +73,13 @@ func Validators(w http.ResponseWriter, r *http.Request) {
 			Description: "beaconcha.in makes the Ethereum 2.0. beacon chain accessible to non-technical end users",
 			Path:        "/validators",
 		},
-		ShowSyncingMessage: services.IsSyncing(),
-		Active:             "validators",
-		Data:               validatorsPageData,
-		Version:            version.Version,
+		ShowSyncingMessage:    services.IsSyncing(),
+		Active:                "validators",
+		Data:                  validatorsPageData,
+		Version:               version.Version,
+		ChainSlotsPerEpoch:    utils.Config.Chain.SlotsPerEpoch,
+		ChainSecondsPerSlot:   utils.Config.Chain.SecondsPerSlot,
+		ChainGenesisTimestamp: utils.Config.Chain.GenesisTimestamp,
 	}
 
 	err = validatorsTemplate.ExecuteTemplate(w, "layout", data)

--- a/handlers/validators_leaderboard.go
+++ b/handlers/validators_leaderboard.go
@@ -27,10 +27,13 @@ func ValidatorsLeaderboard(w http.ResponseWriter, r *http.Request) {
 			Description: "beaconcha.in makes the Ethereum 2.0. beacon chain accessible to non-technical end users",
 			Path:        "/validators/leaderboard",
 		},
-		ShowSyncingMessage: services.IsSyncing(),
-		Active:             "validators",
-		Data:               nil,
-		Version:            version.Version,
+		ShowSyncingMessage:    services.IsSyncing(),
+		Active:                "validators",
+		Data:                  nil,
+		Version:               version.Version,
+		ChainSlotsPerEpoch:    utils.Config.Chain.SlotsPerEpoch,
+		ChainSecondsPerSlot:   utils.Config.Chain.SecondsPerSlot,
+		ChainGenesisTimestamp: utils.Config.Chain.GenesisTimestamp,
 	}
 
 	err := validatorsLeaderboardTemplate.ExecuteTemplate(w, "layout", data)

--- a/handlers/vis.go
+++ b/handlers/vis.go
@@ -30,10 +30,13 @@ func Vis(w http.ResponseWriter, r *http.Request) {
 			Description: "beaconcha.in makes the Ethereum 2.0. beacon chain accessible to non-technical end users",
 			Path:        "/blocks",
 		},
-		ShowSyncingMessage: services.IsSyncing(),
-		Active:             "vis",
-		Data:               nil,
-		Version:            version.Version,
+		ShowSyncingMessage:    services.IsSyncing(),
+		Active:                "vis",
+		Data:                  nil,
+		Version:               version.Version,
+		ChainSlotsPerEpoch:    utils.Config.Chain.SlotsPerEpoch,
+		ChainSecondsPerSlot:   utils.Config.Chain.SecondsPerSlot,
+		ChainGenesisTimestamp: utils.Config.Chain.GenesisTimestamp,
 	}
 
 	err = visTemplate.ExecuteTemplate(w, "layout", data)
@@ -140,9 +143,12 @@ func VisVotes(w http.ResponseWriter, r *http.Request) {
 			Description: "beaconcha.in makes the Ethereum 2.0. beacon chain accessible to non-technical end users",
 			Path:        "/blocks",
 		},
-		ShowSyncingMessage: services.IsSyncing(),
-		Active:             "vis",
-		Data:               &types.VisVotesPageData{ChartData: chartData},
+		ShowSyncingMessage:    services.IsSyncing(),
+		Active:                "vis",
+		Data:                  &types.VisVotesPageData{ChartData: chartData},
+		ChainSlotsPerEpoch:    utils.Config.Chain.SlotsPerEpoch,
+		ChainSecondsPerSlot:   utils.Config.Chain.SecondsPerSlot,
+		ChainGenesisTimestamp: utils.Config.Chain.GenesisTimestamp,
 	}
 
 	err = visVotesTemplate.ExecuteTemplate(w, "layout", data)

--- a/static/js/dashboard.js
+++ b/static/js/dashboard.js
@@ -627,7 +627,22 @@ function createBalanceChart(effective, balance, utilization) {
     },
     xAxis: {
       type: 'datetime',
-      range: 7 * 24 * 60 * 60 * 1000
+      range: 7 * 24 * 60 * 60 * 1000,
+      labels: {
+        formatter: function(){
+          var epoch = timeToEpoch(this.value)
+          var orig = this.axis.defaultLabelFormatter.call(this)
+          return `${orig}<br/>Epoch ${epoch}`
+        }
+      }
+    },
+    tooltip: {
+      formatter: function(tooltip) {
+        var orig = tooltip.defaultFormatter.call(this, tooltip)
+        var epoch = timeToEpoch(this.x)
+        orig[0] = `${orig[0]}<span style="font-size:10px">Epoch ${epoch}</span>`
+        return orig
+      }
     },
     yAxis: [
       {

--- a/templates/index.html
+++ b/templates/index.html
@@ -29,7 +29,14 @@
               subtitle: {},
               xAxis: {
                   type: 'datetime',
-                  range: 7 * 24 * 60 * 60 * 1000
+                  range: 7 * 24 * 60 * 60 * 1000,
+                  labels: {
+                    formatter: function(){
+                        var epoch = timeToEpoch(this.value)
+                        var orig = this.axis.defaultLabelFormatter.call(this)
+                        return `${orig}<br/>Epoch ${epoch}`
+                    }
+                  }
               },
               yAxis: [{
                   title: {
@@ -63,6 +70,14 @@
               }],
               legend: {
                   enabled: true
+              },
+              tooltip: {
+                  formatter: function(tooltip) {
+                      var orig = tooltip.defaultFormatter.call(this, tooltip)
+                      var epoch = timeToEpoch(this.x)
+                      orig[0] = `${orig[0]}<span style="font-size:10px">Epoch ${epoch}</span>`
+                      return orig
+                  }
               }
           }
       },

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -221,7 +221,35 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.18.1/moment-with-locales.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/typeahead.js/0.11.1/typeahead.bundle.min.js"></script>
     <script src="/js/layout.js"></script>
-
+    <script>
+        function slotToTime(slot) {
+            var gts = {{.ChainGenesisTimestamp}}
+            var sps = {{.ChainSecondsPerSlot}}
+            return (gts+slot*sps)*1000
+        }
+        function epochToTime(epoch) {
+            var gts = {{.ChainGenesisTimestamp}}
+            var sps = {{.ChainSecondsPerSlot}}
+            var spe = {{.ChainSlotsPerEpoch}}
+            return (gts+epoch*sps*spe)*1000
+        }
+        function timeToEpoch(ts) {
+            var gts = {{.ChainGenesisTimestamp}}
+            var sps = {{.ChainSecondsPerSlot}}
+            var spe = {{.ChainSlotsPerEpoch}}
+            var slot = Math.floor((ts/1000 - gts) / sps)
+            var epoch = Math.floor(slot/spe)
+            return epoch
+        }
+        function timeToSlot(ts) {
+            var gts = {{.ChainGenesisTimestamp}}
+            var sps = {{.ChainSecondsPerSlot}}
+            var spe = {{.ChainSlotsPerEpoch}}
+            var slot = Math.floor((ts/1000 - gts) / sps)
+            return slot
+        }
+    </script>
+    
     {{ template "js" .Data }}
 
     </body>

--- a/templates/validator.html
+++ b/templates/validator.html
@@ -98,7 +98,14 @@
 			},
 			xAxis: {
 				type: 'datetime',
-				range: 7 * 24 * 60 * 60 * 1000
+				range: 7 * 24 * 60 * 60 * 1000,
+				labels: {
+					formatter: function(){
+						var epoch = timeToEpoch(this.value)
+						var orig = this.axis.defaultLabelFormatter.call(this)
+						return `${orig}<br/>Epoch ${epoch}`
+					}
+				}
 			},
 			yAxis: [{
 				title: {
@@ -113,7 +120,15 @@
 				name: "Effective Balance",
 				step: true,
 				data: {{.EffectiveBalanceHistoryChartData}}
-			}]
+			}],
+			tooltip: {
+				formatter: function(tooltip) {
+					var orig = tooltip.defaultFormatter.call(this, tooltip)
+					var epoch = timeToEpoch(this.x)
+					orig[0] = `${orig[0]}<span style="font-size:10px">Epoch ${epoch}</span>`
+					return orig
+				}
+			}
 		});
 	</script>
 	{{if .DailyProposalCount}}
@@ -176,7 +191,7 @@
 				],
 				rangeSelector: {
 					enabled: false
-				}
+				},
 			})
 		</script>
 	{{end}}

--- a/types/templates.go
+++ b/types/templates.go
@@ -11,11 +11,14 @@ import (
 
 // PageData is a struct to hold web page data
 type PageData struct {
-	Active             string
-	Meta               *Meta
-	ShowSyncingMessage bool
-	Data               interface{}
-	Version            string
+	Active                string
+	Meta                  *Meta
+	ShowSyncingMessage    bool
+	Data                  interface{}
+	Version               string
+	ChainSlotsPerEpoch    uint64
+	ChainSecondsPerSlot   uint64
+	ChainGenesisTimestamp uint64
 }
 
 // Meta is a struct to hold metadata about the page


### PR DESCRIPTION
Not sure about this one, at least it makes it easier to lookup epochs that correspond to a specific time-range on a chart.

Maybe skip the labels and only show the epoch in the tooltip?

![eth2-explorer-pr-epochs-in-labels-and-tooltips](https://user-images.githubusercontent.com/306324/76323133-95972e80-62e4-11ea-8b1e-5ebf2e22b2cc.jpg)
