### PR TITLE
Added first part of OAuth, Fix CSRF Attack Vector, Improved E-Mail confirmation token strength

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ config.yml
 config-lighthouse.yml
 .*swp
 bootstrap/node_modules
+run-local

--- a/cmd/explorer/main.go
+++ b/cmd/explorer/main.go
@@ -213,6 +213,8 @@ func main() {
 		router.HandleFunc("/settings/email/{hash}", handlers.UserConfirmUpdateEmail).Methods("GET")
 
 		authRouter := mux.NewRouter().PathPrefix("/user").Subrouter()
+		authRouter.HandleFunc("/authorize", handlers.UserAuthorizeConfirm).Methods("GET")
+		authRouter.HandleFunc("/authorize", handlers.UserAuthorizeConfirmPost).Methods("POST")
 		authRouter.HandleFunc("/settings", handlers.UserSettings).Methods("GET")
 		authRouter.HandleFunc("/settings/password", handlers.UserUpdatePasswordPost).Methods("POST")
 		authRouter.HandleFunc("/settings/delete", handlers.UserDeletePost).Methods("POST")

--- a/db/frontend.go
+++ b/db/frontend.go
@@ -35,3 +35,9 @@ func UpdatePassword(userId uint64, hash []byte) error {
 	_, err := FrontendDB.Exec("UPDATE users SET password = $1 WHERE id = $2", hash, userId)
 	return err
 }
+
+// AddAuthorizeCode registers a code that can be used in exchange for an access token
+func AddAuthorizeCode(userId uint64, code string) error {
+	_, err := FrontendDB.Exec("INSERT INTO oauth_codes (user_id, code, created_ts) VALUES($1, $2, 'now')", userId, code)
+	return err
+}

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/gogo/protobuf v1.3.1
 	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
 	github.com/google/go-cmp v0.5.1 // indirect
+	github.com/gorilla/csrf v1.7.0
 	github.com/gorilla/mux v1.7.3
 	github.com/gorilla/sessions v1.2.0
 	github.com/hashicorp/golang-lru v0.5.4

--- a/go.sum
+++ b/go.sum
@@ -394,6 +394,8 @@ github.com/googleapis/gnostic v0.0.0-20170729233727-0c5108395e2d/go.mod h1:sJBsC
 github.com/googleapis/gnostic v0.1.0/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTVRp3pOg5EKY=
 github.com/gophercloud/gophercloud v0.1.0/go.mod h1:vxM41WHh5uqHVBMZHzuwNOHh8XEoIEcSTewFxm1c5g8=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
+github.com/gorilla/csrf v1.7.0 h1:mMPjV5/3Zd460xCavIkppUdvnl5fPXMpv2uz2Zyg7/Y=
+github.com/gorilla/csrf v1.7.0/go.mod h1:+a/4tCmqhG6/w4oafeAZ9pEa3/NZOWYVbD9fV0FwIQA=
 github.com/gorilla/mux v1.7.3 h1:gnP5JzjVOuiZD07fKKToCAOjS0yOpj/qPETTXCCS6hw=
 github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/securecookie v1.1.1 h1:miw7JPhV+b/lAHSXz4qd/nN9jRiAFV5FwjeKyCS8BvQ=

--- a/handlers/oauth.go
+++ b/handlers/oauth.go
@@ -1,0 +1,14 @@
+package handlers
+
+/*
+
+TODO:
+Check code creation timestamp (expiration)
+Set consumed flag once exchanged for access token
+
+Code -> AC & Refresh token:
+Check for consumed & expired during access token exchange
+Store device information in this table (makes it easier for users to manage & revoke access for their devices)
+
+
+*/

--- a/tables.sql
+++ b/tables.sql
@@ -310,6 +310,31 @@ create table users
     primary key (id, email)
 );
 
