### PR TITLE
stakingServices: add bloxstaking fee

### DIFF
--- a/templates/stakingServices.html
+++ b/templates/stakingServices.html
@@ -329,7 +329,7 @@
                                     <td data-column="Pool token">No</td>
                                     <td data-column="3rd Party Software">Yes</td>
                                     <td data-column="Min. Stake">32 ETH</td>
-                                    <td data-column="Fee">?</td>
+                                    <td data-column="Fee">US$180/validator/one-time</td>
                                     <td data-column="Open Source">Yes</td>
                                     <td data-column="Social"><a href="https://twitter.com/Blox_Staking" target="_blank"><i
                                                     class="fab fa-twitter ml-1 mr-1"></i></a><a


### PR DESCRIPTION
From https://www.bloxstaking.com/pricing/:

> Flat fee per validator until transfers are available (phase 1.5) OR up to 2 years after activation (whichever happens first).
> $180