### PR TITLE
Feature/add accurate queue estimator

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -1700,7 +1700,7 @@ func GetQueueAheadOfValidator(validatorIndex uint64) (uint64, error) {
 	select count(*)
 	from (
 		select validatorindex, block_slot, block_index 
-		from validator_queue_deposits vqd
+		from validator_queue_deposits
 	) as vqd 
 	inner join validators on
 		validators.validatorindex = vqd.validatorindex and

--- a/db/db.go
+++ b/db/db.go
@@ -1629,7 +1629,7 @@ func updateQueueDeposits() error {
 		metrics.TaskDuration.WithLabelValues("update_queue_deposits").Observe(time.Since(start).Seconds())
 	}()
 
-	// first we remove any publickeys aren't queued in the validators table anymore
+	// first we remove any validator that isn't queued anymore
 	_, err := WriterDb.Exec(`
 		DELETE FROM validator_queue_deposits
 		WHERE validator_queue_deposits.validatorindex NOT IN (
@@ -1641,7 +1641,7 @@ func updateQueueDeposits() error {
 		return err
 	}
 
-	// then we add any new queued ones
+	// then we add any new ones that are queued
 	_, err = WriterDb.Exec(`
 		INSERT INTO validator_queue_deposits
 		SELECT validatorindex FROM validators WHERE activationepoch=9223372036854775807 and status='pending' ON CONFLICT DO NOTHING`)

--- a/handlers/validator.go
+++ b/handlers/validator.go
@@ -336,8 +336,8 @@ func Validator(w http.ResponseWriter, r *http.Request) {
 	if validatorPageData.ActivationEpoch > 100_000_000 {
 		queueAhead, err := db.GetQueueAheadOfValidator(validatorPageData.Index)
 		if err != nil {
-			logger.WithError(err).Warnf("failed to retrieve queue ahead of validator %v", vars["index"])
-			http.Error(w, err.Error(), http.StatusInternalServerError)
+			logger.WithError(err).Warnf("failed to retrieve queue ahead of validator %v: %v", validatorPageData.ValidatorIndex, err)
+			http.Error(w, "Internal server error", http.StatusInternalServerError)
 		}
 		validatorPageData.QueuePosition = queueAhead + 1
 		epochsToWait := queueAhead / *churnRate

--- a/handlers/validator.go
+++ b/handlers/validator.go
@@ -339,9 +339,12 @@ func Validator(w http.ResponseWriter, r *http.Request) {
 			logger.WithError(err).Warnf("failed to retrieve queue ahead of validator %v", vars["index"])
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}
-
-		validatorPageData.QueuePosition = queueAhead
-		estimatedActivationEpoch := validatorPageData.Epoch + (queueAhead / *churnRate) + 1 + utils.Config.Chain.Config.MaxSeedLookahead
+		validatorPageData.QueuePosition = queueAhead + 1
+		epochsToWait := queueAhead / *churnRate
+		// calculate dequeue epoch
+		estimatedActivationEpoch := validatorPageData.Epoch + epochsToWait + 1
+		// add activation offset
+		estimatedActivationEpoch += utils.Config.Chain.Config.MaxSeedLookahead + 1
 		validatorPageData.EstimatedActivationEpoch = estimatedActivationEpoch
 		estimatedDequeueTs := utils.EpochToTime(estimatedActivationEpoch)
 		validatorPageData.EstimatedActivationTs = estimatedDequeueTs

--- a/services/stats.go
+++ b/services/stats.go
@@ -153,7 +153,7 @@ func GetValidatorChurnLimit() (uint64, error) {
 
 	adaptable := uint64(0)
 	if *count > 0 {
-		adaptable = utils.Config.Chain.Config.ChurnLimitQuotient / *count
+		adaptable = *count / utils.Config.Chain.Config.ChurnLimitQuotient
 	}
 
 	if min > adaptable {

--- a/services/stats.go
+++ b/services/stats.go
@@ -66,7 +66,7 @@ func calculateStats() (*types.Stats, error) {
 
 	stats.PendingValidatorCount = &pendingValidatorCount
 
-	validatorChurnLimit, err := GetValidatorChurnLimit()
+	validatorChurnLimit, err := getValidatorChurnLimit(activeValidatorCount)
 	if err != nil {
 		logger.WithError(err).Error("error getting total validator churn limit")
 	}
@@ -141,19 +141,12 @@ func eth1UniqueValidatorsCount() (*uint64, error) {
 }
 
 // GetValidatorChurnLimit returns the rate at which validators can enter or leave the system
-func GetValidatorChurnLimit() (uint64, error) {
+func getValidatorChurnLimit(validatorCount uint64) (uint64, error) {
 	min := utils.Config.Chain.Config.MinPerEpochChurnLimit
 
-	stats := GetLatestStats()
-	count := stats.ActiveValidatorCount
-
-	if count == nil {
-		count = new(uint64)
-	}
-
 	adaptable := uint64(0)
-	if *count > 0 {
-		adaptable = *count / utils.Config.Chain.Config.ChurnLimitQuotient
+	if validatorCount > 0 {
+		adaptable = validatorCount / utils.Config.Chain.Config.ChurnLimitQuotient
 	}
 
 	if min > adaptable {

--- a/static/js/validator.js
+++ b/static/js/validator.js
@@ -81,7 +81,6 @@ function setValidatorStatus(state, activationEpoch) {
       activeNode.classList.add("active")
     }
   }
-
 }
 
 function setupDashboardButtons(validatorIdx) {

--- a/static/js/validator.js
+++ b/static/js/validator.js
@@ -1,7 +1,8 @@
-function setValidatorStatus(state) {
+function setValidatorStatus(state, activationEpoch) {
   // deposited, deposited_valid, deposited_invalid, pending, active_online, active_offline, exiting_online, exiting_offline, slashing_online, slashing_offline, exited, slashed
   // we cans set elements to active, failed and done
   var status = state
+  console.log(status)
 
   var depositToPending = document.querySelector(".validator__lifecycle-progress.validator__lifecycle-deposited")
   var pendingToActive = document.querySelector(".validator__lifecycle-progress.validator__lifecycle-pending")
@@ -70,10 +71,17 @@ function setValidatorStatus(state) {
   }
 
   if (status === "pending") {
-    pendingNode.classList.add("done")
-    pendingToActive.classList.add("active")
-    activeNode.classList.add("active")
+    if (activationEpoch > 100_000_000) {
+      depositedNode.classList.add("done")
+      depositToPending.classList.add("complete")
+      pendingNode.classList.add("active")
+    } else {
+      pendingNode.classList.add("done")
+      pendingToActive.classList.add("active")
+      activeNode.classList.add("active")
+    }
   }
+
 }
 
 function setupDashboardButtons(validatorIdx) {

--- a/tables.sql
+++ b/tables.sql
@@ -1011,3 +1011,14 @@ create table historical_pool_performance
     
     primary key(pool, day)
 );
+
+DROP TABLE IF EXISTS validator_queue_deposits;
+CREATE TABLE validator_queue_deposits (
+	validatorindex int4 NOT NULL,
+	block_slot int4 NULL,
+	block_index int4 NULL,
+	CONSTRAINT validator_queue_deposits_fk FOREIGN KEY (block_slot,block_index) REFERENCES blocks_deposits(block_slot,block_index),
+	CONSTRAINT validator_queue_deposits_fk_validators FOREIGN KEY (validatorindex) REFERENCES validators(validatorindex)
+);
+CREATE INDEX idx_validator_queue_deposits_block_slot ON validator_queue_deposits USING btree (block_slot);
+CREATE UNIQUE INDEX idx_validator_queue_deposits_validatorindexON validator_queue_deposits USING btree (validatorindex);

--- a/templates/validator/countdown.html
+++ b/templates/validator/countdown.html
@@ -26,7 +26,7 @@
 	}
 
 	document.addEventListener('DOMContentLoaded', function() {
-		var genesis = {{.ActivationTs.Unix}}
+		var genesis = {{or .EstimatedActivationTs.Unix .ActivationTs.Unix }}
 		var now = Math.round((new Date()).getTime() / 1000)
 		var secondsLeft = genesis - now
 		var seconds = secondsLeft % 60

--- a/templates/validator/overview.html
+++ b/templates/validator/overview.html
@@ -105,18 +105,16 @@
     <div class="col">
       <div class="px-2">
         <div class="p-2 mx-auto" style="max-width: 50rem;">
-            This validator has been processed by the beacon chain and is currently waiting to be activated. 
-            {{ if lt .ActivationEpoch 100_000_000 }}
-              It will be activated on <span class="font-weight-bolder" title="{{ .ActivationTs }}" data-toggle="tooltip" aria-ethereum-date="{{ .ActivationTs.Unix }}">{{ .ActivationTs }}</span> during epoch <span class="font-weight-bolder">{{ .ActivationEpoch }}</span>. 
-            {{ else if lt .EstimatedActivationEpoch 100_000_000 }}
-              It is estimated to be activated on <span class="font-weight-bolder" title="{{ .ActivationTs }}" data-toggle="tooltip" aria-ethereum-date="{{ .EstimatedActivationTs.Unix }}">{{ .EstimatedActivationTs }}</span> during epoch <span class="font-weight-bolder">{{ .EstimatedActivationEpoch }}</span>. 
-            {{ end }}
-            Make sure your nodes and your client is up and running <em>before</em> the countdown reaches zero.
+          This validator has been processed by the beacon chain and is currently waiting to be activated.
+          {{ if lt .ActivationEpoch 100_000_000 }}
+            It will be activated on <span class="font-weight-bolder" title="{{ .ActivationTs }}" data-toggle="tooltip" aria-ethereum-date="{{ .ActivationTs.Unix }}">{{ .ActivationTs }}</span> during epoch <span class="font-weight-bolder">{{ .ActivationEpoch }}</span>.
+          {{ else if lt .EstimatedActivationEpoch 100_000_000 }}
+            It is estimated to be activated on <span class="font-weight-bolder" title="{{ .ActivationTs }}" data-toggle="tooltip" aria-ethereum-date="{{ .EstimatedActivationTs.Unix }}">{{ .EstimatedActivationTs }}</span> during epoch <span class="font-weight-bolder">{{ .EstimatedActivationEpoch }}</span>.
+          {{ end }}
+          Make sure your nodes and your client is up and running <em>before</em> the countdown reaches zero.
         </div>
         {{ if gt .QueuePosition 0 }}
-          <div class="d-flex justify-content-center" data-toggle="tooltip" title="{{ .ChurnRate }} Validators get dequeued each Epoch.">
-            This validator is currently #{{ .QueuePosition }} in Queue.
-          </div>
+          <div class="d-flex justify-content-center" data-toggle="tooltip" title="{{ .ChurnRate }} Validators get dequeued each Epoch.">This validator is currently #{{ .QueuePosition }} in Queue.</div>
         {{ end }}
         <div class="my-4" style="min-width:300px;">
           {{ template "validatorCountdown" . }}

--- a/templates/validator/overview.html
+++ b/templates/validator/overview.html
@@ -105,17 +105,22 @@
     <div class="col">
       <div class="px-2">
         <div class="p-2 mx-auto" style="max-width: 50rem;">
-          {{ if ne .ActivationEpoch 9223372036854775807 }}
-            This validator has been processed by the beacon chain and is currently waiting to be activated. It will approximately be activated on <span class="font-weight-bolder" title="{{ .ActivationTs }}" data-toggle="tooltip" aria-ethereum-date="{{ .ActivationTs.Unix }}">{{ .ActivationTs }}</span> during epoch <span class="font-weight-bolder">{{ .ActivationEpoch }}</span>. Make sure your nodes and your client is up and running <em>before</em> the countdown reaches zero.
-          {{ else }}
-            This validator has been registered by the beacon chain and is currently waiting to be voted into the activation queue. You can read more about this process in the <a href="https://kb.beaconcha.in/ethereum-2.0-depositing">Ethereum 2.0 Knowledge Base</a>.
-          {{ end }}
+            This validator has been processed by the beacon chain and is currently waiting to be activated. 
+            {{ if lt .ActivationEpoch 100_000_000 }}
+              It will be activated on <span class="font-weight-bolder" title="{{ .ActivationTs }}" data-toggle="tooltip" aria-ethereum-date="{{ .ActivationTs.Unix }}">{{ .ActivationTs }}</span> during epoch <span class="font-weight-bolder">{{ .ActivationEpoch }}</span>. 
+            {{ else if lt .EstimatedActivationEpoch 100_000_000 }}
+              It is estimated to be activated on <span class="font-weight-bolder" title="{{ .ActivationTs }}" data-toggle="tooltip" aria-ethereum-date="{{ .EstimatedActivationTs.Unix }}">{{ .EstimatedActivationTs }}</span> during epoch <span class="font-weight-bolder">{{ .EstimatedActivationEpoch }}</span>. 
+            {{ end }}
+            Make sure your nodes and your client is up and running <em>before</em> the countdown reaches zero.
         </div>
-        {{ if lt .ActivationEpoch 9223372036854775807 }}
-          <div class="py-2" style="min-width:300px;">
-            {{ template "validatorCountdown" . }}
+        {{ if gt .QueuePosition 0 }}
+          <div class="d-flex justify-content-center" data-toggle="tooltip" title="{{ .ChurnRate }} Validators get dequeued each Epoch.">
+            This validator is currently #{{ .QueuePosition }} in Queue.
           </div>
         {{ end }}
+        <div class="my-4" style="min-width:300px;">
+          {{ template "validatorCountdown" . }}
+        </div>
       </div>
     </div>
   </div>

--- a/templates/validator/overview.html
+++ b/templates/validator/overview.html
@@ -114,7 +114,9 @@
           Make sure your nodes and your client is up and running <em>before</em> the countdown reaches zero.
         </div>
         {{ if gt .QueuePosition 0 }}
-          <div class="d-flex justify-content-center" data-toggle="tooltip" title="{{ .ChurnRate }} Validators get dequeued each Epoch.">This validator is currently #{{ .QueuePosition }} in Queue.</div>
+          <div class="d-flex justify-content-center">
+            <p>This validator is currently <span class="font-weight-bolder d-inline-block text-underlined" data-toggle="tooltip" title="{{ .ChurnRate }} Validators get dequeued each Epoch.">#{{ .QueuePosition }}</span> in Queue.</p>
+          </div>
         {{ end }}
         <div class="my-4" style="min-width:300px;">
           {{ template "validatorCountdown" . }}

--- a/templates/validator/validator.html
+++ b/templates/validator/validator.html
@@ -6,7 +6,7 @@
     })
   </script>
   <script src="/js/validator.js"></script>
-	<script>setValidatorStatus({{.Status}})</script>
+	<script>setValidatorStatus({{.Status}}, {{.ActivationEpoch}})</script>
   {{ if and (ne .Status "deposited") (ne .Status "deposited_invalid") (ne .Status "deposited_valid") }}
     <script type="text/javascript" src="/js/datatables.min.js"></script>
     <script type="text/javascript" src="/js/datatable_input.js"></script>

--- a/types/templates.go
+++ b/types/templates.go
@@ -340,7 +340,10 @@ type ValidatorPageData struct {
 	AttestationInclusionEffectiveness   float64
 	CsrfField                           template.HTML
 	NetworkStats                        *IndexPageData
-	EstimatedActivationTs               int64
+	ChurnRate                           uint64
+	QueuePosition                       uint64
+	EstimatedActivationTs               time.Time
+	EstimatedActivationEpoch            uint64
 	InclusionDelay                      int64
 	CurrentAttestationStreak            uint64
 	LongestAttestationStreak            uint64


### PR DESCRIPTION
adds accurate activation estimation and queue position to validator page.

the estimation error i have observed over a set of around 900 validators is pretty much 0, with a small subset of validators being one epoch earlier than predicted (but not really worth it to look into that much deeper).

<img src="https://user-images.githubusercontent.com/110384239/183884892-a7aa0548-ec01-4c40-8943-8dbac542f178.png" width="100%" height="auto" />

also change the validator lifecycle steps a bit to better visualize being queued.
| pending and queued | pending and not queued |
| ------ | ----- |
| ![pending_and_queud](https://user-images.githubusercontent.com/110384239/183885778-d93a761b-37cd-4330-90d3-1a6430fb1ebe.png) | ![pending_to_active](https://user-images.githubusercontent.com/110384239/183885785-d41179e5-f2a6-405b-a234-3386994dc05f.png) |

also added a tooltip to show the current churn rate when queued
<p align="center">
  <img src="https://user-images.githubusercontent.com/110384239/183887359-8656f07b-71ce-4496-ac3b-ae4350309c73.png"/>
</p>

-----

required migration queries:
```sql
CREATE TABLE validator_queue_deposits (
	validatorindex int4 NOT NULL,
	block_slot int4 NULL,
	block_index int4 NULL,
	FOREIGN KEY (block_slot,block_index) REFERENCES blocks_deposits(block_slot,block_index),
	FOREIGN KEY (validatorindex) REFERENCES validators(validatorindex)
);
CREATE INDEX idx_validator_queue_deposits_block_slox ON validator_queue_deposits (block_slot);
CREATE UNIQUE INDEX idx_validator_queue_deposits_validatorindex ON validator_queue_deposits (validatorindex);
```