### PR TITLE
Fix GitHub spelling

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -779,15 +779,15 @@
                             <a class="my-1" href="/premium"><i class="fas fa-user-astronaut mr-2"></i></i>Beaconcha.in Premium</a>
                             <a class="my-1" href="https://shop.beaconcha.in"><i class="fas fa-shopping-cart mr-2"></i>Swag Shop</a>
                             <a class="my-1" href="/pricing"><i class="fas fa-laptop-code mr-2"></i></i>API Pricing</a>
-                            <!-- <a class="my-1" href="https://github.com/gobitfly/eth2-beaconchain-explorer"><i class="fab fa-github mr-2"></i>Github</a> -->
+                            <!-- <a class="my-1" href="https://github.com/gobitfly/eth2-beaconchain-explorer"><i class="fab fa-github mr-2"></i>GitHub</a> -->
                         </div>
                     </div>
                     <div class="col-md-4 mb-2">
                         <h5>Links</h5>
                         <div class="d-flex flex-column">
                             <a class="my-1" href="https://twitter.com/beaconcha_in"><i class="fab fa-twitter mr-2"></i>Beaconcha.in</a>
-                            <a class="my-1" href="https://github.com/gobitfly/eth2-beaconchain-explorer"><i class="fab fa-github mr-2"></i>Github</a>
-                            <a class="my-1" href="https://github.com/gobitfly/eth2-beaconchain-explorer-app"><i class="fab fa-github mr-2"></i>Github Mobile App</a>
+                            <a class="my-1" href="https://github.com/gobitfly/eth2-beaconchain-explorer"><i class="fab fa-github mr-2"></i>GitHub</a>
+                            <a class="my-1" href="https://github.com/gobitfly/eth2-beaconchain-explorer-app"><i class="fab fa-github mr-2"></i>GitHub Mobile App</a>
                             <!-- <a class="my-1" href="https://www.reddit.com/u/etherchain/"><i class="fab fa-reddit mr-2"></i>Reddit</a> -->
                             <!-- <a class="my-1" href="https://gitter.im/gobitfly/beaconchain-explorer"><i class="fab fa-gitter"></i> Gitter Channel</a> -->
                         </div>


### PR DESCRIPTION
Just a couple of minor capitalization fixes: `Github` -> `GitHub`.