### PR TITLE
implement "validator offline" and "validator back online" notifications + fix discord notifs

### DIFF
--- a/handlers/modals.go
+++ b/handlers/modals.go
@@ -174,6 +174,7 @@ func UserModalManageNotificationModal(w http.ResponseWriter, r *http.Request) {
 	events[types.ValidatorExecutedProposalEventName] = r.FormValue(string(types.ValidatorExecutedProposalEventName)) == "on"
 	events[types.ValidatorGotSlashedEventName] = r.FormValue(string(types.ValidatorGotSlashedEventName)) == "on"
 	events[types.SyncCommitteeSoon] = r.FormValue(string(types.SyncCommitteeSoon)) == "on"
+	events[types.ValidatorIsOfflineEventName] = r.FormValue(string(types.ValidatorIsOfflineEventName)) == "on"
 
 	all := r.FormValue("all") == "on"
 

--- a/handlers/user.go
+++ b/handlers/user.go
@@ -2433,7 +2433,7 @@ func NotificationWebhookPage(w http.ResponseWriter, r *http.Request) {
 			Active:     utils.ElementExists(wh.EventNames, string(types.SyncCommitteeSoon)),
 		})
 		events = append(events, types.EventNameCheckbox{
-			EventLabel: "Validator Is Offline",
+			EventLabel: "Validator is Offline",
 			EventName:  types.ValidatorIsOfflineEventName,
 			Active:     utils.ElementExists(wh.EventNames, string(types.ValidatorIsOfflineEventName)),
 		})
