### PR TITLE
export: fix: update cached head if close to head

### DIFF
--- a/rpc/lighthouse.go
+++ b/rpc/lighthouse.go
@@ -797,8 +797,9 @@ func syncCommitteeParticipation(bits []byte) float64 {
 
 // GetValidatorParticipation will get the validator participation from the Lighthouse RPC api
 func (lc *LighthouseClient) GetValidatorParticipation(epoch uint64) (*types.ValidatorParticipation, error) {
-	if epoch > LighthouseLatestHeadEpoch {
+	if epoch >= LighthouseLatestHeadEpoch-1 {
 		// update LighthouseLatestHeadEpoch to make sure we are continuing with the latest data
+		// we need to check when epoch = head and epoch head - 1 so our following logic acts correctly when we are close to the head
 		head, err := lc.GetChainHead()
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
we need to update the cached head more often that just when the passed epoch is larger, as the logic following it checks for both `epoch == head` and `epoch > head - 1 `