### PR TITLE
Add page load and state management capabilities to datatables

### DIFF
--- a/cmd/explorer/main.go
+++ b/cmd/explorer/main.go
@@ -309,6 +309,8 @@ func main() {
 			router.HandleFunc("/mobile", handlers.MobilePage).Methods("GET")
 			router.HandleFunc("/mobile", handlers.MobilePagePost).Methods("POST")
 
+			router.HandleFunc("/tables/state", handlers.DataTableStateChanges).Methods("POST")
+
 			router.HandleFunc("/stakingServices", handlers.StakingServices).Methods("GET")
 			router.HandleFunc("/stakingServices", handlers.AddStakingServicePost).Methods("POST")
 

--- a/cmd/explorer/main.go
+++ b/cmd/explorer/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/gob"
 	"encoding/hex"
 	"eth2-exporter/db"
 	ethclients "eth2-exporter/ethClients"
@@ -42,6 +43,10 @@ func initStripe(http *mux.Router) error {
 	http.HandleFunc("/stripe/create-checkout-session", handlers.StripeCreateCheckoutSession).Methods("POST")
 	http.HandleFunc("/stripe/customer-portal", handlers.StripeCustomerPortal).Methods("POST")
 	return nil
+}
+
+func init() {
+	gob.Register(types.DataTableSaveState{})
 }
 
 func main() {

--- a/db/frontend.go
+++ b/db/frontend.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"context"
 	"database/sql"
 	"encoding/hex"
 	"errors"
@@ -826,4 +827,65 @@ func GetSubsForEventFilter(eventName types.EventName) ([][]byte, map[string][]ty
 		filtersEncode = append(filtersEncode, b)
 	}
 	return filtersEncode, subMap, nil
+}
+
+// SaveDataTableState saves the state of the current datatable state update
+func SaveDataTableState(user uint64, key string, state types.DataTableSaveState) error {
+	ctx, done := context.WithTimeout(context.Background(), time.Second*30)
+	defer done()
+
+	// check how many table states are stored
+	count := 0
+	err := FrontendReaderDB.SelectContext(ctx, &count, `
+		SELECT count(*)
+		FROM users_datatable
+		WHERE user_id = $1
+	`, user)
+	if err != nil {
+		return err
+	}
+
+	// only store the most recent 100 table states across all networks
+	if count > 100 {
+		_, err := FrontendWriterDB.ExecContext(ctx, `
+			DELETE FROM users_datatable 
+			WHERE user_id = $1 
+			ORDER by updated_at asc 
+			LIMIT 10
+		`)
+		if err != nil {
+			return err
+		}
+	}
+
+	// append network prefix
+	key = utils.GetNetwork() + ":" + key
+
+	_, err = FrontendWriterDB.ExecContext(ctx, `
+		INSERT INTO 
+			users_datatable (user_id, key, state) 
+		VALUES ($1, $2, $3) 
+		ON CONFLICT DO UPDATE SET state = $3, updated_at = now()
+	`, user, key, state)
+
+	return err
+}
+
+// GetDataTablesState retrieves the state for a given user and table
+func GetDataTablesState(user uint64, key string) (*types.DataTableSaveState, error) {
+	state := new(types.DataTableSaveState)
+
+	// append network prefix
+	key = utils.GetNetwork() + ":" + key
+
+	ctx, done := context.WithTimeout(context.Background(), time.Second*30)
+	defer done()
+
+	err := FrontendReaderDB.SelectContext(ctx, &state, `
+		SELECT state 
+		FROM users_datatable
+		WHERE user_id = $1 and key = $2
+	`, user, key)
+
+	return state, err
 }

--- a/handlers/auth.go
+++ b/handlers/auth.go
@@ -224,7 +224,7 @@ func LoginPost(w http.ResponseWriter, r *http.Request) {
 	session.Values["subscription"] = user.ProductID
 
 	// save datatable state settings from anon session
-	dataTableStatePrefix := "datatable:state:" + utils.GetNetwork() + ":"
+	dataTableStatePrefix := "table:state:" + utils.GetNetwork() + ":"
 
 	for k, state := range session.Values {
 		k, ok := k.(string)
@@ -233,7 +233,7 @@ func LoginPost(w http.ResponseWriter, r *http.Request) {
 			if ok {
 				err := db.SaveDataTableState(user.ID, strings.TrimPrefix(k, dataTableStatePrefix), state)
 				if err != nil {
-					logger.WithError(err).Error("error saving data table state from session")
+					logger.WithError(err).Error("error saving datatable state from session")
 				}
 			} else {
 				logger.Error("error could not parse datatable state from session, state: %+v", state)

--- a/handlers/auth.go
+++ b/handlers/auth.go
@@ -231,9 +231,12 @@ func LoginPost(w http.ResponseWriter, r *http.Request) {
 		if ok && strings.HasPrefix(k, dataTableStatePrefix) {
 			state, ok := state.(types.DataTableSaveState)
 			if ok {
-				err := db.SaveDataTableState(user.ID, strings.TrimPrefix(k, dataTableStatePrefix), state)
-				if err != nil {
-					logger.WithError(err).Error("error saving datatable state from session")
+				trimK := strings.TrimPrefix(k, dataTableStatePrefix)
+				if len(trimK) > 0 {
+					err := db.SaveDataTableState(user.ID, trimK, state)
+					if err != nil {
+						logger.WithError(err).Error("error saving datatable state from session")
+					}
 				}
 			} else {
 				logger.Error("error could not parse datatable state from session, state: %+v", state)

--- a/handlers/auth.go
+++ b/handlers/auth.go
@@ -222,6 +222,25 @@ func LoginPost(w http.ResponseWriter, r *http.Request) {
 	session.Values["authenticated"] = true
 	session.Values["user_id"] = user.ID
 	session.Values["subscription"] = user.ProductID
+
+	// save datatable state settings from anon session
+	dataTableStatePrefix := "datatable:state:" + utils.GetNetwork() + ":"
+
+	for k, state := range session.Values {
+		k, ok := k.(string)
+		if ok && strings.HasPrefix(k, dataTableStatePrefix) {
+			state, ok := state.(types.DataTableSaveState)
+			if ok {
+				err := db.SaveDataTableState(user.ID, strings.TrimPrefix(k, dataTableStatePrefix), state)
+				if err != nil {
+					logger.WithError(err).Error("error saving data table state from session")
+				}
+			} else {
+				logger.Error("error could not parse datatable state from session, state: %+v", state)
+			}
+			delete(session.Values, k)
+		}
+	}
 	// session.AddFlash("Successfully logged in")
 
 	session.Save(r, w)

--- a/handlers/common.go
+++ b/handlers/common.go
@@ -303,7 +303,7 @@ func DataTableStateChanges(w http.ResponseWriter, r *http.Request) {
 		}
 
 	} else {
-		err = db.SaveDataTableState(user.UserID, "", settings)
+		err = db.SaveDataTableState(user.UserID, settings.Key, settings)
 		if err != nil {
 			logger.Errorf("error saving data table state could save values to db: %v", err)
 			response.Status = "error saving table state"

--- a/handlers/common.go
+++ b/handlers/common.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/gorilla/sessions"
 	"github.com/lib/pq"
 )
 
@@ -313,4 +314,21 @@ func DataTableStateChanges(w http.ResponseWriter, r *http.Request) {
 
 	response.Status = "OK"
 	response.Data = ""
+}
+
+func GetDataTableState(user *types.User, session *sessions.Session, tableKey string) (*types.DataTableSaveState, error) {
+	if user.Authenticated {
+		state, err := db.GetDataTablesState(user.UserID, tableKey)
+		if err != nil {
+			return nil, err
+		}
+		return state, nil
+	}
+
+	stateRaw, ok := session.Values["table:state:"+utils.GetNetwork()+":"+tableKey].(types.DataTableSaveState)
+	if !ok {
+		return nil, fmt.Errorf("error parsing session value into type DataTableSaveState")
+	}
+	return &stateRaw, nil
+
 }

--- a/handlers/common.go
+++ b/handlers/common.go
@@ -279,7 +279,7 @@ func DataTableStateChanges(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if !user.Authenticated {
-		dataTableStatePrefix := "datatable:state:" + utils.GetNetwork() + ":"
+		dataTableStatePrefix := "table:state:" + utils.GetNetwork() + ":"
 		key = dataTableStatePrefix + key
 		count := 0
 		for k, _ := range session.Values {
@@ -296,7 +296,11 @@ func DataTableStateChanges(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 		session.Values[key] = settings
-		session.Save(r, w)
+
+		err := session.Save(r, w)
+		if err != nil {
+			logger.WithError(err).Errorf("error updating session with key: %v and value: %v", key, settings)
+		}
 
 	} else {
 		err = db.SaveDataTableState(user.UserID, "", settings)

--- a/handlers/epochs.go
+++ b/handlers/epochs.go
@@ -28,9 +28,6 @@ func Epochs(w http.ResponseWriter, r *http.Request) {
 
 	epochsCount := services.LatestEpoch()
 
-	startEpoch := epochsCount - 0
-	endEpoch := epochsCount - 0 - 50 + 1
-
 	user, session, err := getUserSession(r)
 	if err != nil {
 		logger.WithError(err).Error("error getting user session")
@@ -51,12 +48,18 @@ func Epochs(w http.ResponseWriter, r *http.Request) {
 	}
 	length := uint64(50)
 	start := uint64(0)
+	var startEpoch uint64
+	var endEpoch uint64
+
 	// set start and end epoch from saved state
-	if state != nil {
+	if state != nil && state.Length != 0 {
 		length = uint64(state.Length)
 		start = uint64(state.Start)
 		startEpoch = epochsCount - uint64(state.Start)
 		endEpoch = epochsCount - uint64(state.Start) - uint64(state.Length) + 1
+	} else {
+		startEpoch = epochsCount
+		endEpoch = epochsCount - 50 + 1
 	}
 
 	if length < 10 {

--- a/handlers/pageData.go
+++ b/handlers/pageData.go
@@ -80,12 +80,6 @@ func InitPageData(w http.ResponseWriter, r *http.Request, active, path, title st
 		for sessionKey, sessionValue := range session.Values {
 			jsn[fmt.Sprintf("%v", sessionKey)] = sessionValue
 		}
-
-		// jsn, err := json.Marshal(session.Values)
-		// if err != nil {
-		// 	logger.WithError(err).Error("session.values: %+v", session.Values)
-
-		// }
 		data.DebugSession = jsn
 	}
 	data.Rates.EthPrice = price.GetEthPrice(data.Rates.Currency)

--- a/handlers/pageData.go
+++ b/handlers/pageData.go
@@ -69,6 +69,25 @@ func InitPageData(w http.ResponseWriter, r *http.Request, active, path, title st
 		NoAds:           user.Authenticated && user.Subscription != "",
 		Debug:           utils.Config.Frontend.Debug,
 	}
+
+	if utils.Config.Frontend.Debug {
+		_, session, err := getUserSession(r)
+		if err != nil {
+			logger.WithError(err).Error("error getting user session")
+		}
+		jsn := make(map[string]interface{})
+		// convert map[interface{}]interface{} -> map[string]interface{}
+		for sessionKey, sessionValue := range session.Values {
+			jsn[fmt.Sprintf("%v", sessionKey)] = sessionValue
+		}
+
+		// jsn, err := json.Marshal(session.Values)
+		// if err != nil {
+		// 	logger.WithError(err).Error("session.values: %+v", session.Values)
+
+		// }
+		data.DebugSession = jsn
+	}
 	data.Rates.EthPrice = price.GetEthPrice(data.Rates.Currency)
 	data.Rates.ExchangeRate = price.GetEthPrice(data.Rates.Currency)
 	data.Rates.EthRoundPrice = price.GetEthRoundPrice(data.Rates.EthPrice)

--- a/tables.sql
+++ b/tables.sql
@@ -498,6 +498,16 @@ create table users
     primary key (id, email)
 );
 
+drop table if exists users_datatable;
+create table users_datatable
+(
+    user_id        int                         not null,
+    key            character varying(256)      not null unique,
+    state          jsonb                       not null,
+    updated_at     timestamp without time zone not null default 'now()',
+    primary key (user_id, key) 
+);
+
 drop table if exists users_stripe_subscriptions;
 create table users_stripe_subscriptions
 (

--- a/templates/blocks.html
+++ b/templates/blocks.html
@@ -9,9 +9,30 @@
         serverSide: true,
         ordering: false,
         searching: true,
-        stateSave: true,
         ajax: "/blocks/data",
-        pageLength: 50,
+        stateSave: true,
+        deferLoading: {{.RecordsTotal}},
+        stateSaveCallback: function (settings, data) {
+          data.search.search = ""
+          data.order = []
+          data.columns = []
+          data.key = `${settings.sTableId}`
+          fetch('/tables/state', {
+            method: "POST",
+            body: JSON.stringify(data),
+          })
+          .then(res => res.json())
+          .then(({ status, data }) => {
+            if (status !== "OK") {
+              console.error("error updating table state, err:", data, "status: ", status)
+            }
+          }).catch(err => {
+            console.error("error updating table state, err: ", err)
+          })
+        },
+        stateDuration: true,
+        pageLength: {{.PageLength}},
+        displayStart: {{.DisplayStart}},
         pagingType: "input",
         language: {
           searchPlaceholder: "Block Number / Graffiti / Proposer Name",
@@ -28,6 +49,8 @@
           } catch (e) {
             console.error(e)
           }
+          document.getElementById('header-placeholder').style.display = 'none'
+          document.getElementById('footer-placeholder').style.display = 'none'
         },
         drawCallback: function (settings) {
           formatTimestamps()
@@ -107,10 +130,11 @@
         <input type="checkbox" id="showonlyemptygraffiti" name="showonlyemptygraffiti" />
         <label for="showonlyemptygraffiti">Show only empty graffiti</label>
       </div>
-      <div class="card">
+      <div class="card mt-2">
+        <div id="header-placeholder" style="height:39px;"></div>
         <div class="card-body px-0 py-3">
           <div class="table-responsive px-0 py-1">
-            <table class="table" id="blocks">
+            <table class="table dataTable no-footer" id="blocks" aria-describedby="blocks_info" role="grid">
               <thead>
                 <tr>
                   <th>Epoch</th>
@@ -127,10 +151,19 @@
                   <th>Graffiti</th>
                 </tr>
               </thead>
-              <tbody></tbody>
+              <tbody>
+                {{ range $i, $row := .Data }}
+                <tr>
+                  {{ range $j, $col := $row }}
+                    <td>{{ $col }}</td>
+                  {{ end }}
+                </tr>
+              {{ end }}
+            </tbody>
             </table>
           </div>
         </div>
+        <div id="footer-placeholder" style="height:64px;"></div>
       </div>
       <div class="d-flex justify-content-between py-2">
         <ins data-revive-zoneid="1" data-revive-id="5b200397ccf8a9353bf44ef99b45268c"></ins>

--- a/templates/blocks.html
+++ b/templates/blocks.html
@@ -153,13 +153,13 @@
               </thead>
               <tbody>
                 {{ range $i, $row := .Data }}
-                <tr>
-                  {{ range $j, $col := $row }}
-                    <td>{{ $col }}</td>
-                  {{ end }}
-                </tr>
-              {{ end }}
-            </tbody>
+                  <tr>
+                    {{ range $j, $col := $row }}
+                      <td>{{ $col }}</td>
+                    {{ end }}
+                  </tr>
+                {{ end }}
+              </tbody>
             </table>
           </div>
         </div>

--- a/templates/epochs.html
+++ b/templates/epochs.html
@@ -15,12 +15,9 @@
         stateSave: true,
         stateSaveCallback: function (settings, data) {
 
-          // console.log('settings', settings)
-          // console.log('data', data)
           data.search.search = ""
           data.order = []
           data.columns = []
-          // data.key = `DataTables_${settings.sTableId}_${window.location.pathname}`
           data.key = `${settings.sTableId}`
           fetch('/tables/state', {
             method: "POST",
@@ -54,6 +51,8 @@
             console.error(e)
           }
           document.getElementById('header-placeholder').style.display = 'none'
+          document.getElementById('footer-placeholder').style.display = 'none'
+
         },
         drawCallback: function (settings) {
           formatTimestamps()
@@ -107,6 +106,7 @@
             </table>
           </div>
         </div>
+        <div id="footer-placeholder" style="height:71px;"></div>
       </div>
       <div class="d-flex justify-content-between py-2">
         <ins data-revive-zoneid="1" data-revive-id="5b200397ccf8a9353bf44ef99b45268c"></ins>

--- a/templates/epochs.html
+++ b/templates/epochs.html
@@ -2,7 +2,7 @@
   <script type="text/javascript" src="/js/datatables.min.js"></script>
   <script type="text/javascript" src="/js/datatable_input.js"></script>
   <script>
-    console.log({{.}})
+    console.log('data: ',{{.}})
     $(document).ready(function () {
       $("#epochs").DataTable({
         processing: true,
@@ -15,19 +15,19 @@
         stateSave: true,
         stateSaveCallback: function (settings, data) {
 
-          console.log('settings', settings)
-          console.log('data', data)
-
+          // console.log('settings', settings)
+          // console.log('data', data)
           data.search.search = ""
           data.order = []
-          data.key = `DataTables_${settings.sTableId}_${window.location.pathname}`
-
+          data.columns = []
+          // data.key = `DataTables_${settings.sTableId}_${window.location.pathname}`
+          data.key = `${settings.sTableId}`
           fetch('/tables/state', {
             method: "POST",
             body: JSON.stringify(data),
           })
-          .then(res => res.json)
-          .then(({ status, data}) => { 
+          .then(res => res.json())
+          .then(({ status, data }) => {
             if (status !== "OK") {
               console.error("error updating table state, err:", data, "status: ", status)
             }
@@ -36,7 +36,8 @@
           })
         },
         stateDuration: true,
-        pageLength: 50,
+        pageLength: {{.PageLength}},
+        displayStart: {{.DisplayStart}},
         language: {
           searchPlaceholder: "Search by Epoch Number",
           search: "",

--- a/templates/epochs.html
+++ b/templates/epochs.html
@@ -100,7 +100,7 @@
                   <tr>
                     {{ range $j, $col := $row }}
                       <td>{{ $col }}</td>
-                    {{end}}
+                    {{ end }}
                   </tr>
                 {{ end }}
               </tbody>

--- a/templates/epochs.html
+++ b/templates/epochs.html
@@ -13,6 +13,28 @@
         ajax: "/epochs/data",
         pagingType: "input",
         stateSave: true,
+        stateSaveCallback: function (settings, data) {
+
+          console.log('settings', settings)
+          console.log('data', data)
+
+          data.search.search = ""
+          data.order = []
+          data.key = `DataTables_${settings.sTableId}_${window.location.pathname}`
+
+          fetch('/tables/state', {
+            method: "POST",
+            body: JSON.stringify(data),
+          })
+          .then(res => res.json)
+          .then(({ status, data}) => { 
+            if (status !== "OK") {
+              console.error("error updating table state, err:", data, "status: ", status)
+            }
+          }).catch(err => {
+            console.error("error updating table state, err: ", err)
+          })
+        },
         stateDuration: true,
         pageLength: 50,
         language: {

--- a/templates/epochs.html
+++ b/templates/epochs.html
@@ -46,7 +46,6 @@
             next: '<i class="fas fa-chevron-right"></i>',
           },
         },
-        data: {{ .Data }},
         preDrawCallback: function () {
           // this does not always work.. not sure how to solve the staying tooltip
           try {
@@ -87,7 +86,7 @@
               <thead>
                 <tr>
                   <th>Epoch</th>
-                  <th>Time</th>
+                  <th style="min-width: 125px">Time</th>
                   <th>Attestations</th>
                   <th>Deposits</th>
                   <th>Slashings <span data-toggle="tooltip" data-placement="top" title="Proposers">P</span> / <span data-toggle="tooltip" data-placement="top" title="Attesters">A</span></th>
@@ -96,7 +95,15 @@
                   <th>Voted</th>
                 </tr>
               </thead>
-              <tbody></tbody>
+              <tbody>
+                {{ range $i, $row := .Data }}
+                  <tr>
+                    {{ range $j, $col := $row }}
+                      <td>{{ $col }}</td>
+                    {{end}}
+                  </tr>
+                {{ end }}
+              </tbody>
             </table>
           </div>
         </div>

--- a/types/templates.go
+++ b/types/templates.go
@@ -37,6 +37,7 @@ type PageData struct {
 	NoAds          bool
 	Debug          bool
 	DebugTemplates []string
+	DebugSession   map[string]interface{}
 }
 
 type PageRates struct {
@@ -710,6 +711,8 @@ type DataTableResponse struct {
 	RecordsTotal    uint64          `json:"recordsTotal"`
 	RecordsFiltered uint64          `json:"recordsFiltered"`
 	Data            [][]interface{} `json:"data"`
+	PageLength      uint64          `json:"pageLength"`
+	DisplayStart    uint64          `json:"displayStart"`
 }
 
 // EpochsPageData is a struct to hold epoch data for the epochs page
@@ -1324,13 +1327,13 @@ type NetworkEventModal struct {
 }
 
 type DataTableSaveState struct {
-	Key     string                    `json:"key"`
-	Time    int64                     `json:"time"`   // Time stamp of when the object was created
-	Start   int64                     `json:"start"`  // Display start point
-	Length  int64                     `json:"length"` // Page length
-	Order   [][]string                `json:"order"`  // 2D array of column ordering information (see `order` option)
-	Search  DataTableSaveStateSearch  `json:"search"`
-	Columns DataTableSaveStateColumns `json:"columns"`
+	Key     string                      `json:"key"`
+	Time    int64                       `json:"time"`   // Time stamp of when the object was created
+	Start   int64                       `json:"start"`  // Display start point
+	Length  int64                       `json:"length"` // Page length
+	Order   [][]string                  `json:"order"`  // 2D array of column ordering information (see `order` option)
+	Search  DataTableSaveStateSearch    `json:"search"`
+	Columns []DataTableSaveStateColumns `json:"columns"`
 }
 
 type DataTableSaveStateOrder struct {

--- a/types/templates.go
+++ b/types/templates.go
@@ -1330,9 +1330,9 @@ type NetworkEventModal struct {
 
 type DataTableSaveState struct {
 	Key     string                      `json:"key"`
-	Time    int64                       `json:"time"`   // Time stamp of when the object was created
-	Start   int64                       `json:"start"`  // Display start point
-	Length  int64                       `json:"length"` // Page length
+	Time    uint64                      `json:"time"`   // Time stamp of when the object was created
+	Start   uint64                      `json:"start"`  // Display start point
+	Length  uint64                      `json:"length"` // Page length
 	Order   [][]string                  `json:"order"`  // 2D array of column ordering information (see `order` option)
 	Search  DataTableSaveStateSearch    `json:"search"`
 	Columns []DataTableSaveStateColumns `json:"columns"`

--- a/types/templates.go
+++ b/types/templates.go
@@ -1322,3 +1322,28 @@ type NetworkEventModal struct {
 	ValidatorPubkey string
 	Events          []EventNameCheckbox
 }
+
+type DataTableSaveState struct {
+	Key     string                    `json:"key"`
+	Time    int64                     `json:"time"`   // Time stamp of when the object was created
+	Start   int64                     `json:"start"`  // Display start point
+	Length  int64                     `json:"length"` // Page length
+	Order   [][]string                `json:"order"`  // 2D array of column ordering information (see `order` option)
+	Search  DataTableSaveStateSearch  `json:"search"`
+	Columns DataTableSaveStateColumns `json:"columns"`
+}
+
+type DataTableSaveStateOrder struct {
+}
+
+type DataTableSaveStateSearch struct {
+	Search          string `json:"search"`          // Search term
+	Regex           bool   `json:"regex"`           // Indicate if the search term should be treated as regex or not
+	Smart           bool   `json:"smart"`           // Flag to enable DataTables smart search
+	CaseInsensitive bool   `json:"caseInsensitive"` // Case insensitive flag
+}
+
+type DataTableSaveStateColumns struct {
+	Visible bool                     `json:"visible"`
+	Search  DataTableSaveStateSearch `json:"search"`
+}

--- a/types/templates.go
+++ b/types/templates.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"database/sql"
+	"database/sql/driver"
 	"encoding/json"
 	"fmt"
 	"html/template"
@@ -9,6 +10,7 @@ import (
 	"time"
 
 	"github.com/lib/pq"
+	"github.com/pkg/errors"
 )
 
 // PageData is a struct to hold web page data
@@ -1334,6 +1336,19 @@ type DataTableSaveState struct {
 	Order   [][]string                  `json:"order"`  // 2D array of column ordering information (see `order` option)
 	Search  DataTableSaveStateSearch    `json:"search"`
 	Columns []DataTableSaveStateColumns `json:"columns"`
+}
+
+func (e *DataTableSaveState) Scan(value interface{}) error {
+	b, ok := value.([]byte)
+	if !ok {
+		return errors.New("type assertion to []byte failed")
+	}
+
+	return json.Unmarshal(b, &e)
+}
+
+func (a DataTableSaveState) Value() (driver.Value, error) {
+	return json.Marshal(a)
 }
 
 type DataTableSaveStateOrder struct {


### PR DESCRIPTION
This PR adds the ability to render datatables on page render using server side session and database state management.

migrations:

```sql
drop table if exists users_datatable;
create table users_datatable
(
    user_id        int                         not null,
    key            character varying(256)      not null unique,
    state          jsonb                       not null,
    updated_at     timestamp without time zone not null default 'now()',
    primary key (user_id, key) 
);
```