### PR TITLE
stakingServices: update staked.us key owner & 3rd party sw

### DIFF
--- a/templates/stakingServices.html
+++ b/templates/stakingServices.html
@@ -416,10 +416,10 @@
                                 </tr>
                                 <tr>
                                     <td data-column="Service"><a href="https://staked.us/">StakedUs</a></td>
-                                    <td data-column="Validator key owner">?</td>
-                                    <td data-column="Withdrawal key owner"> ?</td>
-                                    <td data-column="Pool token"> ?</td>
-                                    <td data-column="3rd Party Software"> ?</td>
+                                    <td data-column="Validator key owner">Service</td>
+                                    <td data-column="Withdrawal key owner">User</td>
+                                    <td data-column="Pool token">No</td>
+                                    <td data-column="3rd Party Software">No</td>
                                     <td data-column="Min. Stake">32 ETH</td>
                                     <td data-column="Fee">US$5/validator/month</td>
                                     <td data-column="Open Source">No</td>


### PR DESCRIPTION
From the staking flow, https://staked.us/v/eth2/stake, a withdrawal key is generated by the user and the address is provided to the service. Validator key not handled by user. Interaction with service uses the web interface, no extra 3rd party software. There isn't any token issued.