### PR TITLE
fix typo on most recent blocks modal

### DIFF
--- a/templates/index/recentBlocks.html
+++ b/templates/index/recentBlocks.html
@@ -13,7 +13,7 @@
             <tr>
               <th>Epoch</th>
               <th>Slot</th>
-              <th data-toggle="tooltip" title="Ececution Layer Block Number">Block</th>
+              <th data-toggle="tooltip" title="Execution Layer Block Number">Block</th>
               <th>Status</th>
               <th>Time</th>
               <th>Proposer</th>


### PR DESCRIPTION
This PR simply fixes a typo in the tooltip for "Blocks" on the "Most recent blocks" modal on the main page