+drop table if exists oauth_codes;
+create table oauth_codes
+(
+    id              serial                      not null,
+    user_id         int                         not null,
+    code            character varying(64)       not null,
+    consumed        bool                        not null default 'f',
+    created_ts      timestamp without time zone not null,
+    primary key (user_id, code)
+);
+
+drop table if exists users_devices;
+create table users_devices
+(
+    id                    serial                      not null,
+    user_id               int                         not null,
+    refresh_token         character varying(64)       not null,
+    device_name           character varying(20)       not null,
+    notification_token    character varying(500),
+    notify_enabled        bool                        not null default 'f',
+    active                bool                        not null default 't',
+    created_ts            timestamp without time zone not null,
+    primary key (user_id, refresh_token)
+);
+
 drop table if exists users_subscriptions;
 create table users_subscriptions
 (

--- a/tables.sql
+++ b/tables.sql
@@ -310,6 +310,18 @@ create table users
     primary key (id, email)
 );
 
+drop table if exists oauth_apps;
+create table oauth_apps
+(
+    id                    serial                      not null,
+    owner_id              int                         not null,
+    redirect_uri          character varying(100)      not null unique,
+    app_name              character varying(35)       not null,
+    active                bool                        not null default 't',
+    created_ts            timestamp without time zone not null,
+    primary key (id, redirect_uri)
+);
+
 drop table if exists oauth_codes;
 create table oauth_codes
 (
@@ -317,6 +329,7 @@ create table oauth_codes
     user_id         int                         not null,
     code            character varying(64)       not null,
     consumed        bool                        not null default 'f',
+    app_id          int                         not null,
     created_ts      timestamp without time zone not null,
     primary key (user_id, code)
 );
@@ -331,6 +344,7 @@ create table users_devices
     notification_token    character varying(500),
     notify_enabled        bool                        not null default 'f',
     active                bool                        not null default 't',
+    app_id                int                         not null,
     created_ts            timestamp without time zone not null,
     primary key (user_id, refresh_token)
 );

--- a/templates/pricing.html
+++ b/templates/pricing.html
@@ -71,11 +71,7 @@
                 <li>Requests per day:<br /> 10,000</li>
                 <li>Total requests per month:<br /> 30,000</li>
               </ul>
-              {{if .User.Authenticated}}
-              <!-- TODO -->
-              {{else}}
-                 <a href="https://beaconcha.in/api/v1/docs/index.html" type="button" class="btn btn-lg btn-block btn-outline-primary">Get started</a>
-              {{end}}
+                 <a href="https://beaconcha.in/api/v1/docs/index.html" target="_blank" type="button" class="btn btn-lg btn-block btn-outline-primary">Get started</a>
             </div>
           </div>
           <div class="card mb-4 box-shadow hot-box">

--- a/templates/user/authorize.html
+++ b/templates/user/authorize.html
@@ -1,0 +1,91 @@
+{{ define "js"}}
+{{end}}
+
+{{ define "css" }}
+<style>
+
+    .authorize-button {
+        min-width: 200px;
+        margin: auto;
+        display: block;
+    }
+
+    .authorize-brand {
+        display: block;
+        margin: auto;
+    }
+
+    .authorize-card {
+        text-align: center;
+    }
+
+    .authorize-buttons {
+        padding-top: 20px;
+    }
+
+    .authorize-description {
+        padding-top: 20px;
+        margin-left: 4vh;
+        margin-right: 4vh;
+    }        
+
+    .authorize-img {
+        margin: 12px;
+    }
+
+    .authorize-logo {
+        font-size: 64px !important;
+    }
+
+</style>  
+{{end}}
+
+{{ define "content"}}
+<div class="container mt-2">
+
+    <div class="row ">
+        <div class="col-xl-7 col-lg-7 col-md-10 col-sm-12 m-auto">
+            {{if .Flashes}}
+                {{range $i, $flash := .Flashes}}
+                <div class="alert {{if contains $flash "Error"}}alert-danger{{else}}alert-success{{end}} alert-dismissible fade show my-3 py-2" role="alert">
+                        <div class="p-2">{{$flash | formatHTML}}</div>
+                        <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+                            <span aria-hidden="true">&times;</span>
+                        </button>
+                    </div>
+                {{end}}
+            {{end}}
+            <div class="user__settings-container">
+               
+                <!-- Update Password -->
+                <div class="card my-3 authorize-card">
+                    <!-- <div class="card-header">
+                        <div class="authorize-brand navbar-brand">
+                            <i class="fas fa-satellite-dish"></i>
+                            <span class="brand-text">beaconcha.in</span>
+                        </div>
+                    </div> -->
+                    <div class="card-body">
+                        <div class="authorize-img">
+                            <h1 class="h1 mb-1 mb-md-0 authorize-logo"><i class="mr-2 fas fa-user-circle"></i></h1>
+                        </div>
+                        <p class="authorize-description">Do you want to link your account with <strong>{{ .AppName }}</strong>?</p>
+                        <form class="authorize-buttons" action="authorize" method="post">
+                            <div class="form-group col-md-12">
+                                <button type="submit" class="btn btn-primary authorize-button">Continue</button>
+                            </div>
+                            <div class="form-group col-md-12">
+                                <a href="/" class="btn secondary authorize-button">Cancel</a>
+                            </div>
+                        </form>
+                    </div>
+                </div>
+                
+            
+        </div>
+    </div>
+
+
+
+</div>
+{{end}}

