### PR TITLE
rpc/lighthouse: assume unsecure http just like prysm client

### DIFF
--- a/rpc/lighthouse.go
+++ b/rpc/lighthouse.go
@@ -25,7 +25,7 @@ type LighthouseClient struct {
 // NewLighthouseClient is used to create a new Lighthouse client
 func NewLighthouseClient(endpoint string) (*LighthouseClient, error) {
 	client := &LighthouseClient{
-		endpoint:            endpoint,
+		endpoint:            "http://" + endpoint,
 		assignmentsCacheMux: &sync.Mutex{},
 	}
 	client.assignmentsCache, _ = lru.New(128)


### PR DESCRIPTION
without this change, indexer,node.host needs to be prefixed with `http://` for lh, or you get:

`
ERRO[0000] beacon-node seems to be unavailable: error retrieving chain head: Get "localhost:5052/beacon/head": unsupported protocol scheme "localhost"  module=exporter
`