### PR TITLE
Feature/remove finalized column

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -1591,23 +1591,6 @@ func UpdateEpochStatus(stats *types.ValidatorParticipation) error {
 	return err
 }
 
-// UpdateEpochFinalization will update finalized-flag of unfinalized epochs
-func UpdateEpochFinalization(finality_epoch uint64) error {
-	// to prevent a full table scan, the query is constrained to update only between the last epoch that was tagged finalized and the passed finality_epoch
-	// will not fill gaps in the db in finalization this way, but makes the query much faster.
-	_, err := WriterDb.Exec(`
-	UPDATE epochs
-	SET finalized = true
-	WHERE epoch BETWEEN	(
-			SELECT epoch
-			FROM   epochs
-			WHERE  finalized = true
-			ORDER  BY epoch DESC
-			LIMIT  1
-		) AND $1 `, finality_epoch)
-	return err
-}
-
 // GetTotalValidatorsCount will return the total-validator-count
 func GetTotalValidatorsCount() (uint64, error) {
 	var totalCount uint64

--- a/db/db.go
+++ b/db/db.go
@@ -783,25 +783,26 @@ func SaveEpoch(data *types.EpochData) error {
 			validatorscount, 
 			averagevalidatorbalance, 
 			totalvalidatorbalance,
-			finalized, 
 			eligibleether, 
 			globalparticipationrate, 
-			votedether
+			votedether,
+			completeparticipationstats
 		)
 		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14) 
 		ON CONFLICT (epoch) DO UPDATE SET 
-			blockscount             = excluded.blockscount, 
-			proposerslashingscount  = excluded.proposerslashingscount,
-			attesterslashingscount  = excluded.attesterslashingscount,
-			attestationscount       = excluded.attestationscount,
-			depositscount           = excluded.depositscount,
-			voluntaryexitscount     = excluded.voluntaryexitscount,
-			validatorscount         = excluded.validatorscount,
-			averagevalidatorbalance = excluded.averagevalidatorbalance,
-			totalvalidatorbalance   = excluded.totalvalidatorbalance,
-			eligibleether           = excluded.eligibleether,
-			globalparticipationrate = excluded.globalparticipationrate,
-			votedether              = excluded.votedether`,
+			blockscount                = excluded.blockscount, 
+			proposerslashingscount     = excluded.proposerslashingscount,
+			attesterslashingscount     = excluded.attesterslashingscount,
+			attestationscount          = excluded.attestationscount,
+			depositscount              = excluded.depositscount,
+			voluntaryexitscount        = excluded.voluntaryexitscount,
+			validatorscount            = excluded.validatorscount,
+			averagevalidatorbalance    = excluded.averagevalidatorbalance,
+			totalvalidatorbalance      = excluded.totalvalidatorbalance,
+			eligibleether              = excluded.eligibleether,
+			globalparticipationrate    = excluded.globalparticipationrate,
+			votedether                 = excluded.votedether,
+			completeparticipationstats = excluded.completeparticipationstats`,
 		data.Epoch,
 		len(data.Blocks),
 		proposerSlashingsCount,