@@ -2527,7 +2527,7 @@ func NotificationWebhookPage(w http.ResponseWriter, r *http.Request) {
 		EventName:  types.SyncCommitteeSoon,
 	})
 	events = append(events, types.EventNameCheckbox{
-		EventLabel: "Validator Is Offline",
+		EventLabel: "Validator is Offline",
 		EventName:  types.ValidatorIsOfflineEventName,
 	})
 	events = append(events, types.EventNameCheckbox{

--- a/handlers/user.go
+++ b/handlers/user.go
@@ -2433,6 +2433,11 @@ func NotificationWebhookPage(w http.ResponseWriter, r *http.Request) {
 			Active:     utils.ElementExists(wh.EventNames, string(types.SyncCommitteeSoon)),
 		})
 		events = append(events, types.EventNameCheckbox{
+			EventLabel: "Validator Is Offline",
+			EventName:  types.ValidatorIsOfflineEventName,
+			Active:     utils.ElementExists(wh.EventNames, string(types.ValidatorIsOfflineEventName)),
+		})
+		events = append(events, types.EventNameCheckbox{
 			EventLabel: "Machine Offline",
 			EventName:  types.MonitoringMachineOfflineEventName,
 			Active:     utils.ElementExists(wh.EventNames, string(types.MonitoringMachineOfflineEventName)),
@@ -2522,6 +2527,10 @@ func NotificationWebhookPage(w http.ResponseWriter, r *http.Request) {
 		EventName:  types.SyncCommitteeSoon,
 	})
 	events = append(events, types.EventNameCheckbox{
+		EventLabel: "Validator Is Offline",
+		EventName:  types.ValidatorIsOfflineEventName,
+	})
+	events = append(events, types.EventNameCheckbox{
 		EventLabel: "Machine Offline",
 		EventName:  types.MonitoringMachineOfflineEventName,
 	})
@@ -2572,6 +2581,7 @@ func UsersAddWebhook(w http.ResponseWriter, r *http.Request) {
 	validatorProposalSubmitted := r.FormValue(string(types.ValidatorExecutedProposalEventName)) == "on"
 	validatorGotSlashed := r.FormValue(string(types.ValidatorGotSlashedEventName)) == "on"
 	validatorSyncCommiteeSoon := r.FormValue(string(types.SyncCommitteeSoon)) == "on"
+	validatorIsOffline := r.FormValue(string(types.ValidatorIsOfflineEventName)) == "on"
 	monitoringMachineOffline := r.FormValue(string(types.MonitoringMachineOfflineEventName)) == "on"
 	monitoringHddAlmostfull := r.FormValue(string(types.MonitoringMachineDiskAlmostFullEventName)) == "on"
 	monitoringCpuLoad := r.FormValue(string(types.MonitoringMachineCpuLoadEventName)) == "on"
@@ -2590,6 +2600,7 @@ func UsersAddWebhook(w http.ResponseWriter, r *http.Request) {
 	events[string(types.ValidatorExecutedProposalEventName)] = validatorProposalSubmitted
 	events[string(types.ValidatorGotSlashedEventName)] = validatorGotSlashed
 	events[string(types.SyncCommitteeSoon)] = validatorSyncCommiteeSoon
+	events[string(types.ValidatorIsOfflineEventName)] = validatorIsOffline
 	events[string(types.MonitoringMachineOfflineEventName)] = monitoringMachineOffline
 	events[string(types.MonitoringMachineDiskAlmostFullEventName)] = monitoringHddAlmostfull
 	events[string(types.MonitoringMachineCpuLoadEventName)] = monitoringCpuLoad
@@ -2717,6 +2728,7 @@ func UsersEditWebhook(w http.ResponseWriter, r *http.Request) {
 	validatorProposalSubmitted := r.FormValue(string(types.ValidatorExecutedProposalEventName)) == "on"
 	validatorGotSlashed := r.FormValue(string(types.ValidatorGotSlashedEventName)) == "on"
 	validatorSyncCommiteeSoon := r.FormValue(string(types.SyncCommitteeSoon)) == "on"
+	validatorIsOffline := r.FormValue(string(types.ValidatorIsOfflineEventName)) == "on"
 	monitoringMachineOffline := r.FormValue(string(types.MonitoringMachineOfflineEventName)) == "on"
 	monitoringHddAlmostfull := r.FormValue(string(types.MonitoringMachineDiskAlmostFullEventName)) == "on"
 	monitoringCpuLoad := r.FormValue(string(types.MonitoringMachineCpuLoadEventName)) == "on"
@@ -2735,6 +2747,7 @@ func UsersEditWebhook(w http.ResponseWriter, r *http.Request) {
 	events[string(types.ValidatorExecutedProposalEventName)] = validatorProposalSubmitted
 	events[string(types.ValidatorGotSlashedEventName)] = validatorGotSlashed
 	events[string(types.SyncCommitteeSoon)] = validatorSyncCommiteeSoon
+	events[string(types.ValidatorIsOfflineEventName)] = validatorIsOffline
 	events[string(types.MonitoringMachineOfflineEventName)] = monitoringMachineOffline
 	events[string(types.MonitoringMachineDiskAlmostFullEventName)] = monitoringHddAlmostfull
 	events[string(types.MonitoringMachineCpuLoadEventName)] = monitoringCpuLoad

--- a/services/notifications.go
+++ b/services/notifications.go
@@ -923,9 +923,9 @@ func queueWebhookNotifications(notificationsByUserID map[uint64]map[types.EventN
 									Webhook: w,
 									Event: types.WebhookEvent{
 										Network:     utils.GetNetwork(),
-									Name:        string(n.GetEventName()),
-									Title:       n.GetTitle(),
-									Description: n.GetInfo(false),
+										Name:        string(n.GetEventName()),
+										Title:       n.GetTitle(),
+										Description: n.GetInfo(false),
 										Epoch:       n.GetEpoch(),
 										Target:      n.GetEventFilter(),
 									},

--- a/services/notifications.go
+++ b/services/notifications.go
@@ -1572,7 +1572,7 @@ func collectOfflineValidatorNotifications(notificationsByUserID map[uint64]map[t
 						continue
 					}
 					// validator is currently bellow threshold and was previously reported as offline
-					// note: this doesn't necessarily guarantee that epochsSinceOffline is larger than EventThreshold specified by the sub
+					// note: this doesn't necessarily guarantee that epochsSinceOffline is larger than or equal to EventThreshold specified by the sub
 					//       if an attestation for the exported epoch gets included in the one after it, epochsSinceOffline might end up as EventThreshold - 1
 					//       in this scenario we still want to trigger the "back online notifcation", as otherwise the user might think they are still offline
 					originalLastSeenEpoch, err := strconv.ParseUint(sub.State.String, 10, 64)

--- a/services/notifications.go
+++ b/services/notifications.go
@@ -1487,7 +1487,7 @@ func collectOfflineValidatorNotifications(notificationsByUserID map[uint64]map[t
 	// we use the latest exported epoch because that's what the lastattestationslot column is based upon
 	// note: could trigger missfires if there are gaps in the epoch processing.
 	// unless we do a choerence check this is hard to avoid
-	err := db.PraterReaderDb.Get(&latestExportedEpoch, `select epoch from epochs where eligibleether <> 0 order by epoch desc limit 1`)
+	err := db.ReaderDb.Get(&latestExportedEpoch, `select epoch from epochs where eligibleether <> 0 order by epoch desc limit 1`)
 	if err != nil {
 		logger.Infof("failed to get last exported epoch: %v", err)
 	}
@@ -1522,7 +1522,7 @@ func collectOfflineValidatorNotifications(notificationsByUserID map[uint64]map[t
 			LastAttestationSlot sql.NullInt64 `db:"lastattestationslot"`
 			Pubkey              []byte        `db:"pubkey"`
 		}
-		err = db.PraterReaderDb.Select(&dataArr, `select validatorindex, pubkey, lastattestationslot from validators where pubkey = ANY($1) order by validatorindex`, pq.ByteaArray(batch))
+		err = db.ReaderDb.Select(&dataArr, `select validatorindex, pubkey, lastattestationslot from validators where pubkey = ANY($1) order by validatorindex`, pq.ByteaArray(batch))
 		if err != nil {
 			return fmt.Errorf("failed to query potenitally offline validators: %v", err)
 		}

--- a/services/notifications.go
+++ b/services/notifications.go
@@ -1127,7 +1127,6 @@ func sendDiscordNotifications(useDB *sqlx.DB) error {
 					break // stop
 				}
 				// sleep between retries
-				logger.Infof("sleeping for %v", webhook.Retries)
 				time.Sleep(time.Duration(webhook.Retries) * time.Second)
 
 				reqBody := new(bytes.Buffer)
@@ -1782,7 +1781,7 @@ func (n *validatorIsOfflineNotification) GetInfo(includeUrl bool) string {
 
 func (n *validatorIsOfflineNotification) GetTitle() string {
 	if n.IsOffline {
-		return "Validator Is Offline"
+		return "Validator is Offline"
 	} else {
 		return "Validator Back Online"
 	}

--- a/static/js/notificationsCenter.js
+++ b/static/js/notificationsCenter.js
@@ -1,6 +1,6 @@
 var csrfToken = ""
 
-const VALIDATOR_EVENTS = ["validator_attestation_missed", "validator_proposal_missed", "validator_proposal_submitted", "validator_got_slashed", "validator_synccommittee_soon"]
+const VALIDATOR_EVENTS = ["validator_attestation_missed", "validator_proposal_missed", "validator_proposal_submitted", "validator_got_slashed", "validator_synccommittee_soon", "validator_is_offline"]
 
 // const MONITORING_EVENTS = ['monitoring_machine_offline', 'monitoring_hdd_almostfull', 'monitoring_cpu_load']
 
@@ -572,6 +572,9 @@ function loadValidatorsData(data) {
                     badgeColor = "badge-light"
                     break
                   case "validator_synccommittee_soon":
+                    badgeColor = "badge-light"
+                    break
+                  case "validator_is_offline":
                     badgeColor = "badge-light"
                     break
                 }

--- a/tables.sql
+++ b/tables.sql
@@ -552,7 +552,6 @@ create table users_subscriptions
     created_ts        timestamp without time zone not null,
     created_epoch     int                         not null,
     unsubscribe_hash  bytea,
-	channels          _text,
     internal_state    varchar,
     primary key (user_id, event_name, event_filter)
 );

--- a/tables.sql
+++ b/tables.sql
@@ -34,6 +34,7 @@ create index idx_validators_pubkeyhex_pattern_pos on validators (pubkeyhex varch
 create index idx_validators_status on validators (status);
 create index idx_validators_balanceactivation on validators (balanceactivation);
 create index idx_validators_activationepoch on validators (activationepoch);
+CREATE INDEX validators_is_offline_vali_idx ON validators (validatorindex, lastattestationslot, pubkey);
 
 drop table if exists validator_pool;
 create table validator_pool

--- a/tables.sql
+++ b/tables.sql
@@ -551,7 +551,9 @@ create table users_subscriptions
     last_sent_epoch   int,
     created_ts        timestamp without time zone not null,
     created_epoch     int                         not null,
-    unsubscribe_hash  bytea                        ,
+    unsubscribe_hash  bytea,
+	channels          _text,
+    internal_state    varchar,
     primary key (user_id, event_name, event_filter)
 );
 create index idx_users_subscriptions_unsubscribe_hash on users_subscriptions (unsubscribe_hash);

--- a/templates/modals.html
+++ b/templates/modals.html
@@ -23,7 +23,12 @@
               {{ range $i, $event := .Events }}
                 <div class="input-group my-1">
                   <div class="form-check form-check-inline w-100">
-                    <label for="watchlist_{{ $event.EventName }}" class="form-check-label mr-auto font-weight-normal py-2">{{ $event.EventLabel }}</label>
+                    <label for="watchlist_{{ $event.EventName }}" class="form-check-label mr-auto font-weight-normal py-2">
+                      {{ $event.EventLabel }}
+                      {{ if eq $event.EventName "validator_attestation_missed" }}
+                        <i data-toggle="tooltip" title="Will trigger every epoch (6.4 minutes) during downtime" class="fas fa-exclamation-circle text-warning"></i>
+                      {{ end }}
+                    </label>
                     <input {{ if $event.Active }}checked{{ end }} name="{{ $event.EventName }}" class="form-check-input checkbox-custom-size ml-2 mr-0" type="checkbox" id="watchlist_{{ $event.EventName }}" />
                   </div>
                 </div>
@@ -137,7 +142,12 @@
               {{ range $i, $event := .Events }}
                 <div class="input-group my-1">
                   <div class="form-check form-check-inline w-100">
-                    <label for="watchlist-selected-{{ $event.EventName }}" class="form-check-label mr-auto font-weight-normal py-2">{{ $event.EventLabel }}</label>
+                    <label for="watchlist-selected-{{ $event.EventName }}" class="form-check-label mr-auto font-weight-normal py-2">
+                      {{ $event.EventLabel }}
+                      {{ if eq $event.EventName "validator_attestation_missed" }}
+                        <i data-toggle="tooltip" title="Will trigger every epoch (6.4 minutes) during downtime." class="fas fa-exclamation-circle text-warning"></i>
+                      {{ end }}
+                    </label>
                     <input {{ if $event.Active }}checked{{ end }} name="{{ $event.EventName }}" class="form-check-input checkbox-custom-size ml-2 mr-0" type="checkbox" id="watchlist-selected-{{ $event.EventName }}" />
                   </div>
                 </div>

--- a/templates/user/notifications.html
+++ b/templates/user/notifications.html
@@ -10,6 +10,7 @@
       validator_got_slashed: "validator slashed",
       validator_proposal_missed: "proposals missed",
       validator_proposal_submitted: "proposals submitted",
+      validator_is_offline: "validator is offline",
       eth_client_update: "eth client update",
       user_tax_report: "monthly report",
       monitoring_machine_offline: "machine offline",
@@ -25,6 +26,7 @@
       ["validator_proposal_missed", "proposals missed"],
       ["validator_attestation_missed", "attestations missed"],
       ["validator_synccommittee_soon", "sync committee"],
+      ["validator_is_offline", "validator is offline"],
     ]
 
     function createCheckbox(filter, event, checked, text) {

--- a/types/frontend.go
+++ b/types/frontend.go
@@ -23,7 +23,7 @@ const (
 	ValidatorMissedAttestationEventName              EventName = "validator_attestation_missed"
 	ValidatorGotSlashedEventName                     EventName = "validator_got_slashed"
 	ValidatorDidSlashEventName                       EventName = "validator_did_slash"
-	ValidatorStateChangedEventName                   EventName = "validator_state_changed"
+	ValidatorIsOfflineEventName                      EventName = "validator_is_offline"
 	ValidatorReceivedDepositEventName                EventName = "validator_received_deposit"
 	NetworkSlashingEventName                         EventName = "network_slashing"
 	NetworkValidatorActivationQueueFullEventName     EventName = "network_validator_activation_queue_full"
@@ -65,7 +65,7 @@ var EventLabel map[EventName]string = map[EventName]string{
 	ValidatorMissedAttestationEventName:              "Your validator(s) missed an attestation",
 	ValidatorGotSlashedEventName:                     "Your validator(s) got slashed",
 	ValidatorDidSlashEventName:                       "Your validator(s) slashed another validator",
-	ValidatorStateChangedEventName:                   "Your validator(s) state changed",
+	ValidatorIsOfflineEventName:                      "Your validator(s) state changed",
 	ValidatorReceivedDepositEventName:                "Your validator(s) received a deposit",
 	NetworkSlashingEventName:                         "A slashing event has been registered by the network",
 	NetworkValidatorActivationQueueFullEventName:     "The activation queue is full",
@@ -104,7 +104,7 @@ var EventNames = []EventName{
 	ValidatorMissedAttestationEventName,
 	ValidatorGotSlashedEventName,
 	ValidatorDidSlashEventName,
-	ValidatorStateChangedEventName,
+	ValidatorIsOfflineEventName,
 	ValidatorReceivedDepositEventName,
 	NetworkSlashingEventName,
 	NetworkValidatorActivationQueueFullEventName,
@@ -154,6 +154,10 @@ var AddWatchlistEvents = []EventNameDesc{
 		Desc:  "Sync committee",
 		Event: SyncCommitteeSoon,
 	},
+	{
+		Desc:  "Validator Is Offline",
+		Event: ValidatorIsOfflineEventName,
+	},
 }
 
 // this is the source of truth for the network events that are supported by the user/notification page
@@ -188,6 +192,7 @@ const (
 )
 
 type Notification interface {
+	GetLatestState() string
 	GetSubscriptionID() uint64
 	GetEventName() EventName
 	GetEpoch() uint64
@@ -213,6 +218,7 @@ type Subscription struct {
 	CreatedEpoch    uint64         `db:"created_epoch"`
 	EventThreshold  float64        `db:"event_threshold"`
 	UnsubscribeHash sql.NullString `db:"unsubscribe_hash" swaggertype:"string"`
+	State           sql.NullString `db:"internal_state"`
 }
 
 type TaggedValidators struct {

--- a/types/frontend.go
+++ b/types/frontend.go
@@ -155,7 +155,7 @@ var AddWatchlistEvents = []EventNameDesc{
 		Event: SyncCommitteeSoon,
 	},
 	{
-		Desc:  "Validator Is Offline",
+		Desc:  "Validator is Offline",
 		Event: ValidatorIsOfflineEventName,
 	},
 }

--- a/types/frontend.go
+++ b/types/frontend.go
@@ -218,7 +218,7 @@ type Subscription struct {
 	CreatedEpoch    uint64         `db:"created_epoch"`
 	EventThreshold  float64        `db:"event_threshold"`
 	UnsubscribeHash sql.NullString `db:"unsubscribe_hash" swaggertype:"string"`
-	State           sql.NullString `db:"internal_state"`
+	State           sql.NullString `db:"internal_state" swaggertype:"string"`
 }
 
 type TaggedValidators struct {


### PR DESCRIPTION
migration: 
```sql
ALTER TABLE users_subscriptions ADD COLUMN IF NOT EXISTS internal_state varchar;
CREATE INDEX CONCURRENTLY IF NOT exists validators_is_offline_vali_idx ON validators (validatorindex, lastattestationslot, pubkey);
```
also includes fixes for discord notifications: requests per webhook are now done sequentially and rate limiting is handled correctly.
oh and discord embeds also now get batched to reduce webhook load & speed up processing.
![image](https://user-images.githubusercontent.com/110384239/194847187-4ae604ba-98bc-4815-8ec4-d9d74a30c482.png)
![image](https://user-images.githubusercontent.com/110384239/194847305-3b7dc7ed-0d74-4b87-a168-a872522981a7.png)
