### PR TITLE
Fetch total slot per epoch from chain config

### DIFF
--- a/handlers/index.go
+++ b/handlers/index.go
@@ -46,6 +46,7 @@ func Index(w http.ResponseWriter, r *http.Request) {
 		data.DebugTemplates = indexTemplateFiles
 	}
 
+	data.Data.(*types.IndexPageData).ChainSlotsPerEpoch = data.ChainSlotsPerEpoch
 	data.Data.(*types.IndexPageData).ShowSyncingMessage = data.ShowSyncingMessage
 	data.Data.(*types.IndexPageData).Countdown = utils.Config.Frontend.Countdown
 

--- a/services/services.go
+++ b/services/services.go
@@ -202,6 +202,7 @@ func getIndexPageData() (*types.IndexPageData, error) {
 	currency := "ETH"
 
 	data := &types.IndexPageData{}
+	data.ChainSlotsPerEpoch = utils.Config.Chain.Config.SlotsPerEpoch
 	data.Mainnet = utils.Config.Chain.Config.ConfigName == "mainnet"
 	data.NetworkName = utils.Config.Chain.Config.ConfigName
 	data.DepositContract = utils.Config.Indexer.Eth1DepositContractAddress

--- a/templates/index/index.html
+++ b/templates/index/index.html
@@ -151,7 +151,8 @@
                     return this.page.scheduled_count
                 },
                 epochCompletePercent: function () {
-                    return ((32 - this.page.scheduled_count) / 32) * 100
+                    var slotsPerEpoch = {{.ChainSlotsPerEpoch}}
+                    return ((slotsPerEpoch - this.page.scheduled_count) / slotsPerEpoch) * 100
                 }
             },
             filters: {

--- a/templates/index/postGenesis.html
+++ b/templates/index/postGenesis.html
@@ -2,7 +2,7 @@
   <div style="position:relative" class="card mt-3 index-stats">
     {{ if not .ShowSyncingMessage }}
       <div style="position:absolute; border-bottom-left-radius: 0; border-bottom-right-radius: 0; font-size:.70rem; height:.8rem;" class="progress w-100" data-placement="bottom" :title="'This epoch is '+ epochCompletePercent +'% complete'">
-        <div :style="'width:' + epochCompletePercent + '%;padding: 0 .3rem;'" class="progress-bar bg-secondary" role="progressbar" :aria-valuenow="scheduledCount" aria-valuemin="0" aria-valuemax="32"><span v-if="scheduledCount > 0">${scheduledCount} / 32 slots left in epoch ${ page.current_epoch }</span><span v-else>${page.current_epoch} epoch complete</span></div>
+        <div :style="'width:' + epochCompletePercent + '%;padding: 0 .3rem;'" class="progress-bar bg-secondary" role="progressbar" :aria-valuenow="scheduledCount" aria-valuemin="0" aria-valuemax="{{.ChainSlotsPerEpoch}}"><span v-if="scheduledCount > 0">${scheduledCount} / {{.ChainSlotsPerEpoch}}slots left in epoch ${ page.current_epoch }</span><span v-else>${page.current_epoch} epoch complete</span></div>
       </div>
     {{ end }}
     <div class="card-header pt-3">

--- a/types/templates.go
+++ b/types/templates.go
@@ -134,6 +134,7 @@ type IndexPageData struct {
 	CurrentEpoch              uint64                 `json:"current_epoch"`
 	CurrentFinalizedEpoch     uint64                 `json:"current_finalized_epoch"`
 	CurrentSlot               uint64                 `json:"current_slot"`
+	ChainSlotsPerEpoch        uint64                 `json:"chain_slots_per_epoch"`
 	ScheduledCount            uint8                  `json:"scheduled_count"`
 	FinalityDelay             uint64                 `json:"finality_delay"`
 	ActiveValidators          uint64                 `json:"active_validators"`


### PR DESCRIPTION
Post genesis chart was displaying slots per epoch as 32 statically,
this is a chain configuration parameter and should not be static