### PR TITLE
add rocketpool to staking pool distribution page

### DIFF
--- a/exporter/rocketpool.go
+++ b/exporter/rocketpool.go
@@ -546,7 +546,6 @@ func (rp *RocketpoolExporter) SaveNodes() error {
 }
 
 func (rp *RocketpoolExporter) SyncNodesToSPS() error {
-	logger.Infof("%d", len(rp.NodesByAddress))
 	if len(rp.NodesByAddress) == 0 {
 		return nil
 	}

--- a/exporter/rocketpool.go
+++ b/exporter/rocketpool.go
@@ -594,7 +594,7 @@ func (rp *RocketpoolExporter) SyncNodesToSPS() error {
 			valueStrings = append(valueStrings, fmt.Sprintf(valueStringsTpl, valueStringsArgs...))
 			addressString := fmt.Sprintf("%x", d.Address)
 			valueArgs = append(valueArgs, addressString)
-			valueArgs = append(valueArgs, "Rocketpool 0x" + addressString[:8])
+			valueArgs = append(valueArgs, "Rocketpool 0x"+addressString[:8])
 			valueArgs = append(valueArgs, "Staking Pool")
 			valueArgs = append(valueArgs, 32)
 		}

--- a/exporter/rocketpool.go
+++ b/exporter/rocketpool.go
@@ -204,6 +204,10 @@ func (rp *RocketpoolExporter) Save(count int64) error {
 	if err != nil {
 		return err
 	}
+	err = rp.SyncNodesToSPS()
+	if err != nil {
+		return err
+	}
 	err = rp.SaveDAOProposals()
 	if err != nil {
 		return err
@@ -535,6 +539,69 @@ func (rp *RocketpoolExporter) SaveNodes() error {
 		_, err := tx.Exec(stmt, valueArgs...)
 		if err != nil {
 			return fmt.Errorf("error inserting into rocketpool_nodes: %w", err)
+		}
+	}
+
+	return tx.Commit()
+}
+
+func (rp *RocketpoolExporter) SyncNodesToSPS() error {
+	logger.Infof("%d", len(rp.NodesByAddress))
+	if len(rp.NodesByAddress) == 0 {
+		return nil
+	}
+
+	t0 := time.Now()
+	defer func(t0 time.Time) {
+		logger.WithFields(logrus.Fields{"duration": time.Since(t0)}).Debugf("synced rocketpool-nodes to sps")
+	}(t0)
+
+	data := make([]*RocketpoolNode, len(rp.NodesByAddress))
+	i := 0
+	for _, node := range rp.NodesByAddress {
+		data[i] = node
+		i++
+	}
+
+	tx, err := db.DB.Beginx()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	nArgs := 4
+	valueStringsArr := make([]string, nArgs)
+	for i := range valueStringsArr {
+		valueStringsArr[i] = "$%d"
+	}
+	valueStringsTpl := "(" + strings.Join(valueStringsArr, ",") + ")"
+	valueStringsArgs := make([]interface{}, nArgs)
+
+	batchSize := 1000
+	for b := 0; b < len(data); b += batchSize {
+		start := b
+		end := b + batchSize
+		if len(data) < end {
+			end = len(data)
+		}
+
+		valueStrings := make([]string, 0, batchSize)
+		valueArgs := make([]interface{}, 0, batchSize*nArgs)
+		for i, d := range data[start:end] {
+			for j := 0; j < nArgs; j++ {
+				valueStringsArgs[j] = i*nArgs + j + 1
+			}
+			valueStrings = append(valueStrings, fmt.Sprintf(valueStringsTpl, valueStringsArgs...))
+			addressString := fmt.Sprintf("%x", d.Address)
+			valueArgs = append(valueArgs, addressString)
+			valueArgs = append(valueArgs, "Rocketpool 0x" + addressString[:8])
+			valueArgs = append(valueArgs, "Staking Pool")
+			valueArgs = append(valueArgs, 32)
+		}
+		stmt := fmt.Sprintf(`insert into stake_pools_stats (address, name, category, deposit) values %s on conflict (address) do nothing`, strings.Join(valueStrings, ","))
+		_, err := tx.Exec(stmt, valueArgs...)
+		if err != nil {
+			return fmt.Errorf("error inserting into stake_pools_stats: %w", err)
 		}
 	}
 

--- a/services/charts_updater.go
+++ b/services/charts_updater.go
@@ -1642,7 +1642,7 @@ func depositsDistributionChartData() (*types.GenericChartData, error) {
 				if strings.Contains(name, drillSeries[j].ID) {
 					if len(drillSeries[j].Data) < 30 {
 						drillSeries[j].Data = append(drillSeries[j].Data,
-						[2]string{name, fmt.Sprintf("%d", count)})
+							[2]string{name, fmt.Sprintf("%d", count)})
 					} else {
 						lastIndex := len(drillSeries[j].Data) - 1
 						// check if the last index is called "Others"
@@ -1739,7 +1739,7 @@ func depositsDistributionChartData() (*types.GenericChartData, error) {
 				if strings.Contains(name, drillSeries[j].ID) {
 					if len(drillSeries[j].Data) < 30 {
 						drillSeries[j].Data = append(drillSeries[j].Data,
-						[2]string{name, fmt.Sprintf("%d", count)})
+							[2]string{name, fmt.Sprintf("%d", count)})
 					} else {
 						lastIndex := len(drillSeries[j].Data) - 1
 						// check if the last index is called "Others"

--- a/services/charts_updater.go
+++ b/services/charts_updater.go
@@ -7,6 +7,7 @@ import (
 	"eth2-exporter/utils"
 	"fmt"
 	"sort"
+	"strconv"
 	"sync"
 	"time"
 
@@ -1494,7 +1495,7 @@ func depositsDistributionChartData() (*types.GenericChartData, error) {
 				having sum(amount) >= 32e9
 			) a 
 			group by from_address) b
-		full outer join stake_pools_stats as sps on b.address=sps.address
+		full outer join stake_pools_stats as sps on b.address=sps.address where b.count is not null
 		order by count desc`)
 		if err != nil {
 			return nil, fmt.Errorf("error getting eth1-deposits-distribution: %w", err)
@@ -1544,6 +1545,11 @@ func depositsDistributionChartData() (*types.GenericChartData, error) {
 				Name:      "Defi",
 				Y:         0,
 				Drilldown: "Defi",
+			},
+			{
+				Name:      "Rocketpool",
+				Y:         0,
+				Drilldown: "Rocketpool",
 			},
 			{
 				Name:      "Guarda",
@@ -1598,6 +1604,11 @@ func depositsDistributionChartData() (*types.GenericChartData, error) {
 				Data: [][2]string{},
 			},
 			{
+				Name: "Rocketpool",
+				ID:   "Rocketpool",
+				Data: [][2]string{},
+			},
+			{
 				Name: "Guarda",
 				ID:   "Guarda",
 				Data: [][2]string{},
@@ -1629,8 +1640,25 @@ func depositsDistributionChartData() (*types.GenericChartData, error) {
 				}
 
 				if strings.Contains(name, drillSeries[j].ID) {
-					drillSeries[j].Data = append(drillSeries[j].Data,
+					if len(drillSeries[j].Data) < 30 {
+						drillSeries[j].Data = append(drillSeries[j].Data,
 						[2]string{name, fmt.Sprintf("%d", count)})
+					} else {
+						lastIndex := len(drillSeries[j].Data) - 1
+						// check if the last index is called "Others"
+						if drillSeries[j].Data[lastIndex][0] != "Others" {
+							// if its not, create it
+							drillSeries[j].Data = append(drillSeries[j].Data,
+								[2]string{"Others", "0"})
+							lastIndex++
+						}
+						oldCount := drillSeries[j].Data[lastIndex][1]
+						currentCount, err := strconv.ParseUint(oldCount, 10, 64)
+						if err != nil {
+							currentCount = 0
+						}
+						drillSeries[j].Data[lastIndex][1] = fmt.Sprintf("%d", currentCount+count)
+					}
 					foundMatch = true
 					break
 				}
@@ -1664,7 +1692,7 @@ func depositsDistributionChartData() (*types.GenericChartData, error) {
 				having sum(amount) >= 32e9
 			) a 
 			group by from_address) b
-		full outer join stake_pools_stats as sps on b.address=sps.address
+		full outer join stake_pools_stats as sps on b.address=sps.address where b.count is not null
 		order by count desc`)
 		if err != nil {
 			return nil, fmt.Errorf("error getting eth1-deposits-distribution: %w", err)
@@ -1709,8 +1737,25 @@ func depositsDistributionChartData() (*types.GenericChartData, error) {
 				}
 
 				if strings.Contains(name, drillSeries[j].ID) {
-					drillSeries[j].Data = append(drillSeries[j].Data,
+					if len(drillSeries[j].Data) < 30 {
+						drillSeries[j].Data = append(drillSeries[j].Data,
 						[2]string{name, fmt.Sprintf("%d", count)})
+					} else {
+						lastIndex := len(drillSeries[j].Data) - 1
+						// check if the last index is called "Others"
+						if drillSeries[j].Data[lastIndex][0] != "Others" {
+							// if its not, create it
+							drillSeries[j].Data = append(drillSeries[j].Data,
+								[2]string{"Others", "0"})
+							lastIndex++
+						}
+						oldCount := drillSeries[j].Data[lastIndex][1]
+						currentCount, err := strconv.ParseUint(oldCount, 10, 64)
+						if err != nil {
+							currentCount = 0
+						}
+						drillSeries[j].Data[lastIndex][1] = fmt.Sprintf("%d", currentCount+count)
+					}
 					foundMatch = true
 					break
 				}

--- a/tables.sql
+++ b/tables.sql
@@ -720,7 +720,8 @@ create table stake_pools_stats
     deposit int, 
     name text not null, 
     category text, 
-    PRIMARY KEY(id, address, deposit, name)
+    PRIMARY KEY(id, address, deposit, name),
+    UNIQUE (address)
 );
 
 drop table if exists price;


### PR DESCRIPTION
## Additions:
- Adds Rocketpool to both the prater and mainnet version of the `/pools` page
- Automatically syncs Rocket Pool Node Operators to the `stake_pools_stats` table
- Fixed a small bug that made entries with no validators show up
- Also Caps drilldown slices at 30 to prevent browser lag issues
### Important notes:
**The following applies to the official mainnet instance ([beaconcha.in](https://beaconcha.in))**
_Before upgrading_, a query has to be run against existing instances that have the `rocketpool` service enabled in the config.
```sql
-- add unique constrain on address
alter table stake_pools_stats add constraint unique_address unique (address);
```
For the [prater.beaconcha.in](https://prater.beaconcha.in) instance, another query has to be executed to remove outdated Rocket Pool entries:
```sql
-- drop outdated rocketpool entries (as is the case on the prater instance)
delete from stake_pools_stats where name like 'Rocketpool%';
```
> These changes were **not** tested against a mainnet instance. I am pretty confident that no noticeable load increase should occur, but I can not be 100% confident without actually running against mainnet.
### Jpegs
<img src="https://user-images.githubusercontent.com/34715248/154587075-f74f2593-4cf6-4dc7-adbb-92384d9ebd9f.png" width=50%><img src="https://user-images.githubusercontent.com/34715248/154587077-058c50ba-63f8-4cac-8109-332312ff82cb.png" width=50%>
