### PR TITLE
Upgrade minimum required Go version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,7 +53,7 @@ services:
                 # condition: service_healthy
 
     go:
-        image: golang:1.15
+        image: golang:1.16
         container_name: golang 
         restart: always
         volumes:


### PR DESCRIPTION
Since,

https://github.com/gobitfly/eth2-beaconchain-explorer/blob/1144414b5d765e2dc575b4bc7d48c6689e900f74/config/config.go#L3-L4

minimum Go 1.16 version is required