### PR TITLE
Kong Api gateway and rate-limiting 

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ We currently do not provide any pre-built binaries of the explorer. Docker image
 ## Developing locally with docker
 - Clone the repository
 - Run `docker-compose up` to start instances of the following containers `eth1`, `prysm`, `postgres` and `golang`.
-- Open a new terminal in project directory and run `docker run -it --rm --net=host -v ${pwd}/:/src  postgres psql -f /src/tables.sql -d db -h 0.0.0.0 -U postgres` to create new tables in the database  
+- Open a new terminal in project directory and run `docker run -it --rm --net=host -v $(pwd):/src  postgres psql -f /src/tables.sql -d db -h 0.0.0.0 -U postgres` to create new tables in the database  
 - Wait for the client to finish initial sync, you can check this by looking at logs of `prysm` instance.
 - Copy the `config-example.yml` file and adapt it to your environment.\
  In your `.yml` file specify `eth1Endpoint` as `'./private/eth1_node/.ethereum/goerli/geth.ipc'`. 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,14 @@ We currently do not provide any pre-built binaries of the explorer. Docker image
 - Connect to `golang` instance by running `docker exec -ti golang bash` and run `make all`
 - Start the explorer binary and pass the path to the config file as argument 
 
-      ./bin/explorer --config your_config.yml   
+      ./bin/explorer --config your_config.yml  
+
+## For Kong
+- type in the database `create role kong login;` and `create database kong;` 
+-  uncomment `"# command: kong migrations bootstrap"` line in the `docker-compose.yml` file
+- run `docker-compose up` wait till you see `kong exit(0)` then stop containers by pressing `ctr+C`
+- comment this line "# command: kong migrations bootstrap"`
+- run `docker-compose up`
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -79,11 +79,11 @@ We currently do not provide any pre-built binaries of the explorer. Docker image
       ./bin/explorer --config your_config.yml  
 
 ## For Kong
-- type in the database `create role kong login;` and `create database kong;` 
--  uncomment `"# command: kong migrations bootstrap"` line in the `docker-compose.yml` file
-- run `docker-compose up` wait till you see `kong exit(0)` then stop containers by pressing `ctr+C`
-- comment this line "# command: kong migrations bootstrap"`
-- run `docker-compose up`
+- Type in the database `create role kong login;` and `create database kong;` 
+- Uncomment `"# command: kong migrations bootstrap"` line in the `docker-compose.yml` file
+- Run `docker-compose up` wait till you see `kong exit(0)` then stop containers by pressing `ctr+C` and run `docker-compose down`
+- Comment this line "command: kong migrations bootstrap"`
+- Run `docker-compose up`
 
 ## Development
 

--- a/db/frontend.go
+++ b/db/frontend.go
@@ -21,6 +21,12 @@ func GetUserEmailById(id uint64) (string, error) {
 	return mail, err
 }
 
+func GetUserApiKeyById(id uint64) (string, error) {
+	var apiKey string = ""
+	err := FrontendDB.Get(&apiKey, "SELECT api_key FROM users WHERE id = $1", id)
+	return apiKey, err
+}
+
 // DeleteUserByEmail deletes a user.
 func DeleteUserByEmail(email string) error {
 	_, err := FrontendDB.Exec("DELETE FROM users WHERE email = $1", email)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,8 @@ services:
         environment:
             - POSTGRES_PASSWORD=pass
             - POSTGRES_USER=postgres
-            - POSTGRES_DB=db
+            # - POSTGRES_DB=db // goerli db
+            - POSTGRES_DB=maindb
             - PGDATA=/postgresql/data
         volumes:
             - db:/postgresql/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,5 +57,17 @@ services:
         stdin_open: true
         tty: true
 
+    kong:
+        image: kong:2.2.0
+        container_name: kong 
+        restart: always
+        network_mode: host
+        environment: 
+            - KONG_DATABASE=postgres 
+            - KONG_PG_HOST=0.0.0.0
+        # command: kong migrations bootstrap
+        depends_on:
+            - prysm
+
 volumes: 
     db:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,9 @@ services:
         volumes:
             - ./private/eth1_node:/root
         network_mode: host
-        command: 
-            - --goerli
+        # uncomment the lines below for goerli testnet
+        # command: 
+        #     - --goerli
 
 
     postgres:
@@ -30,13 +31,14 @@ services:
         restart: always
         volumes:
             - ./private/eth2_data:/data
-            - ./private/eth1_node/.ethereum/goerli:$HOME/Goerli
+            #- ./private/eth1_node/.ethereum/goerli:$HOME/ipc # goerli testnet
+            - ./private/eth1_node/.ethereum/:$HOME/ipc # mainnet
         network_mode: host
         command: 
             - --datadir=/data
             - --rpc-host=0.0.0.0
             - --monitoring-host=0.0.0.0
-            - --http-web3provider=$HOME/Goerli/geth.ipc
+            - --http-web3provider=$HOME/ipc/geth.ipc
             - --accept-terms-of-use
         depends_on:
             - eth1

--- a/handlers/user.go
+++ b/handlers/user.go
@@ -62,9 +62,19 @@ func UserSettings(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	apiKey, err := db.GetUserApiKeyById(user.UserID)
+	if err != nil {
+		logger.Errorf("Error retrieving the api_key for user: %v %v", user.UserID, err)
+		session.Flashes("Error: Something went wrong.")
+		session.Save(r, w)
+		apiKey = "Not available!"
+		//return
+	}
+
 	userSettingsData.Email = email
 	userSettingsData.Flashes = utils.GetFlashes(w, r, authSessionName)
 	userSettingsData.CsrfField = csrf.TemplateField(r)
+	userSettingsData.APIKey = apiKey
 
 	data := &types.PageData{
 		HeaderAd: true,

--- a/kong/kong_configurator.go
+++ b/kong/kong_configurator.go
@@ -1,0 +1,67 @@
+package kong
+
+import (
+	"io/ioutil"
+	"net/http"
+	"strings"
+)
+
+func post_to_kong_admin(api_url string, data string) (response string) {
+	reqBody := strings.NewReader(data)
+	resp, err := http.Post("http://0.0.0.0:8001"+api_url,
+		"application/x-www-form-urlencoded", reqBody)
+	if err != nil {
+		print(err)
+	}
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		print(err)
+	}
+	return string(body)
+}
+
+func SetupKong() {
+	post_to_kong_admin("/services/", "url=http://0.0.0.0:3333&name=api")
+	post_to_kong_admin("/services/api/routes/", "hosts[]=0.0.0.0")
+	post_to_kong_admin("/services/api/routes/", "hosts[]=127.0.0.1")
+	post_to_kong_admin("/services/api/routes/", "hosts[]=localhost")
+	post_to_kong_admin("/services/api/routes/", "hosts[]=beaconcha.in")
+	post_to_kong_admin("/services/api/plugins/", "name=key-auth")
+}
+
+func addConsumer(userID string, apiKey string) {
+	post_to_kong_admin("/consumers/", "username="+userID) // 'custom_id' doesn't work, 'username' is used for storing the id
+	post_to_kong_admin("/consumers/"+userID+"/key-auth/", "key="+apiKey)
+}
+
+func SubUserToSapphire(userID string, apiKey string) {
+	addConsumer(userID, apiKey)
+	post_to_kong_admin("/consumers/"+userID+"/plugins/",
+		"name=rate-limiting&config.minute=100&config.day=100000&config.month=500000&config.policy=local")
+}
+
+func SubUserToEmerald(userID string, apiKey string) {
+	addConsumer(userID, apiKey)
+	post_to_kong_admin("/consumers/"+userID+"/plugins/",
+		"name=rate-limiting&config.day=200000&config.month=1000000&config.policy=local")
+}
+
+func SubUserToDiamond(userID string, apiKey string) {
+	addConsumer(userID, apiKey)
+	post_to_kong_admin("/consumers/"+userID+"/plugins/",
+		"name=rate-limiting&config.month=4000000&config.policy=local")
+}
+
+func SubUserToFree(userID string, apiKey string) {
+	addConsumer(userID, apiKey)
+	post_to_kong_admin("/consumers/"+userID+"/plugins/",
+		"name=rate-limiting&config.minute=10&config.day=10000&config.month=30000&config.policy=local")
+}
+
+//usage
+// func main() {
+// 	setupKong()
+// 	SubUserToSapphire("username", "apikey")
+
+// }

--- a/kong/kong_configurator.go
+++ b/kong/kong_configurator.go
@@ -6,62 +6,60 @@ import (
 	"strings"
 )
 
-func post_to_kong_admin(api_url string, data string) (response string) {
+func postToKongAdmin(apiURL string, data string) (response string) {
 	reqBody := strings.NewReader(data)
-	resp, err := http.Post("http://0.0.0.0:8001"+api_url,
+	resp, err := http.Post("http://0.0.0.0:8001"+apiURL,
 		"application/x-www-form-urlencoded", reqBody)
 	if err != nil {
-		print(err)
+		logger.Errorf("error posting to kong admin: %v", err)
 	}
 	defer resp.Body.Close()
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		print(err)
+		logger.Errorf("error receiving kong admin response: %v", err)
 	}
 	return string(body)
 }
 
+// SetupKong limit any '/api' calls to the kong port 8000 from specified hosts
 func SetupKong() {
-	post_to_kong_admin("/services/", "url=http://0.0.0.0:3333&name=api")
-	post_to_kong_admin("/services/api/routes/", "hosts[]=0.0.0.0")
-	post_to_kong_admin("/services/api/routes/", "hosts[]=127.0.0.1")
-	post_to_kong_admin("/services/api/routes/", "hosts[]=localhost")
-	post_to_kong_admin("/services/api/routes/", "hosts[]=beaconcha.in")
-	post_to_kong_admin("/services/api/plugins/", "name=key-auth")
+	postToKongAdmin("/services/", "url=http://0.0.0.0:3333&name=api")
+	postToKongAdmin("/services/api/routes/", "hosts[]=0.0.0.0")
+	postToKongAdmin("/services/api/routes/", "hosts[]=127.0.0.1")
+	postToKongAdmin("/services/api/routes/", "hosts[]=localhost")
+	postToKongAdmin("/services/api/routes/", "hosts[]=beaconcha.in")
+	postToKongAdmin("/services/api/plugins/", "name=key-auth")
 }
 
 func addConsumer(userID string, apiKey string) {
-	post_to_kong_admin("/consumers/", "username="+userID) // 'custom_id' doesn't work, 'username' is used for storing the id
-	post_to_kong_admin("/consumers/"+userID+"/key-auth/", "key="+apiKey)
+	postToKongAdmin("/consumers/", "username="+userID) // 'custom_id' doesn't work, 'username' is used for storing the id
+	postToKongAdmin("/consumers/"+userID+"/key-auth/", "key="+apiKey)
 }
 
+// SubUserToSapphire subscribe a user to Sapphire plan
 func SubUserToSapphire(userID string, apiKey string) {
 	addConsumer(userID, apiKey)
-	post_to_kong_admin("/consumers/"+userID+"/plugins/",
+	postToKongAdmin("/consumers/"+userID+"/plugins/",
 		"name=rate-limiting&config.minute=100&config.day=100000&config.month=500000&config.policy=local")
 }
 
+// SubUserToEmerald subscribe a user to Emerald plan
 func SubUserToEmerald(userID string, apiKey string) {
 	addConsumer(userID, apiKey)
-	post_to_kong_admin("/consumers/"+userID+"/plugins/",
+	postToKongAdmin("/consumers/"+userID+"/plugins/",
 		"name=rate-limiting&config.day=200000&config.month=1000000&config.policy=local")
 }
 
+// SubUserToDiamond subscribe a user to Diamond plan
 func SubUserToDiamond(userID string, apiKey string) {
 	addConsumer(userID, apiKey)
-	post_to_kong_admin("/consumers/"+userID+"/plugins/",
+	postToKongAdmin("/consumers/"+userID+"/plugins/",
 		"name=rate-limiting&config.month=4000000&config.policy=local")
 }
 
+// SubUserToFree subscribe a user to Free plan
 func SubUserToFree(userID string, apiKey string) {
 	addConsumer(userID, apiKey)
-	post_to_kong_admin("/consumers/"+userID+"/plugins/",
+	postToKongAdmin("/consumers/"+userID+"/plugins/",
 		"name=rate-limiting&config.minute=10&config.day=10000&config.month=30000&config.policy=local")
 }
-
-//usage
-// func main() {
-// 	setupKong()
-// 	SubUserToSapphire("username", "apikey")
-
-// }

--- a/kong/logger.go
+++ b/kong/logger.go
@@ -1,0 +1,5 @@
+package kong
+
+import "github.com/sirupsen/logrus"
+
+var logger = logrus.New().WithField("module", "kong")

--- a/tables.sql
+++ b/tables.sql
@@ -307,6 +307,7 @@ create table users
     password_reset_hash     character varying(40),
     password_reset_ts       timestamp without time zone,
     register_ts             timestamp without time zone,
+    api_key                 character varying(256),
     primary key (id, email)
 );
 

--- a/templates/user/settings.html
+++ b/templates/user/settings.html
@@ -106,6 +106,23 @@
                     </div>
                 </div>
                 
+                <div class="card my-3"> 
+                    <div class="card-header">
+                        <h3 class="h5">Api Key <i class="fas fa-exclamation-triangle text-warning"></i></h3>
+                    </div>
+                    <div class="card-body">
+                        <div style="display: flex; flex-direction: column">
+                            <span class="text-danger">
+                                Warning, everybody can access your account with this key. KEEP IT SAFE!
+                            </span>
+                            <hr/>
+                            <span>
+                                8s9dafy8dhgasiuhgisayg8saygasfd9gyua89yf
+                            </span>
+                        </div>
+                    </div>
+                </div>
+
                 <!-- Delete Account -->
                 <div class="card my-3"> 
                     <div class="card-header">

--- a/templates/user/settings.html
+++ b/templates/user/settings.html
@@ -117,7 +117,7 @@
                             </span>
                             <hr/>
                             <span>
-                                8s9dafy8dhgasiuhgisayg8saygasfd9gyua89yf
+                                {{ .APIKey }}
                             </span>
                         </div>
                     </div>

--- a/types/templates.go
+++ b/types/templates.go
@@ -695,6 +695,7 @@ type CsrfData struct {
 
 type UserSettingsPageData struct {
 	Email     string `json:"email"`
+	APIKey    string `json:"api_key"`
 	CsrfField template.HTML
 	AuthData
 }


### PR DESCRIPTION
Please follow the setup procedure for kong from "README", and add column "api_key" as "character varying(256)" to the table "users" on the database. Now a new user can be created and they will have a unique apikey generated and stored on the db.
Limits for the new user can be set by using the package "kong", and user can access their private key in the account settings page.

Check the file "kong/kong_configurator.go" to see all available rate-limiting functions

Notes for improvement:
a better way for generating the api-key.
having "SetupKong()" function called when the software is run for the first time.
having a method for parsing the messages returned from the kong admin to do verification.