@@ -812,10 +813,10 @@ func SaveEpoch(data *types.EpochData) error {
 		validatorsCount,
 		validatorBalanceAverage.Uint64(),
 		validatorBalanceSum.Uint64(),
-		false,
 		data.EpochParticipationStats.EligibleEther,
 		data.EpochParticipationStats.GlobalParticipationRate,
-		data.EpochParticipationStats.VotedEther)
+		data.EpochParticipationStats.VotedEther,
+		data.EpochParticipationStats.Complete)
 
 	if err != nil {
 		return fmt.Errorf("error executing save epoch statement: %w", err)

--- a/db/db.go
+++ b/db/db.go
@@ -1585,9 +1585,10 @@ func UpdateEpochStatus(stats *types.ValidatorParticipation) error {
 		UPDATE epochs SET
 			eligibleether = $1,
 			globalparticipationrate = $2,
-			votedether = $3
+			votedether = $3,
+			completeparticipationstats = $5
 		WHERE epoch = $4`,
-		stats.EligibleEther, stats.GlobalParticipationRate, stats.VotedEther, stats.Epoch)
+		stats.EligibleEther, stats.GlobalParticipationRate, stats.VotedEther, stats.Epoch, stats.Complete)
 
 	return err
 }

--- a/db/streaks.go
+++ b/db/streaks.go
@@ -20,7 +20,7 @@ func UpdateAttestationStreaks() (updatedToLastFinalizedEpoch bool, err error) {
 	}()
 
 	lastFinalizedEpoch := 0
-	err = WriterDb.Get(&lastFinalizedEpoch, `select coalesce(max(epoch),0) from epochs where finalized = 't'`)
+	err = WriterDb.Get(&lastFinalizedEpoch, `SELECT COALESCE(MAX(epoch), 0) FROM epochs where epoch <= (select finalizedepoch from network_liveness order by headepoch desc limit 1)`)
 	if err != nil {
 		return false, fmt.Errorf("error getting latestEpoch: %w", err)
 	}

--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -24,8 +24,8 @@ var epochBlacklist = make(map[uint64]uint64)
 
 // Start will start the export of data from rpc into the database
 func Start(client rpc.Client) error {
-	go performanceDataUpdater()
 	go networkLivenessUpdater(client)
+	go performanceDataUpdater()
 	go eth1DepositsExporter()
 	go genesisDepositsExporter()
 	go checkSubscriptions()
@@ -404,7 +404,7 @@ func doFullCheck(client rpc.Client) {
 	logger.Infof("updating status of epochs %v-%v", startEpoch, head.HeadEpoch)
 	err = updateEpochStatus(client, startEpoch, head.HeadEpoch)
 	if err != nil {
-		logger.Errorf("error updating epoch stratus: %v", err)
+		logger.Errorf("error updating epoch status: %v", err)
 	}
 	logger.Infof("exporting validation queue")
 	err = exportValidatorQueue(client)

--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -406,12 +406,6 @@ func doFullCheck(client rpc.Client) {
 	if err != nil {
 		logger.Errorf("error updating epoch stratus: %v", err)
 	}
-	// set all finalized epochs to finalized
-	err = db.UpdateEpochFinalization(head.FinalizedEpoch)
-	if err != nil {
-		logger.Errorf("error updating finalization of epochs: %v", err)
-	}
-
 	logger.Infof("exporting validation queue")
 	err = exportValidatorQueue(client)
 	if err != nil {

--- a/handlers/epochs.go
+++ b/handlers/epochs.go
@@ -81,10 +81,10 @@ func Epochs(w http.ResponseWriter, r *http.Request) {
 		voluntaryexitscount, 
 		validatorscount, 
 		averagevalidatorbalance, 
-		finalized,
 		eligibleether,
 		globalparticipationrate,
-		votedether
+		votedether,
+		completeparticipationstats
 	FROM epochs 
 	WHERE epoch >= $1 AND epoch <= $2
 	ORDER BY epoch DESC`, endEpoch, startEpoch)
@@ -103,9 +103,9 @@ func Epochs(w http.ResponseWriter, r *http.Request) {
 			b.AttestationsCount,
 			b.DepositsCount,
 			fmt.Sprintf("%v / %v", b.ProposerSlashingsCount, b.AttesterSlashingsCount),
-			utils.FormatYesNo(b.Finalized),
+			utils.FormatYesNo(b.Epoch <= services.LatestFinalizedEpoch()),
 			utils.FormatBalance(b.EligibleEther, currency),
-			utils.FormatGlobalParticipationRate(b.VotedEther, b.GlobalParticipationRate, currency),
+			utils.FormatGlobalParticipationRate(b.VotedEther, b.GlobalParticipationRate, currency, b.ParticipationStatsCompelete),
 		}
 	}
 
@@ -189,10 +189,10 @@ func EpochsData(w http.ResponseWriter, r *http.Request) {
 				voluntaryexitscount, 
 				validatorscount, 
 				averagevalidatorbalance, 
-				finalized,
 				eligibleether,
 				globalparticipationrate,
-				votedether
+				votedether,
+				completeparticipationstats
 			FROM epochs 
 			WHERE epoch >= $1 AND epoch <= $2
 			ORDER BY epoch DESC`, endEpoch, startEpoch)
@@ -207,10 +207,10 @@ func EpochsData(w http.ResponseWriter, r *http.Request) {
 				voluntaryexitscount, 
 				validatorscount, 
 				averagevalidatorbalance, 
-				finalized,
 				eligibleether,
 				globalparticipationrate,
-				votedether
+				votedether,
+				completeparticipationstats
 			FROM epochs 
 			WHERE epoch = $1
 			ORDER BY epoch DESC`, search)
