### PR TITLE
Fix bitlist format

### DIFF
--- a/utils/format.go
+++ b/utils/format.go
@@ -406,7 +406,7 @@ func FormatBitlist(bits []byte) template.HTML {
 	var buf strings.Builder
 	buf.WriteString("<div class=\"text-bitlist\">")
 	perLine := 8
-	for y := 0; y < len(bits)/perLine; y++ {
+	for y := 0; y < len(bits); y += perLine {
 		start, end := y, y+perLine
 		if end > len(bits) {
 			end = len(bits)


### PR DESCRIPTION
In the fixed line, `y` should be a start byte index, not a line number. Otherwise, the same bits are displayed again and again, for example:

<img width="702" alt="Screenshot 2021-09-11 at 16 49 22" src="https://user-images.githubusercontent.com/29590423/132950146-ef78b19b-66f9-4ae6-b62c-4fcabc7d802d.png">
