### PR TITLE
Clarify "Deposits Distribution" chart

### DIFF
--- a/services/charts_updater.go
+++ b/services/charts_updater.go
@@ -1484,8 +1484,8 @@ func depositsDistributionChartData() (*types.GenericChartData, error) {
 	chartData := &types.GenericChartData{
 		IsNormalChart:    true,
 		Type:             "pie",
-		Title:            "Deposits Distribution",
-		Subtitle:         "Deposits Distribution by ETH1-Addresses.",
+		Title:            "Eth1 Deposit Addresses",
+		Subtitle:         "Validator distribution by Eth1 deposit address.",
 		TooltipFormatter: `function(){ return '<b>'+this.point.name+'</b><br\>Percentage: '+this.point.percentage.toFixed(2)+'%<br\>Validators: '+this.point.y }`,
 		PlotOptionsPie: `{
 			borderWidth: 1,


### PR DESCRIPTION
The chart shows the distribution of validators by Eth1 deposit address, not the distribution of deposits by Eth1 deposit address.

(Also ETH1 => Eth1.)