### PR TITLE
Poap page - remove duplicated sentence

### DIFF
--- a/templates/poap.html
+++ b/templates/poap.html
@@ -246,9 +246,6 @@ $(document).ready(function() {
 					<li>The tokens will be distributed via a mechanism called a <a href="https://blog.ricmoo.com/merkle-air-drops-e6406945584d">merkle drop</a>. This is like an airdrop, but badges are only distributed to those who actively claim them reducing state bloat and chain congestion.</li>
 				</ol>  
 			</p>
-			<p>
-				This is like an airdrop, but badges are only distributed to those who actively claim them, reducing state bloat and chain congestion.
-			</p>
 			<h2 class="h5">Generate the flag for you validator:</h2>
 				<!-- <input id="address-input" oninput="setAddress(this.value);" class="from-control my-2" type="text" placeholder="ETH1 Address (eg: 0xAb5801a7D398351b8bE11C439e05C5B3259aeC9B)"></input> -->
 				<div style="flex-direction: row-reverse;" class="row">


### PR DESCRIPTION
`This is like an airdrop, but badges are only distributed to those who actively claim them reducing state bloat and chain congestion` was already mentioned in the above.

