### PR TITLE
fix: incorrect finalization & offset participation rate

### DIFF
--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -400,6 +400,11 @@ func doFullCheck(client rpc.Client) {
 	if err != nil {
 		logger.Errorf("error updating epoch stratus: %v", err)
 	}
+	// set the finalized epoch to finalized
+	err = db.UpdateEpochFinalization(head.FinalizedEpoch)
+	if err != nil {
+		logger.Errorf("error updating finalization of epochs: %v", err)
+	}
 
 	logger.Infof("exporting validation queue")
 	err = exportValidatorQueue(client)
@@ -514,7 +519,7 @@ func updateEpochStatus(client rpc.Client, startEpoch, endEpoch uint64) error {
 		if err != nil {
 			logger.Printf("error retrieving epoch participation statistics: %v", err)
 		} else {
-			logger.Printf("updating epoch %v with status finalized = %v", epoch, epochParticipationStats.Finalized)
+			logger.Printf("updating epoch %v with participation rate %v", epoch, epochParticipationStats.GlobalParticipationRate)
 			err := db.UpdateEpochStatus(epochParticipationStats)
 
 			if err != nil {
@@ -522,7 +527,7 @@ func updateEpochStatus(client rpc.Client, startEpoch, endEpoch uint64) error {
 			}
 		}
 	}
-	return db.UpdateEpochFinalization()
+	return nil
 }
 
 func performanceDataUpdater() {

--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -400,7 +400,7 @@ func doFullCheck(client rpc.Client) {
 	if err != nil {
 		logger.Errorf("error updating epoch stratus: %v", err)
 	}
-	// set the finalized epoch to finalized
+	// set all finalized epochs to finalized
 	err = db.UpdateEpochFinalization(head.FinalizedEpoch)
 	if err != nil {
 		logger.Errorf("error updating finalization of epochs: %v", err)

--- a/rpc/lighthouse.go
+++ b/rpc/lighthouse.go
@@ -838,7 +838,7 @@ func (lc *LighthouseClient) GetValidatorParticipation(epoch uint64) (*types.Vali
 	}
 
 	var res *types.ValidatorParticipation
-	if epoch < LighthouseLatestHeadEpoch-1 {
+	if epoch < request_epoch {
 		// we requested the next epoch, so we have to use the previous value for everything here
 		res = &types.ValidatorParticipation{
 			Epoch:                   epoch,

--- a/rpc/lighthouse.go
+++ b/rpc/lighthouse.go
@@ -22,6 +22,9 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+// LighthouseLatestHeadEpoch is used to cache the latest head epoch for participation requests
+var LighthouseLatestHeadEpoch uint64 = 0
+
 // LighthouseClient holds the Lighthouse client info
 type LighthouseClient struct {
 	endpoint            string
@@ -378,7 +381,6 @@ func (lc *LighthouseClient) GetEpochData(epoch uint64) (*types.EpochData, error)
 			logger.Errorf("error retrieving epoch participation statistics for epoch %v: %v", epoch, err)
 			data.EpochParticipationStats = &types.ValidatorParticipation{
 				Epoch:                   epoch,
-				Finalized:               false,
 				GlobalParticipationRate: 1.0,
 				VotedEther:              0,
 				EligibleEther:           0,
@@ -795,7 +797,36 @@ func syncCommitteeParticipation(bits []byte) float64 {
 
 // GetValidatorParticipation will get the validator participation from the Lighthouse RPC api
 func (lc *LighthouseClient) GetValidatorParticipation(epoch uint64) (*types.ValidatorParticipation, error) {
-	resp, err := lc.get(fmt.Sprintf("%s/lighthouse/validator_inclusion/%d/global", lc.endpoint, epoch))
+	if epoch > LighthouseLatestHeadEpoch {
+		// update LighthouseLatestHeadEpoch to make sure we are continuing with the latest data
+		head, err := lc.GetChainHead()
+		if err != nil {
+			return nil, err
+		}
+		logger.Infof("Updating LighthouseLatestHeadEpoch to %v", head.HeadEpoch)
+		LighthouseLatestHeadEpoch = head.HeadEpoch
+	}
+
+	if epoch > LighthouseLatestHeadEpoch {
+		return nil, fmt.Errorf("epoch %v is newer than the latest head %v", epoch, LighthouseLatestHeadEpoch)
+	}
+	if epoch == LighthouseLatestHeadEpoch {
+		// participation stats are calculated at the end of an epoch,
+		// making it impossible to retrieve stats of an currently ongoing epoch
+		return nil, fmt.Errorf("epoch %v can't be retrieved as it hasn't finished yet", epoch)
+	}
+
+	request_epoch := epoch
+	if epoch < LighthouseLatestHeadEpoch-1 {
+		// we offset the request epoch by one for older epochs so we get the complete participation numbers
+		// this is required as votes can be include up to one epoch after their intended inclusion
+		// we also have to make sure we don't attempt to request the current head epoch,
+		// since requesting it is impossible – see above error about it
+		// ref: https://lighthouse-book.sigmaprime.io/validator-inclusion.html#global
+		request_epoch += 1
+	}
+
+	resp, err := lc.get(fmt.Sprintf("%s/lighthouse/validator_inclusion/%d/global", lc.endpoint, request_epoch))
 	if err != nil {
 		return nil, fmt.Errorf("error retrieving validator participation data for epoch %v: %v", epoch, err)
 	}
@@ -806,14 +837,24 @@ func (lc *LighthouseClient) GetValidatorParticipation(epoch uint64) (*types.Vali
 		return nil, fmt.Errorf("error parsing validator participation data for epoch %v: %v", epoch, err)
 	}
 
-	return &types.ValidatorParticipation{
-		Epoch: epoch,
-		// technically there are rules for delayed finalization through previous epoch, applied only later. But good enough, this matches previous wonky behavior
-		Finalized:               float32(parsedResponse.Data.CurrentEpochTargetAttestingGwei)/float32(parsedResponse.Data.CurrentEpochActiveGwei) > (float32(2) / float32(3)),
-		GlobalParticipationRate: float32(parsedResponse.Data.PreviousEpochTargetAttestingGwei) / float32(parsedResponse.Data.CurrentEpochActiveGwei),
-		VotedEther:              uint64(parsedResponse.Data.PreviousEpochTargetAttestingGwei),
-		EligibleEther:           uint64(parsedResponse.Data.CurrentEpochActiveGwei),
-	}, nil
+	var res *types.ValidatorParticipation
+	if epoch < LighthouseLatestHeadEpoch-1 {
+		// we requested the next epoch, so we have to use the previous value for everything here
+		res = &types.ValidatorParticipation{
+			Epoch:                   epoch,
+			GlobalParticipationRate: float32(parsedResponse.Data.PreviousEpochTargetAttestingGwei) / float32(parsedResponse.Data.PreviousEpochActiveGwei),
+			VotedEther:              uint64(parsedResponse.Data.PreviousEpochTargetAttestingGwei),
+			EligibleEther:           uint64(parsedResponse.Data.PreviousEpochActiveGwei),
+		}
+	} else {
+		res = &types.ValidatorParticipation{
+			Epoch:                   epoch,
+			GlobalParticipationRate: float32(parsedResponse.Data.CurrentEpochTargetAttestingGwei) / float32(parsedResponse.Data.CurrentEpochActiveGwei),
+			VotedEther:              uint64(parsedResponse.Data.CurrentEpochTargetAttestingGwei),
+			EligibleEther:           uint64(parsedResponse.Data.CurrentEpochActiveGwei),
+		}
+	}
+	return res, nil
 }
 
 func (lc *LighthouseClient) GetFinalityCheckpoints(epoch uint64) (*types.FinalityCheckpoints, error) {

--- a/rpc/prysm.go
+++ b/rpc/prysm.go
@@ -1008,7 +1008,6 @@ func (pc *PrysmClient) GetValidatorParticipation(epoch uint64) (*types.Validator
 		logger.Printf("error retrieving epoch participation statistics: %v", err)
 		return &types.ValidatorParticipation{
 			Epoch:                   epoch,
-			Finalized:               false,
 			GlobalParticipationRate: 0,
 			VotedEther:              0,
 			EligibleEther:           0,
@@ -1016,7 +1015,6 @@ func (pc *PrysmClient) GetValidatorParticipation(epoch uint64) (*types.Validator
 	}
 	return &types.ValidatorParticipation{
 		Epoch:                   epoch,
-		Finalized:               epochParticipationStatistics.Finalized,
 		GlobalParticipationRate: epochParticipationStatistics.Participation.GlobalParticipationRate,
 		VotedEther:              epochParticipationStatistics.Participation.VotedEther,
 		EligibleEther:           epochParticipationStatistics.Participation.EligibleEther,

--- a/types/exporter.go
+++ b/types/exporter.go
@@ -47,7 +47,6 @@ type EpochData struct {
 // ValidatorParticipation is a struct to hold validator participation data
 type ValidatorParticipation struct {
 	Epoch                   uint64
-	Finalized               bool
 	GlobalParticipationRate float32
 	VotedEther              uint64
 	EligibleEther           uint64


### PR DESCRIPTION
fixes incorrect finalization tracking by using the finalized epoch returned by lighthouse instead of assuming everything over 2/3 as finalized. also fixes a small off-by-one issue with the participation rate (epoch n had the participation rate of epoch n-1).

this PR adds one extra request per epoch, as `GetValidatorParticipation` has to know the header epoch - it is cached to not cause strain while processing old epochs though and shouldn't be any cause for concern.