### PR TITLE
exporter, tags: don't skip sleep when failing to retrieve relays from db

### DIFF
--- a/exporter/tags.go
+++ b/exporter/tags.go
@@ -40,7 +40,6 @@ func mevBoostRelaysExporter() {
 			}
 		} else {
 			logger.Warnf("failed to retrieve relays from db: %v", err)
-			continue
 		}
 		time.Sleep(time.Second * 60)
 	}


### PR DESCRIPTION
should never trigger but spamming the db is also not what we want when it does fail