### PR TITLE
add tooltips to abbreviations

### DIFF
--- a/static/js/validator.js
+++ b/static/js/validator.js
@@ -305,7 +305,6 @@ function createValidatorDataTable(index) {
 	  $.ajax({url:'/validator/'+index+'/rank',
 			data : {"index": index}, 
 			success: (result)=>{
-				console.log(result);
 				$('#validatorRank').html(result[0].rank)
 			}
 		})

--- a/templates/validator/infoTable.html
+++ b/templates/validator/infoTable.html
@@ -120,7 +120,7 @@
                     <th>Status</th>
                     <th>Time</th>
                     <th>Root Hash</th>
-                    <th>Att.</th>
+                    <th><span data-toggle="tooltip" data-placement="top" title="Attestations">Att.</span></th>
                     <th>Deposits</th>
                     <th>Slashings <span data-toggle="tooltip" data-placement="top" title="Proposers">P</span>/
                     <span data-toggle="tooltip" data-placement="top" title="Attesters">A</span></th>

--- a/utils/format.go
+++ b/utils/format.go
@@ -212,7 +212,10 @@ func FormatGlobalParticipationRate(e uint64, r float64) template.HTML {
 func FormatGraffiti(graffiti []byte) template.HTML {
 	s := strings.Map(fixUtf, string(bytes.Trim(graffiti, "\x00")))
 	h := template.HTMLEscapeString(s)
-	return template.HTML(fmt.Sprintf("<span aria-graffiti=\"%#x\">%s</span>", graffiti, h))
+	if len(s) <= 6 {
+		return template.HTML(fmt.Sprintf("<span aria-graffiti=\"%#x\">%s</span>", graffiti, h))
+	}
+	return template.HTML(fmt.Sprintf("<span aria-graffiti=\"%#x\" data-toggle=\"tooltip\" data-placement=\"top\" title=\"%s\" >%s...</span>", graffiti, h, h[:6]))
 }
 
 // FormatGraffitiAsLink will return the graffiti formated as html-link


### PR DESCRIPTION
Shortens graffiti to avoid horizontal scroll on block table, the full graffiti is visible as a tool tip. Add tool tips to other abbreviations.    