### PR TITLE
charts: use 'average' instead of 'sum' for column.dataGrouping.approximation

### DIFF
--- a/static/js/highcharts/highcharts-global-options.js
+++ b/static/js/highcharts/highcharts-global-options.js
@@ -156,6 +156,11 @@ Highcharts.setOptions({
       line: {
         animation: false,
         lineWidth: 2.5
+      },
+      column: {
+        dataGrouping: {
+          approximation: 'sum'
+        }
       }
     }
   })

--- a/templates/genericchart.html
+++ b/templates/genericchart.html
@@ -70,9 +70,7 @@
             plotOptions: {
                 column: {
                     stacking: {{.StackingMode}},
-                    dataGrouping: {
-                        {{ if .ColumnDataGroupingApproximation }}approximation: {{.ColumnDataGroupingApproximation}},{{end}}
-                    },
+                    {{ if .ColumnDataGroupingApproximation }}dataGrouping: {approximation: {{.ColumnDataGroupingApproximation}}},{{end}}
                     dataLabels: {
                         enabled: {{ .DataLabelsEnabled }},
                         {{ if .DataLabelsFormatter }} formatter: {{ .DataLabelsFormatter }}, {{end}}


### PR DESCRIPTION
discussion: https://discord.com/channels/595666850260713488/746343380900118528/844197765990580335