### PR TITLE
fix calculation of income history

### DIFF
--- a/types/templates.go
+++ b/types/templates.go
@@ -302,7 +302,7 @@ type ValidatorStatsTablePageData struct {
 
 type ValidatorStatsTableRow struct {
 	ValidatorIndex         uint64
-	Day                    uint64
+	Day                    int64
 	StartBalance           sql.NullInt64 `db:"start_balance"`
 	EndBalance             sql.NullInt64 `db:"end_balance"`
 	Income                 int64         `db:"-"`
@@ -354,7 +354,7 @@ type ValidatorBalanceHistory struct {
 
 // ValidatorBalanceHistory is a struct for the validator income history data
 type ValidatorIncomeHistory struct {
-	Day          uint64 `db:"day"`
+	Day          int64 `db:"day"` // day can be -1 which is pre-genesis
 	Income       int64
 	StartBalance int64 `db:"start_balance" json:"-"`
 	EndBalance   int64 `db:"end_balance" json:"-"`

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -172,7 +172,7 @@ func EpochToTime(epoch uint64) time.Time {
 }
 
 // EpochToTime will return a time.Time for an epoch
-func DayToTime(day uint64) time.Time {
+func DayToTime(day int64) time.Time {
 	return time.Unix(int64(Config.Chain.GenesisTimestamp), 0).Add(time.Hour * time.Duration(24*int(day)))
 }
 


### PR DESCRIPTION
with this PR we will export pre-genesis-deposits with day=-1 into the validator_stats table to ease calculation of income-history

delete statistics-entries
```sql
delete from validator_stats where day = 0 or day = -1
```

re-export statistics
```bash
./statistics -statistics.day=0
```