### PR TITLE
templates: add missing states to `/validators` filter check on load

### DIFF
--- a/templates/validators.html
+++ b/templates/validators.html
@@ -80,6 +80,8 @@
                 slashing: true,
                 exiting: true,
                 exited: true,
+                voluntary: true,
+                deposited: true
             };
             if (window.location.hash) {
                 var hashState = window.location.hash.substring(1);


### PR DESCRIPTION
hash state was getting ignored due to an outdated `possibleStates` object