### PR TITLE
adds global notification toggle

### DIFF
--- a/cmd/explorer/main.go
+++ b/cmd/explorer/main.go
@@ -370,6 +370,7 @@ func main() {
 			authRouter.HandleFunc("/settings/delete", handlers.UserDeletePost).Methods("POST")
 			authRouter.HandleFunc("/settings/email", handlers.UserUpdateEmailPost).Methods("POST")
 			authRouter.HandleFunc("/notifications", handlers.UserNotificationsCenter).Methods("GET")
+			authRouter.HandleFunc("/notifications/channels", handlers.UsersNotificationChannels).Methods("POST")
 			authRouter.HandleFunc("/notifications/data", handlers.UserNotificationsData).Methods("GET")
 			authRouter.HandleFunc("/notifications/subscribe", handlers.UserNotificationsSubscribe).Methods("POST")
 			authRouter.HandleFunc("/notifications/unsubscribe", handlers.UserNotificationsUnsubscribe).Methods("POST")

--- a/static/css/notificationsCenter.css
+++ b/static/css/notificationsCenter.css
@@ -82,9 +82,9 @@ kbd {
   font-weight: 400;
   line-height: 1.45rem !important;
 }
-.heading-section { 
+/* .heading-section { 
   height: 60px; 
-}
+} */
 .i-custom:hover {
   display: inline-block;
   border-radius: 50%;

--- a/tables.sql
+++ b/tables.sql
@@ -551,11 +551,19 @@ create table users_subscriptions
     unsubscribe_hash  bytea                        ,
     primary key (user_id, event_name, event_filter)
 );
-
 create index idx_users_subscriptions_unsubscribe_hash on users_subscriptions (unsubscribe_hash);
 
-
 CREATE TYPE notification_channels as ENUM ('webhook_discord', 'webhook', 'email', 'push');
+
+drop table if exists users_notification_channels;
+create table users_notification_channels
+(
+    user_id int                   not null,
+    channel notification_channels not null,
+    active  boolean default 't'   not null,
+    primary key (user_id, channel)
+);
+
 drop table if exists notification_queue;
 create table notification_queue(
     id                  serial not null,
@@ -565,6 +573,8 @@ create table notification_queue(
     channel             notification_channels not null,
     content             jsonb not null
 );
+
+drop table if exists notification_
 
 -- deprecated
 -- drop table if exists users_notifications;

--- a/templates/mail/layout.html
+++ b/templates/mail/layout.html
@@ -39,7 +39,7 @@
   </head>
 
   <body style="font-family: 'Roboto', sans-serif; margin: 0; font-size: 1rem; font-weight: 400; line-height: 1.5; color: #343a40; text-align: left" ontouchstart="">
-    <table width="800" border="0" cellpadding="0" cellspacing="0">
+    <table style="max-width: 800px" width="100%" border="0" cellpadding="0" cellspacing="0">
       <thead style="height: 35px; width: inherit; background-color: #2f2e42; position: relative; color: #413938;">
         <tr style="height: inherit;">
           <th style="padding-left: 10px; padding-right: 10px; padding-top: 6px; height: inherit; width: 100%; background-color: #2f2e42">

--- a/templates/user/notificationsCenter.html
+++ b/templates/user/notificationsCenter.html
@@ -28,11 +28,14 @@
 			</nav>
 			<!-- <a href="/user/notifications">Old version</a> -->
 		</div>
-		<div class="row d-flex align-items-center justify-content-between mx-0 my-5 container-min-width heading-section">
-			<div class="col-12 col-md pl-0">
+		<div class="row d-flex align-items-center justify-content-between mx-0 my-5 container-min-width heading-section flex-wrap">
+			<div class="pl-0">
 				<h1 class="heading text-nowrap">Notifications Center</h1>
-        <h2 class="heading-l3 text-muted font-weight-light">Manage the notifications you want to receive</h2>
+        		<h2 class="heading-l3 text-muted font-weight-light">Manage the notifications you want to receive</h2>
 			</div>
+			<button class="btn btn-dark text-white mx-0 my-2 mr-md-3" data-toggle="modal" data-target="#manage-notification-channels">
+				<span class="text-nowrap">Notification Channels</span>
+			</button>
 		</div>
 		<div class="row flex-column flex-sm-row justify-content-center align-content-center mx-0 my-2 metrics-section mx-auto">
 		  <div class="col-12 col-sm col-xl mr-sm-3 mt-1 mb-2 p-2 shadow-sm border custom-border-radius custom-background-color">
@@ -348,7 +351,7 @@
 							<div class="mr-2">Web</div> -->
 						</div>
 						<div class="form-check form-check-inline w-100 my-2" id="manage_validator_attestation_missed">
-							<label class="form-check-label mr-auto font-weight-normal">Attestations missed</label>
+							<label class="form-check-label mr-auto font-weight-normal" for="manage-attestation-missed">Attestations missed</label>
 							<!--<input class="form-check-input checkbox-custom-size mr-4" type="checkbox" id="push" value="">-->
 							<input class="form-check-input checkbox-custom-size ml-2 mr-0" type="checkbox" id="email" value="">
 							<!--<input class="form-check-input checkbox-custom-size mr-2" type="checkbox" id="web" value="">-->
@@ -460,5 +463,39 @@
 			</div>
 		</div>
 	</div>
+
+		<!-- Notification Channel Modal -->
+		<div class="modal fade custom-modal" id="manage-notification-channels" data-backdrop="static" data-keyboard="false" tabindex="-1" role="dialog" aria-labelledby="addValidatorLabel" aria-hidden="true">
+			<div class="modal-dialog modal-dialog-centered custom-modal-dialog" role="document">
+				<div class="modal-content mx-0 custom-background-color custom-modal-content custom-remove-modal">
+					<form method="post" action="/user/notifications/channels">
+						{{ .CsrfField }}
+						<div class="mb-1 mb-sm-4 custom-remove-modal-close">
+							<button class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+						</div>
+						<div class="col-sm-12 d-flex flex-column align-items-center justify-content-center mb-3 mb-sm-5 px-0 h6">
+							<div class="w-100 heading-l2 text-center">
+								Notification Channels
+								<span class="d-block mt-3 heading-l4 text-left">Global setting to toggle the channels over which you would like to receive notifications. By default all channels are active.</span>
+							</div>
+							<div class="w-100 my-3">
+								{{ range $i, $ch := .NotificationChannels }}
+									<div class="form-check form-check-inline w-100 my-2 py-1">
+										<label class="form-check-label w-100 font-weight-normal" for="channel-{{$ch.Channel}}">{{$ch.Channel | formatNotificationChannel}}</label>
+										<input class="form-check-input checkbox-custom-size ml-2 mr-0" type="checkbox" id="channel-{{$ch.Channel}}" name="{{$ch.Channel}}" {{if $ch.Active}}checked{{end}}>
+									</div>
+								{{ end }}
+							</div>
+						</div>
+						<div class="col-sm-12 d-flex align-items-center justify-content-between mt-auto mt-sm-1 px-0">
+							<button class="btn btn-dark btn-sm w-50 mr-2 mr-sm-3 text-white" data-dismiss="modal">Cancel</button>
+							<button id="update-notification-channels" class="btn btn-primary btn-primary btn-sm w-50 ml-sm-3 text-white">Update</button>
+						</div>
+				    </form>
+				</div>
+			</div>
+		</div>
+
+	
 	{{end}}
 {{end}}

--- a/templates/user/webhooks.html
+++ b/templates/user/webhooks.html
@@ -49,18 +49,18 @@
                         <rect class="cls-1" data-name="&lt;Transparent Rectangle&gt;" id="_Transparent_Rectangle_"/>
                     </svg>
                     Webhooks 
-                    <button type="button" class="btn btn-outline-primary ml-2" data-toggle="modal" data-target="#add-webhook-modal">
-                        Add Webhook
-                    </button>
                 </h1>
-                <nav aria-label="breadcrumb">
+                <!-- <nav aria-label="breadcrumb">
                     <ol class="breadcrumb font-size-1 mb-0" style="padding:0; background-color:transparent;">
                         <li class="breadcrumb-item"><a href="/" title="Home">Home</a></li>
                         <li class="breadcrumb-item active" aria-current="page">
                             Webhooks 
                         </li>
                     </ol>
-                </nav>
+                </nav> -->
+                <button type="button" class="btn btn-outline-primary ml-2" data-toggle="modal" data-target="#add-webhook-modal">
+                    Add Webhook
+                </button>
             </div>
             <div class="mb-4">
                 <span>Webhooks allow external services to be notified when certain events happen. When the specified events happen, we’ll send a POST request to each of the URLs you provide. Optionally, you can configure the webhook to support discord embeds. Free tier users can add one webhook, with a mobile subscriptions up to two webhooks can be added and with an API subscription a total of five webhooks are supported.</span>

--- a/types/frontend.go
+++ b/types/frontend.go
@@ -377,3 +377,35 @@ type UserWebhookSubscriptions struct {
 	WebhookID      uint64 `db:"webhook_id"`
 	SubscriptionID uint64 `db:"subscription_id"`
 }
+
+type NotificationChannel string
+
+var NotificationChannelLabels map[NotificationChannel]string = map[NotificationChannel]string{
+	EmailNotificationChannel:          "Email Notification",
+	PushNotificationChannel:           "Push Notification",
+	WebhookNotificationChannel:        "Webhook Notification",
+	WebhookDiscordNotificationChannel: "Discord Notification",
+}
+
+const (
+	EmailNotificationChannel          NotificationChannel = "email"
+	PushNotificationChannel           NotificationChannel = "push"
+	WebhookNotificationChannel        NotificationChannel = "webhook"
+	WebhookDiscordNotificationChannel NotificationChannel = "webhook_discord"
+)
+
+var NotificationChannels = []NotificationChannel{
+	EmailNotificationChannel,
+	PushNotificationChannel,
+	WebhookNotificationChannel,
+	WebhookDiscordNotificationChannel,
+}
+
+func GetNotificationChannel(channel string) (NotificationChannel, error) {
+	for _, ch := range NotificationChannels {
+		if string(ch) == channel {
+			return ch, nil
+		}
+	}
+	return "", errors.Errorf("Could not convert channel from string to NotificationChannel type. %v is not a known channel type", channel)
+}

--- a/types/templates.go
+++ b/types/templates.go
@@ -1026,7 +1026,13 @@ type UserNotificationsCenterPageData struct {
 	MonitoringSubscriptions []Subscription                       `json:"monitoring_subscriptions"`
 	Machines                []string
 	DashboardLink           string `json:"dashboardLink"`
+	NotificationChannels    []UserNotificationChannels
 	// Subscriptions []*Subscription
+}
+
+type UserNotificationChannels struct {
+	Channel NotificationChannel `db:"channel"`
+	Active  bool                `db:"active"`
 }
 
 type UserValidatorNotificationTableData struct {

--- a/utils/format.go
+++ b/utils/format.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/hex"
 	"eth2-exporter/price"
+	"eth2-exporter/types"
 	"fmt"
 	"html"
 	"html/template"
@@ -835,4 +836,12 @@ func FormatFloat(num float64, precision int) string {
 	s := strings.TrimRight(strings.TrimRight(p.Sprintf(f, num), "0"), ".")
 	r := []rune(p.Sprintf(s, num))
 	return string(r)
+}
+
+func FormatNotificationChannel(ch types.NotificationChannel) string {
+	label, ok := types.NotificationChannelLabels[ch]
+	if !ok {
+		return ""
+	}
+	return label
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -62,6 +62,7 @@ func GetTemplateFuncs() template.FuncMap {
 		"includeHTML":                             IncludeHTML,
 		"formatHTML":                              FormatMessageToHtml,
 		"formatBalance":                           FormatBalance,
+		"formatNotificationChannel":               FormatNotificationChannel,
 		"formatBalanceSql":                        FormatBalanceSql,
 		"formatCurrentBalance":                    FormatCurrentBalance,
 		"formatEffectiveBalance":                  FormatEffectiveBalance,


### PR DESCRIPTION
Adds the possibility to toggle different notification channels. This PR will add support for email, push and webhook notification channels. All channels are activated by default and can be deactivated by the user on demand.

Migrations necessary before the pull request is merged.
```sql
create table users_notification_channels
(
    user_id int                   not null,
    channel notification_channels not null,
    active  boolean default 't'   not null,
    primary key (user_id, channel)
);
```