### PR TITLE
exporter: fix: turn uint into int to prevent underflowing it

### DIFF
--- a/rpc/lighthouse.go
+++ b/rpc/lighthouse.go
@@ -23,7 +23,7 @@ import (
 )
 
 // LighthouseLatestHeadEpoch is used to cache the latest head epoch for participation requests
-var LighthouseLatestHeadEpoch uint64 = 0
+var LighthouseLatestHeadEpoch int64 = 0
 
 // LighthouseClient holds the Lighthouse client info
 type LighthouseClient struct {

--- a/rpc/lighthouse.go
+++ b/rpc/lighthouse.go
@@ -23,7 +23,7 @@ import (
 )
 
 // LighthouseLatestHeadEpoch is used to cache the latest head epoch for participation requests
-var LighthouseLatestHeadEpoch int64 = 0
+var LighthouseLatestHeadEpoch uint64 = 0
 
 // LighthouseClient holds the Lighthouse client info
 type LighthouseClient struct {
@@ -797,7 +797,7 @@ func syncCommitteeParticipation(bits []byte) float64 {
 
 // GetValidatorParticipation will get the validator participation from the Lighthouse RPC api
 func (lc *LighthouseClient) GetValidatorParticipation(epoch uint64) (*types.ValidatorParticipation, error) {
-	if epoch >= LighthouseLatestHeadEpoch-1 {
+	if LighthouseLatestHeadEpoch == 0 || epoch >= LighthouseLatestHeadEpoch-1 {
 		// update LighthouseLatestHeadEpoch to make sure we are continuing with the latest data
 		// we need to check when epoch = head and epoch head - 1 so our following logic acts correctly when we are close to the head
 		head, err := lc.GetChainHead()


### PR DESCRIPTION
`uint` underflow if you subtrack from them and they are 0. who wouldve guessed that