### PR TITLE
Update educationServices.html - Adding beacon digest

### DIFF
--- a/templates/educationServices.html
+++ b/templates/educationServices.html
@@ -676,7 +676,16 @@
                               </td>
                               <td data-column="Support">N/A</td>
                           </tr>
-                            
+                          <tr>
+                              <td data-column="Name"><a
+                                          href="https://shsr2001.github.io/beacondigest/">Beacon Digest Data Reports</a></td>
+                              <td data-column="Author"><a
+                                    href="https://github.com/ethereum/rig">Robust Incentives Group - Ethereum Foundation</a></td>
+                              <td data-column="Type">Data Reports</td>
+                              <td data-column="Association"><a href="https://twitter.com/ethereum">Ethereum Foundation</a>
+                              </td>
+                              <td data-column="Support">N/A</td>
+                          </tr>
                             
 
                             </tbody>


### PR DESCRIPTION
Requesting the addition of Beacon Digest - A publication of biweekly data reports as a part of the efforts of the Robust Incentives Groups (RIG) at the Ethereum Foundations 