### PR TITLE
stakingServices: change stkr fee to 23% of rewards

### DIFF
--- a/templates/stakingServices.html
+++ b/templates/stakingServices.html
@@ -139,7 +139,7 @@
 								<td data-column="Pool token">Yes</td>
 								<td data-column="3rd Party Software">No</td>
 								<td data-column="Min. Stake">0.5 ETH</td>
-								<td data-column="Fee">1%</td>
+								<td data-column="Fee">23% of rewards</td>
 								<td data-column="Open Source">Yes</td>
 								<td data-column="Social">
 									<a href="https://twitter.com/ankr" target="_blank"><i class="fab fa-twitter ml-1 mr-1"></i></a>


### PR DESCRIPTION
The "[litepaper](https://assets.ankr.com/files/stkr_litepaper.pdf)", page 12, indicates that the payment rate to staking users is 77%, resulting in an effective 23% fee (for rewards).