@@ -230,9 +230,9 @@ func EpochsData(w http.ResponseWriter, r *http.Request) {
 			b.AttestationsCount,
 			b.DepositsCount,
 			fmt.Sprintf("%v / %v", b.ProposerSlashingsCount, b.AttesterSlashingsCount),
-			utils.FormatYesNo(b.Finalized),
+			utils.FormatYesNo(b.Epoch <= services.LatestFinalizedEpoch()),
 			utils.FormatBalance(b.EligibleEther, currency),
-			utils.FormatGlobalParticipationRate(b.VotedEther, b.GlobalParticipationRate, currency),
+			utils.FormatGlobalParticipationRate(b.VotedEther, b.GlobalParticipationRate, currency, b.ParticipationStatsCompelete),
 		}
 	}
 

--- a/handlers/index.go
+++ b/handlers/index.go
@@ -46,7 +46,7 @@ func Index(w http.ResponseWriter, r *http.Request) {
 		data.DebugTemplates = indexTemplateFiles
 	}
 
-	data.Data.(*types.IndexPageData).ShowSyncingMessage = data.ShowSyncingMessage
+	data.ShowSyncingMessage = data.Data.(*types.IndexPageData).ShowSyncingMessage
 	data.Data.(*types.IndexPageData).Countdown = utils.Config.Frontend.Countdown
 
 	err := indexTemplate.ExecuteTemplate(w, "layout", data)

--- a/rpc/lighthouse.go
+++ b/rpc/lighthouse.go
@@ -384,6 +384,7 @@ func (lc *LighthouseClient) GetEpochData(epoch uint64) (*types.EpochData, error)
 				GlobalParticipationRate: 1.0,
 				VotedEther:              0,
 				EligibleEther:           0,
+				Complete:                false,
 			}
 		}
 	}()
@@ -846,6 +847,7 @@ func (lc *LighthouseClient) GetValidatorParticipation(epoch uint64) (*types.Vali
 			GlobalParticipationRate: float32(parsedResponse.Data.PreviousEpochTargetAttestingGwei) / float32(parsedResponse.Data.PreviousEpochActiveGwei),
 			VotedEther:              uint64(parsedResponse.Data.PreviousEpochTargetAttestingGwei),
 			EligibleEther:           uint64(parsedResponse.Data.PreviousEpochActiveGwei),
+			Complete:                true,
 		}
 	} else {
 		res = &types.ValidatorParticipation{
@@ -853,6 +855,7 @@ func (lc *LighthouseClient) GetValidatorParticipation(epoch uint64) (*types.Vali
 			GlobalParticipationRate: float32(parsedResponse.Data.CurrentEpochTargetAttestingGwei) / float32(parsedResponse.Data.CurrentEpochActiveGwei),
 			VotedEther:              uint64(parsedResponse.Data.CurrentEpochTargetAttestingGwei),
 			EligibleEther:           uint64(parsedResponse.Data.CurrentEpochActiveGwei),
+			Complete:                false,
 		}
 	}
 	return res, nil

--- a/rpc/prysm.go
+++ b/rpc/prysm.go
@@ -1011,6 +1011,7 @@ func (pc *PrysmClient) GetValidatorParticipation(epoch uint64) (*types.Validator
 			GlobalParticipationRate: 0,
 			VotedEther:              0,
 			EligibleEther:           0,
+			Complete:                false,
 		}, nil
 	}
 	return &types.ValidatorParticipation{
@@ -1018,6 +1019,7 @@ func (pc *PrysmClient) GetValidatorParticipation(epoch uint64) (*types.Validator
 		GlobalParticipationRate: epochParticipationStatistics.Participation.GlobalParticipationRate,
 		VotedEther:              epochParticipationStatistics.Participation.VotedEther,
 		EligibleEther:           epochParticipationStatistics.Participation.EligibleEther,
+		Complete:                false,
 	}, nil
 }
 

