### PR TITLE
exporter: mark all epochs before the last finalized epoch as finalized

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -1452,6 +1452,12 @@ func UpdateEpochStatus(stats *types.ValidatorParticipation) error {
 	return err
 }
 
+// UpdateEpochFinalization will update finalized-flag of all epochs before the last finalized epoch
+func UpdateEpochFinalization() error {
+	_, err := DB.Exec(`UPDATE epochs SET finalized = true WHERE epoch < (SELECT MAX(epoch) FROM epochs WHERE finalized = true)`)
+	return err
+}
+
 // GetTotalValidatorsCount will return the total-validator-count
 func GetTotalValidatorsCount() (uint64, error) {
 	var totalCount uint64

--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -503,7 +503,7 @@ func updateEpochStatus(client rpc.Client, startEpoch, endEpoch uint64) error {
 			}
 		}
 	}
-	return nil
+	return db.UpdateEpochFinalization()
 }
 
 func performanceDataUpdater() {

--- a/rpc/prysm.go
+++ b/rpc/prysm.go
@@ -211,7 +211,7 @@ func (pc *PrysmClient) GetEpochAssignments(epoch uint64) (*types.EpochAssignment
 		return cachedValue.(*types.EpochAssignments), nil
 	}
 
-	logger.Infof("caching assignements for epoch %v", epoch)
+	logger.Infof("caching assignments for epoch %v", epoch)
 	start := time.Now()
 	assignments := &types.EpochAssignments{
 		ProposerAssignments: make(map[uint64]uint64),
@@ -257,7 +257,7 @@ func (pc *PrysmClient) GetEpochAssignments(epoch uint64) (*types.EpochAssignment
 		pc.assignmentsCache.Add(epoch, assignments)
 	}
 
-	logger.Infof("cached assignements for epoch %v took %v", epoch, time.Since(start))
+	logger.Infof("cached assignments for epoch %v took %v", epoch, time.Since(start))
 	return assignments, nil
 }
 


### PR DESCRIPTION
fix #980 