--- a/templates/user/authorize.html
+++ b/templates/user/authorize.html
@@ -3,7 +3,6 @@
 
 {{ define "css" }}
 <style>
-
     .authorize-button {
         min-width: 200px;
         margin: auto;
@@ -27,7 +26,7 @@
         padding-top: 20px;
         margin-left: 4vh;
         margin-right: 4vh;
-    }        
+    }
 
     .authorize-img {
         margin: 12px;
@@ -36,8 +35,7 @@
     .authorize-logo {
         font-size: 64px !important;
     }
-
-</style>  
+</style>
 {{end}}
 
 {{ define "content"}}
@@ -47,7 +45,8 @@
         <div class="col-xl-7 col-lg-7 col-md-10 col-sm-12 m-auto">
             {{if .Flashes}}
                 {{range $i, $flash := .Flashes}}
-                <div class="alert {{if contains $flash "Error"}}alert-danger{{else}}alert-success{{end}} alert-dismissible fade show my-3 py-2" role="alert">
+                    <div class="alert {{if contains $flash "Error"}}alert-danger{{else}}alert-success{{end}} alert-dismissible fade show my-3 py-2"
+                        role="alert">
                         <div class="p-2">{{$flash | formatHTML}}</div>
                         <button type="button" class="close" data-dismiss="alert" aria-label="Close">
                             <span aria-hidden="true">&times;</span>
@@ -55,37 +54,29 @@
                     </div>
                 {{end}}
             {{end}}
-            <div class="user__settings-container">
-               
-                <!-- Update Password -->
-                <div class="card my-3 authorize-card">
-                    <!-- <div class="card-header">
-                        <div class="authorize-brand navbar-brand">
-                            <i class="fas fa-satellite-dish"></i>
-                            <span class="brand-text">beaconcha.in</span>
-                        </div>
-                    </div> -->
-                    <div class="card-body">
-                        <div class="authorize-img">
-                            <h1 class="h1 mb-1 mb-md-0 authorize-logo"><i class="mr-2 fas fa-user-circle"></i></h1>
-                        </div>
-                        <p class="authorize-description">Do you want to link your account with <strong>{{ .AppName }}</strong>?</p>
-                        <form class="authorize-buttons" action="authorize" method="post">
-                            <div class="form-group col-md-12">
-                                <button type="submit" class="btn btn-primary authorize-button">Continue</button>
+            {{if .AppData }}
+                <div class="user__settings-container">
+                    <div class="card my-3 authorize-card">
+                        <div class="card-body">
+                            <div class="authorize-img">
+                                <h1 class="h1 mb-1 mb-md-0 authorize-logo"><i class="mr-2 fas fa-user-circle"></i></h1>
                             </div>
-                            <div class="form-group col-md-12">
-                                <a href="/" class="btn secondary authorize-button">Cancel</a>
-                            </div>
-                        </form>
+                            <p class="authorize-description">Do you want to link your account with
+                                <strong>{{ .AppData.AppName }}</strong>?</p>
+                            <form class="authorize-buttons" action="authorize" method="post">
+                                {{ .CsrfField }}
+                                <input type="hidden" name="redirect_uri" value="{{ .AppData.RedirectURI }}">
+                                <div class="form-group col-md-12">
+                                    <button type="submit" class="btn btn-primary authorize-button">Continue</button>
+                                </div>
+                                <div class="form-group col-md-12">
+                                    <a href="/" class="btn secondary authorize-button">Cancel</a>
+                                </div>
+                            </form>
+                        </div>
                     </div>
                 </div>
-                
-            
+            {{end}}
         </div>
     </div>
-
-
-
-</div>
 {{end}}

--- a/templates/user/settings.html
+++ b/templates/user/settings.html
@@ -66,6 +66,7 @@
                     </div>
                     <div class="card-body">
                         <form id="email-form" action="settings/email" method="POST">
+                            {{ .CsrfField }}
                             <div class="form-group">
                                 <label for="email">Email address</label>
                                 <div class="input-group">
@@ -86,6 +87,7 @@
                     </div>
                     <div class="card-body">
                         <form action="settings/password" method="post">
+                            {{ .CsrfField }}
                             <input value="{{.Email}}" inputmode="email" type="text" maxlength="100" class="form-control visually-hidden" autocomplete="email" name="email">
                             <div class="form-group">
                                 <label for="old-password">Old Password</label>
@@ -141,6 +143,7 @@
             </div>
             <div class="modal-footer">
                 <form id="delete-form" action="settings/delete" method="POST">
+                    {{ .CsrfField }}
                     <button id="delete-button" type="submit" class="btn btn-outline-danger btn-sm" data-dismiss="modal">Delete</button>
                 </form>
             </div>

--- a/types/config.go
+++ b/types/config.go
@@ -39,6 +39,7 @@ type Config struct {
 		EndEpoch   uint64 `yaml:"endEpoch"`
 	} `yaml:"onetimeexport"`
 	Frontend struct {
+		CsrfAuthKey  string `yaml:"csrfAuthKey" envconfig:"FRONTEND_CSRFAUTHKEY`
 		Enabled      bool   `yaml:"enabled" envconfig:"FRONTEND_ENABLED"`
 		Imprint      string `yaml:"imprint" envconfig:"FRONTEND_IMPRINT"`
 		SiteDomain   string `yaml:"siteDomain" envconfig:"FRONTEND_SITE_DOMAIN"`

--- a/types/frontend.go
+++ b/types/frontend.go
@@ -79,3 +79,11 @@ type TaggedValidators struct {
 	Validator
 	Events []EventName `db:"events"`
 }
+
+type OAuthAppData struct {
+	ID          uint64 `db:"id"`
+	Owner       uint64 `db:"owner_id"`
+	AppName     string `db:"app_name"`
+	RedirectURI string `db:"redirect_uri"`
+	Active      bool   `db:"active"`
+}

--- a/types/templates.go
+++ b/types/templates.go
@@ -215,6 +215,7 @@ type ValidatorPageData struct {
 	User                                *User
 	AverageAttestationInclusionDistance float64
 	AttestationInclusionEffectiveness   float64
+	CsrfField                           template.HTML
 }
 
 // DailyProposalCount is a struct for the daily proposal count data
@@ -683,17 +684,23 @@ type User struct {
 }
 
 type AuthData struct {
-	Flashes []interface{}
-	Email   string
+	Flashes   []interface{}
+	Email     string
+	CsrfField template.HTML
+}
+
+type CsrfData struct {
+	CsrfField template.HTML
 }
 
 type UserSettingsPageData struct {
-	Email string `json:"email"`
+	Email     string `json:"email"`
+	CsrfField template.HTML
 	AuthData
 }
 
 type UserAuthorizeConfirmPageData struct {
-	AppName string
+	AppData *OAuthAppData
 	AuthData
 }
 
@@ -709,11 +716,13 @@ type UserNotificationsPageData struct {
 
 type AdvertiseWithUsPageData struct {
 	FlashMessage string
+	CsrfField    template.HTML
 }
 
 type ApiPricing struct {
 	FlashMessage string
 	User         *User
+	CsrfField    template.HTML
 }
 
 type StakeWithUsPageData struct {

--- a/types/templates.go
+++ b/types/templates.go
@@ -692,6 +692,11 @@ type UserSettingsPageData struct {
 	AuthData
 }
 
+type UserAuthorizeConfirmPageData struct {
+	AppName string
+	AuthData
+}
+
 type UserNotificationsPageData struct {
 	Email              string   `json:"email"`
 	CountWatchlist     int      `json:"countwatchlist"`

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -11,7 +11,6 @@ import (
 	"log"
 	"math"
 	"math/big"
-	"math/rand"
 	"net/http"
 	"os"
 	"os/signal"
@@ -221,13 +220,11 @@ func RoundDecimals(f float64, n int) float64 {
 
 const charset = "abcdefghijklmnopqrstuvwxyz0123456789"
 
-var seededRand = rand.New(rand.NewSource(time.Now().UnixNano()))
-
 // RandomString returns a random hex-string
 func RandomString(length int) string {
-	b := make([]byte, length)
+	b, _ := GenerateRandomBytesSecure(length)
 	for i := range b {
-		b[i] = charset[seededRand.Intn(len(charset))]
+		b[i] = charset[int(b[i])%len(charset)]
 	}
 	return string(b)
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	securerand "crypto/rand"
 	"database/sql"
 	"encoding/hex"
 	"eth2-exporter/types"
@@ -229,6 +230,16 @@ func RandomString(length int) string {
 		b[i] = charset[seededRand.Intn(len(charset))]
 	}
 	return string(b)
+}
+
+func GenerateRandomBytesSecure(n int) ([]byte, error) {
+	b := make([]byte, n)
+	_, err := securerand.Read(b)
+	if err != nil {
+		return nil, err
+	}
+
+	return b, nil
 }
 
 func SqlRowsToJSON(rows *sql.Rows) ([]interface{}, error) {


### PR DESCRIPTION
This PR addresses three things:

- First part of OAuth is implemented (contains authorize page, db stuff, callback with code)
- Fixed CSRF attack vector by using csrf tokens for post forms
- Switched to secure random instead of pseudo random for E-Mail confirmation token

**Migration Guide**

1. Create OAuth tables: (exported from tables.sql)
```
drop table if exists oauth_apps;
create table oauth_apps
(
    id                    serial                      not null,
    owner_id              int                         not null,
    redirect_uri          character varying(100)      not null unique,
    app_name              character varying(35)       not null,
    active                bool                        not null default 't',
    created_ts            timestamp without time zone not null,
    primary key (id, redirect_uri)
);

drop table if exists oauth_codes;
create table oauth_codes
(
    id              serial                      not null,
    user_id         int                         not null,
    code            character varying(64)       not null,
    consumed        bool                        not null default 'f',
    app_id          int                         not null,
    created_ts      timestamp without time zone not null,
    primary key (user_id, code)
);

drop table if exists users_devices;
create table users_devices
(
    id                    serial                      not null,
    user_id               int                         not null,
    refresh_token         character varying(64)       not null,
    device_name           character varying(20)       not null,
    notification_token    character varying(500),
    notify_enabled        bool                        not null default 'f',
    active                bool                        not null default 't',
    app_id                int                         not null,
    created_ts            timestamp without time zone not null,
    primary key (user_id, refresh_token)
);
```
2. Seed oauth_apps table with beaconcha.in mobile app
`insert into oauth_apps(owner_id, redirect_uri, app_name, created_ts) VALUES(1, 'callback://beaconchainmobile', 'Beaconchain´s Validator Monitor', 'now');`

3. Generate an CSRF Auth Key (random 32 byte as hex string) and add it to the target configuration yaml under frontend.
Example:
```
frontend:
    csrfAuthKey: '0123456789abcdef000000000000000000000000000000000000000000000000'
    enabled: ...
```
Do not use the key from the example above!