### PR TITLE
Better short form of "Ethereum 2.0"

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -222,7 +222,7 @@
 							<span class="nav-icon">	
 								<img src="/img/gitcoin_logo.svg" style="width: auto; height: 1rem;" class="mb-2"> 	
 							</span>	
-							<span class="nav-text">Support ETH 2.0</span>	
+							<span class="nav-text">Support Eth2</span>	
 						</a>	
 					</li>
 					<li class="nav-item {{ if eq .Active "epochs"}}active{{end}}">


### PR DESCRIPTION
"ETH 2.0" is suboptimal as a short form of "Ethereum 2.0". Better alternatives include "Eth 2.0" and "Eth2". Here is some of the thinking:

 * All-caps is relevant for asset ticker symbols. However Ethereum 2.0 is not an asset: it is a protocol, a network.
 * Natively there is only one asset for both Ethereum 1.0 and Ethereum 2.0, namely ETH.
 * Exchanges such as Coinbase are introducing an "ETH2" token which is a derivative staking asset with a centralised custodian. We don't want confusion there :)
 * In the same way that one would not write "ETHEREUM 2.0", one should not write "ETH 2.0". More correct forms IMO include Eth2, eth2, Eth 2.0, eth 2.0.