### PR TITLE
Fix eth1 deposits: consider multiple deposits per tx (fix #172)

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -109,7 +109,8 @@ func GetEth1DepositsJoinEth2Deposits(query string, length, start uint64, orderBy
 				ENCODE(eth1.publickey::bytea, 'hex') LIKE LOWER($1)
 				OR ENCODE(eth1.withdrawal_credentials::bytea, 'hex') LIKE LOWER($1)
 				OR ENCODE(eth1.from_address::bytea, 'hex') LIKE LOWER($1)
-				OR ENCODE(tx_hash::bytea, 'hex') LIKE LOWER($1)`, query+"%")
+				OR ENCODE(tx_hash::bytea, 'hex') LIKE LOWER($1)
+				OR CAST(eth1.block_number AS text) LIKE LOWER($1)`, query+"%")
 	} else {
 		err = DB.Get(&totalCount, "SELECT COUNT(*) FROM eth1_deposits")
 	}
@@ -152,12 +153,10 @@ func GetEth1DepositsJoinEth2Deposits(query string, length, start uint64, orderBy
 			v.pubkey = eth1.publickey
 		WHERE
 			ENCODE(eth1.publickey::bytea, 'hex') LIKE LOWER($3)
-		OR
-			ENCODE(eth1.withdrawal_credentials::bytea, 'hex') LIKE LOWER($3)
-		OR
-			ENCODE(eth1.from_address::bytea, 'hex') LIKE LOWER($3)
-		OR
-			ENCODE(tx_hash::bytea, 'hex') LIKE LOWER($3)
+			OR ENCODE(eth1.withdrawal_credentials::bytea, 'hex') LIKE LOWER($3)
+			OR ENCODE(eth1.from_address::bytea, 'hex') LIKE LOWER($3)
+			OR ENCODE(tx_hash::bytea, 'hex') LIKE LOWER($3)
+			OR CAST(eth1.block_number AS text) LIKE LOWER($3)
 		ORDER BY %s %s
 		LIMIT $1
 		OFFSET $2`, orderBy, orderDir), length, start, query+"%", latestEpoch, validatorOnlineThresholdSlot)

--- a/exporter/eth1.go
+++ b/exporter/eth1.go
@@ -234,7 +234,7 @@ func saveEth1Deposits(depositsToSave []*types.Eth1Deposit) error {
 			valid_signature
 		)
 		VALUES ($1, $2, $3, $4, TO_TIMESTAMP($5), $6, $7, $8, $9, $10, $11, $12, $13)
-		ON CONFLICT (tx_hash) DO UPDATE SET
+		ON CONFLICT (tx_hash, merkletree_index) DO UPDATE SET
 			tx_input               = EXCLUDED.tx_input,
 			tx_index               = EXCLUDED.tx_index,
 			block_number           = EXCLUDED.block_number,

--- a/tables.sql
+++ b/tables.sql
@@ -147,7 +147,7 @@ create table blocks
     depositscount          int   not null,
     voluntaryexitscount    int   not null,
     proposer               int   not null,
-    status                 text  not null,
+    status                 text  not null, /* Can be 0 = scheduled, 1 proposed, 2 missed, 3 orphaned */
     primary key (slot, blockroot)
 );
 create index idx_blocks_proposer on blocks (proposer);

--- a/tables.sql
+++ b/tables.sql
@@ -280,7 +280,7 @@ create table eth1_deposits
     merkletree_index       bytea                       not null,
     removed                bool                        not null,
     valid_signature        bool                        not null,
-    primary key (tx_hash)
+    primary key (tx_hash, merkletree_index)
 );
 create index idx_eth1_deposits on eth1_deposits (publickey);
 


### PR DESCRIPTION
This fixes #172 

After merging we need to drop and create the `eth1_deposits` table, the exporter will re-fetch all the the eth1-deposits this time it will also include multiple deposits inside a single tx.