--- a/services/services.go
+++ b/services/services.go
@@ -381,7 +381,7 @@ func getIndexPageData() (*types.IndexPageData, error) {
 		epoch.FinalizedFormatted = utils.FormatYesNo(epoch.Finalized)
 		epoch.VotedEtherFormatted = utils.FormatBalance(epoch.VotedEther, currency)
 		epoch.EligibleEtherFormatted = utils.FormatBalanceShort(epoch.EligibleEther, currency)
-		epoch.GlobalParticipationRateFormatted = utils.FormatGlobalParticipationRate(epoch.VotedEther, epoch.GlobalParticipationRate, currency)
+		epoch.GlobalParticipationRateFormatted = utils.FormatGlobalParticipationRate(epoch.VotedEther, epoch.GlobalParticipationRate, currency, epoch.ParticipationStatsCompelete)
 	}
 	data.Epochs = epochs
 

--- a/services/services.go
+++ b/services/services.go
@@ -598,5 +598,5 @@ func GetLatestStats() *types.Stats {
 
 // IsSyncing returns true if the chain is still syncing
 func IsSyncing() bool {
-	return time.Now().Add(time.Minute * -10).After(utils.EpochToTime(LatestEpoch()))
+	return LatestNodeEpoch() != LatestEpoch()
 }

--- a/services/services.go
+++ b/services/services.go
@@ -598,5 +598,5 @@ func GetLatestStats() *types.Stats {
 
 // IsSyncing returns true if the chain is still syncing
 func IsSyncing() bool {
-	return LatestNodeEpoch() != LatestEpoch()
+	return LatestEpoch() < LatestNodeEpoch()-1
 }

--- a/services/services.go
+++ b/services/services.go
@@ -227,6 +227,7 @@ func getIndexPageData() (*types.IndexPageData, error) {
 	data.Mainnet = utils.Config.Chain.Config.ConfigName == "mainnet"
 	data.NetworkName = utils.Config.Chain.Config.ConfigName
 	data.DepositContract = utils.Config.Indexer.Eth1DepositContractAddress
+	data.ShowSyncingMessage = IsSyncing()
 
 	var epoch uint64
 	err := db.WriterDb.Get(&epoch, "SELECT COALESCE(MAX(epoch), 0) FROM epochs")

--- a/services/services.go
+++ b/services/services.go
@@ -364,6 +364,17 @@ func getIndexPageData() (*types.IndexPageData, error) {
 		return nil, fmt.Errorf("error retrieving index epoch data: %v", err)
 	}
 
+	if len(epochs) < 15 && currentNodeEpoch >= 15 {
+		// fill in projected epochs
+		for e := currentNodeEpoch - (15 - uint64(len(epochs)) - 1); e <= currentNodeEpoch; e++ {
+			tmp := types.IndexPageDataEpochs{
+				Epoch:                   e,
+				GlobalParticipationRate: 1,
+			}
+			epochs = append([]*types.IndexPageDataEpochs{&tmp}, epochs...)
+		}
+	}
+
 	for _, epoch := range epochs {
 		epoch.Ts = utils.EpochToTime(epoch.Epoch)
 		epoch.Finalized = epoch.Epoch <= finalizedNodeEpoch

--- a/services/services.go
+++ b/services/services.go
@@ -36,23 +36,24 @@ var logger = logrus.New().WithField("module", "services")
 
 // Init will initialize the services
 func Init() {
-	ready.Add(5)
+	ready.Add(4)
 	go epochUpdater()
 	go slotUpdater()
 	go latestProposedSlotUpdater()
 
 	if utils.Config.Frontend.OnlyAPI {
 		ready.Done()
-		ready.Done()
 	} else {
-		go indexPageDataUpdater()
 		go poolsUpdater()
 	}
 	ready.Wait()
-
 	if utils.Config.Frontend.OnlyAPI {
 		return
 	}
+	// we do this after the rest has readied up to ensure we get a complete index page
+	ready.Add(1)
+	go indexPageDataUpdater()
+	ready.Wait()
 
 	if !utils.Config.Frontend.DisableCharts {
 		go chartsPageDataUpdater()

--- a/tables.sql
+++ b/tables.sql
@@ -256,20 +256,20 @@ create table validatorqueue_exit
 drop table if exists epochs;
 create table epochs
 (
-    epoch                   int    not null,
-    blockscount             int    not null default 0,
-    proposerslashingscount  int    not null,
-    attesterslashingscount  int    not null,
-    attestationscount       int    not null,
-    depositscount           int    not null,
-    voluntaryexitscount     int    not null,
-    validatorscount         int    not null,
-    averagevalidatorbalance bigint not null,
-    totalvalidatorbalance   bigint not null,
-    finalized               bool,
-    eligibleether           bigint,
-    globalparticipationrate float,
-    votedether              bigint,
+    epoch                      int    not null,
+    blockscount                int    not null default 0,
+    proposerslashingscount     int    not null,
+    attesterslashingscount     int    not null,
+    attestationscount          int    not null,
+    depositscount              int    not null,
+    voluntaryexitscount        int    not null,
+    validatorscount            int    not null,
+    averagevalidatorbalance    bigint not null,
+    totalvalidatorbalance      bigint not null,
+    completeparticipationstats bool   default false,
+    eligibleether              bigint,
+    globalparticipationrate    float,
+    votedether                 bigint,
     primary key (epoch)
 );
 
@@ -448,6 +448,7 @@ create table network_liveness
     previousjustifiedepoch int not null,
     primary key (ts)
 );
+CREATE INDEX idx_network_liveness_headepoch ON network_liveness (headepoch);
 
 drop table if exists graffitiwall;
 create table graffitiwall

--- a/templates/epoch.html
+++ b/templates/epoch.html
@@ -203,7 +203,7 @@
                 >
               </div>
               <div class="progress" style="height: 5px; width: 250px;">
-                <div class="progress-bar" role="progressbar" style="width: {{ .GlobalParticipationRate | formatPercentage }}%;" aria-valuenow="{{ .GlobalParticipationRate | formatPercentage }}" aria-valuemin="0" aria-valuemax="100"></div>
+                <div class="progress-bar {{ if not .ParticipationStatsCompelete }}progress-bar-striped progress-bar-animated{{ end }}" role="progressbar" style="width: {{ .GlobalParticipationRate | formatPercentage }}%;" aria-valuenow="{{ .GlobalParticipationRate | formatPercentage }}" aria-valuemin="0" aria-valuemax="100"></div>
               </div>
             </div>
           </div>

--- a/templates/index/index.html
+++ b/templates/index/index.html
@@ -150,6 +150,9 @@
                 scheduledCount: function () {
                     return this.page.scheduled_count
                 },
+                syncing: function () {
+                    return this.page.ShowSyncingMessage
+                },
                 epochCompletePercent: function () {
                     return ((32 - this.page.scheduled_count) / 32) * 100
                 }
@@ -171,7 +174,7 @@
                         $.getJSON('/index/data', function (response) {
                             this.page = response;
                         }.bind(this));
-                        this.updateIn = 15;
+                        this.updateIn = 12;
                     } else {
                         this.updateIn--;
                     }

--- a/templates/index/networkStats.html
+++ b/templates/index/networkStats.html
@@ -3,7 +3,7 @@
     <div class="d-flex justify-content-between">
       <div class="p-2">
         <div class="text-secondary mb-0">Epoch</div>
-        <h5 class="font-weight-normal mb-0"><span data-toggle="tooltip" data-placement="top" title="The most recent epoch">${ page.current_epoch.toLocaleString('en-GB') }</span> / <span data-toggle="tooltip" data-placement="top" title="The most recent finalized epoch">${ page.current_finalized_epoch.toLocaleString('en-GB') }</span></h5>
+        <h5 class="font-weight-normal mb-0"><span data-toggle="tooltip" data-placement="top" title="The most recent exported epoch">${ page.current_epoch.toLocaleString('en-GB') }</span> / <span data-toggle="tooltip" data-placement="top" title="The most recent exported finalized epoch">${ page.current_finalized_epoch.toLocaleString('en-GB') }</span></h5>
       </div>
       <div class="text-right p-2">
         <div class="text-secondary mb-0">Current Slot</div>

--- a/templates/index/postGenesis.html
+++ b/templates/index/postGenesis.html
@@ -1,10 +1,9 @@
 {{ define "postGenesis" }}
   <div style="position:relative" class="card mt-3 index-stats">
-    {{ if not .ShowSyncingMessage }}
-      <div style="position:absolute; border-bottom-left-radius: 0; border-bottom-right-radius: 0; font-size:.70rem; height:.8rem;" class="progress w-100" data-placement="bottom" :title="'This epoch is '+ epochCompletePercent +'% complete'">
-        <div :style="'width:' + epochCompletePercent + '%;padding: 0 .3rem;'" class="progress-bar bg-secondary" role="progressbar" :aria-valuenow="scheduledCount" aria-valuemin="0" aria-valuemax="32"><span v-if="scheduledCount > 0">${scheduledCount} / 32 slots left in epoch ${ page.current_epoch }</span><span v-else>${page.current_epoch} epoch complete</span></div>
-      </div>
-    {{ end }}
+    <div style="position:absolute; border-bottom-left-radius: 0; border-bottom-right-radius: 0; font-size:.70rem; height:.8rem;" class="progress w-100" data-placement="bottom" :title="'This epoch is '+ epochCompletePercent +'% complete'">
+      <div v-if="syncing" :style="'width: 100%;padding: 0 .3rem;'" class="progress-bar bg-secondary progress-bar-striped progress-bar-animated" role="progressbar"><span>Exporter is catching up with Chain...</span></div>
+      <div v-else :style="'width:' + epochCompletePercent + '%;padding: 0 .3rem;'" class="progress-bar bg-secondary" role="progressbar" :aria-valuenow="scheduledCount" aria-valuemin="0" aria-valuemax="32"><span v-if="scheduledCount > 0">${scheduledCount} / 32 slots left in epoch ${ page.current_epoch }</span><span v-else>${page.current_epoch} epoch complete</span></div>
+    </div>
     <div class="card-header pt-3">
       <div class="row">
         {{ template "networkStats" }}

--- a/templates/index/postGenesis.html
+++ b/templates/index/postGenesis.html
@@ -1,7 +1,7 @@
 {{ define "postGenesis" }}
   <div style="position:relative" class="card mt-3 index-stats">
     <div style="position:absolute; border-bottom-left-radius: 0; border-bottom-right-radius: 0; font-size:.70rem; height:.8rem;" class="progress w-100" data-placement="bottom" :title="'This epoch is '+ epochCompletePercent +'% complete'">
-      <div v-if="syncing" :style="'width: 100%;padding: 0 .3rem;'" class="progress-bar bg-secondary progress-bar-striped progress-bar-animated" role="progressbar"><span>Exporter is catching up with Chain...</span></div>
+      <div v-if="syncing" :style="'width: 100%;padding: 0 .3rem;'" class="progress-bar bg-secondary progress-bar-striped progress-bar-animated" role="progressbar"><span>Explorer is catching up with Chain...</span></div>
       <div v-else :style="'width:' + epochCompletePercent + '%;padding: 0 .3rem;'" class="progress-bar bg-secondary" role="progressbar" :aria-valuenow="scheduledCount" aria-valuemin="0" aria-valuemax="32"><span v-if="scheduledCount > 0">${scheduledCount} / 32 slots left in epoch ${ page.current_epoch }</span><span v-else>${page.current_epoch} epoch complete</span></div>
     </div>
     <div class="card-header pt-3">

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -193,8 +193,7 @@
                   </div>
                 </div>
               {{ end }}
-            {{ end }}
-            {{ if .ShowSyncingMessage }}
+            {{ else }}
               <div data-toggle="tooltip" title="" data-original-title="The explorer is currently syncing with the network" id="banner-status" class="info-item d-flex mr-1 mr-lg-3">
                 <div class="info-item-body"><i class="fas fa-sync"></i></div>
               </div>

--- a/types/exporter.go
+++ b/types/exporter.go
@@ -54,6 +54,7 @@ type ValidatorParticipation struct {
 	GlobalParticipationRate float32
 	VotedEther              uint64
 	EligibleEther           uint64
+	Complete                bool
 }
 
 // BeaconCommitteItem is a struct to hold beacon committee data

--- a/types/templates.go
+++ b/types/templates.go
@@ -170,6 +170,7 @@ type IndexPageDataEpochs struct {
 	GlobalParticipationRateFormatted template.HTML `json:"globalparticipationrate_formatted"`
 	VotedEther                       uint64        `json:"votedether"`
 	VotedEtherFormatted              template.HTML `json:"votedether_formatted"`
+	ParticipationStatsCompelete      bool          `db:"completeparticipationstats" json:"participation_stats_complete"`
 }
 
 // IndexPageDataBlocks is a struct to hold detail data for the main web page
@@ -200,7 +201,6 @@ type IndexPageEpochHistory struct {
 	Epoch           uint64 `db:"epoch"`
 	ValidatorsCount uint64 `db:"validatorscount"`
 	EligibleEther   uint64 `db:"eligibleether"`
-	Finalized       bool   `db:"finalized"`
 }
 
 // IndexPageDataBlocks is a struct to hold detail data for the main web page
@@ -724,39 +724,40 @@ type DataTableResponse struct {
 
 // EpochsPageData is a struct to hold epoch data for the epochs page
 type EpochsPageData struct {
-	Epoch                   uint64  `db:"epoch"`
-	BlocksCount             uint64  `db:"blockscount"`
-	ProposerSlashingsCount  uint64  `db:"proposerslashingscount"`
-	AttesterSlashingsCount  uint64  `db:"attesterslashingscount"`
-	AttestationsCount       uint64  `db:"attestationscount"`
-	DepositsCount           uint64  `db:"depositscount"`
-	VoluntaryExitsCount     uint64  `db:"voluntaryexitscount"`
-	ValidatorsCount         uint64  `db:"validatorscount"`
-	AverageValidatorBalance uint64  `db:"averagevalidatorbalance"`
-	Finalized               bool    `db:"finalized"`
-	EligibleEther           uint64  `db:"eligibleether"`
-	GlobalParticipationRate float64 `db:"globalparticipationrate"`
-	VotedEther              uint64  `db:"votedether"`
+	Epoch                       uint64  `db:"epoch"`
+	BlocksCount                 uint64  `db:"blockscount"`
+	ProposerSlashingsCount      uint64  `db:"proposerslashingscount"`
+	AttesterSlashingsCount      uint64  `db:"attesterslashingscount"`
+	AttestationsCount           uint64  `db:"attestationscount"`
+	DepositsCount               uint64  `db:"depositscount"`
+	VoluntaryExitsCount         uint64  `db:"voluntaryexitscount"`
+	ValidatorsCount             uint64  `db:"validatorscount"`
+	AverageValidatorBalance     uint64  `db:"averagevalidatorbalance"`
+	ParticipationStatsCompelete bool    `db:"completeparticipationstats"`
+	EligibleEther               uint64  `db:"eligibleether"`
+	GlobalParticipationRate     float64 `db:"globalparticipationrate"`
+	VotedEther                  uint64  `db:"votedether"`
 }
 
 // EpochPageData is a struct to hold detailed epoch data for the epoch page
 type EpochPageData struct {
-	Epoch                   uint64  `db:"epoch"`
-	BlocksCount             uint64  `db:"blockscount"`
-	ProposerSlashingsCount  uint64  `db:"proposerslashingscount"`
-	AttesterSlashingsCount  uint64  `db:"attesterslashingscount"`
-	AttestationsCount       uint64  `db:"attestationscount"`
-	DepositsCount           uint64  `db:"depositscount"`
-	VoluntaryExitsCount     uint64  `db:"voluntaryexitscount"`
-	ValidatorsCount         uint64  `db:"validatorscount"`
-	AverageValidatorBalance uint64  `db:"averagevalidatorbalance"`
-	Finalized               bool    `db:"finalized"`
-	EligibleEther           uint64  `db:"eligibleether"`
-	GlobalParticipationRate float64 `db:"globalparticipationrate"`
-	VotedEther              uint64  `db:"votedether"`
+	Epoch                       uint64  `db:"epoch"`
+	BlocksCount                 uint64  `db:"blockscount"`
+	ProposerSlashingsCount      uint64  `db:"proposerslashingscount"`
+	AttesterSlashingsCount      uint64  `db:"attesterslashingscount"`
+	AttestationsCount           uint64  `db:"attestationscount"`
+	DepositsCount               uint64  `db:"depositscount"`
+	VoluntaryExitsCount         uint64  `db:"voluntaryexitscount"`
+	ValidatorsCount             uint64  `db:"validatorscount"`
+	AverageValidatorBalance     uint64  `db:"averagevalidatorbalance"`
+	ParticipationStatsCompelete bool    `db:"completeparticipationstats"`
+	EligibleEther               uint64  `db:"eligibleether"`
+	GlobalParticipationRate     float64 `db:"globalparticipationrate"`
+	VotedEther                  uint64  `db:"votedether"`
 
 	Blocks []*IndexPageDataBlocks
 
+	Finalized             bool
 	SyncParticipationRate float64
 	Ts                    time.Time
 	NextEpoch             uint64

--- a/utils/format.go
+++ b/utils/format.go
@@ -149,6 +149,10 @@ func FormatBalanceChange(balance *int64, currency string) template.HTML {
 
 // FormatBalance will return a string for a balance
 func FormatBalanceShort(balanceInt uint64, currency string) template.HTML {
+	if balanceInt == 0.0 {
+		return template.HTML("Exporting...")
+	}
+
 	exchangeRate := ExchangeRateForCurrency(currency)
 	balance := FormatFloat((float64(balanceInt)/float64(1e9))*float64(exchangeRate), 2)
 

--- a/utils/format.go
+++ b/utils/format.go
@@ -339,17 +339,21 @@ func FormatEth1TxHash(hash []byte) template.HTML {
 }
 
 // FormatGlobalParticipationRate will return the global-participation-rate formated as html
-func FormatGlobalParticipationRate(e uint64, r float64, currency string) template.HTML {
+func FormatGlobalParticipationRate(e uint64, r float64, currency string, complete bool) template.HTML {
 	p := message.NewPrinter(language.English)
 	rr := fmt.Sprintf("%.2f%%", r*100)
 	tpl := `
 	<div style="position:relative;width:inherit;height:inherit;">
 	  %.0[1]f <small class="text-muted ml-3">(%[2]v)</small>
 	  <div class="progress" style="position:absolute;bottom:-6px;width:100%%;height:4px;">
-		<div class="progress-bar" role="progressbar" style="width: %[2]v;" aria-valuenow="%[2]v" aria-valuemin="0" aria-valuemax="100"></div>
+		<div class="progress-bar %[3]v" role="progressbar" style="width: %[2]v;" aria-valuenow="%[2]v" aria-valuemin="0" aria-valuemax="100"></div>
 	  </div>
 	</div>`
-	return template.HTML(p.Sprintf(tpl, float64(e)/1e9*price.GetEthPrice(currency), rr))
+	var incomplete_style string
+	if !complete {
+		incomplete_style = "progress-bar-striped progress-bar-animated"
+	}
+	return template.HTML(p.Sprintf(tpl, float64(e)/1e9*price.GetEthPrice(currency), rr, incomplete_style))
 }
 
 // FormatGraffiti will return the graffiti formated as html


### PR DESCRIPTION
> **Note**
> needs to be tested with bigtable changes

-----

- the `finalized` column has been renamed to `completeparticipationstats` and now tracks if the participation stats have been requested using the epoch after it.
    - this flag is used to style the participation progress bar as an intermediate type if false: ![image](https://user-images.githubusercontent.com/110384239/185879655-bc66fb1b-d6c6-40bc-895c-245bc5d7b9ec.png)
    - this flag would also allow us to more easily save redundant epoch statistics exports in the future (dont need to update them if they are complete and the epoch is finalized) 
 - a value of 0 for the eligible ether column is now rendered as `Exporting ...` 
![image](https://user-images.githubusercontent.com/110384239/185884508-b7c12935-47ff-4786-999f-364029251bc2.png)
- epochs that haven't been exported yet are shown on the index page ![image](https://user-images.githubusercontent.com/110384239/185884646-7d21e5e5-2d8f-4d83-9285-46deaaaa91c4.png)
- fixed the "syncing" state not being set correctly on initial index load ![image](https://user-images.githubusercontent.com/110384239/185884839-f520a582-7777-4c41-9a92-6e3822ba9959.png) 
- the index page progress bar is now aware of the sync state ![image](https://user-images.githubusercontent.com/110384239/185884924-35faeab7-fbee-4c68-9698-6ea45fe93489.png)
- finality delay is now always calculated using epoch numbers from the node, preventing false positives during explorer sync
- API should be unaffected, as the finality for epochs is simply calculated on demand. unexported epochs are not exposed over the API and only exist virtually on the index page.
- the app checks for finality issues using epoch participation, so unaffected by this change.

