### PR TITLE
Adjust FormatBalanceChange to be more informative

### DIFF
--- a/utils/format.go
+++ b/utils/format.go
@@ -139,9 +139,9 @@ func FormatBalanceChange(balance *int64, currency string) template.HTML {
 		}
 
 		if balanceF < 0 {
-			return template.HTML(fmt.Sprintf("<span title=\"%.0f GWei\" data-toggle=\"tooltip\" class=\"text-danger\">%.5f ETH</span>", float64(*balance), balanceF))
+			return template.HTML(fmt.Sprintf("<span class=\"text-danger float-right\">%.0f GWei</span>", float64(*balance)))
 		}
-		return template.HTML(fmt.Sprintf("<span title=\"%.0f GWei\" data-toggle=\"tooltip\" class=\"text-success\">+%.5f ETH</span>", float64(*balance), balanceF))
+		return template.HTML(fmt.Sprintf("<span class=\"text-success float-right\">+%.0f GWei</span>", float64(*balance)))
 	} else {
 		if balance == nil {
 			return template.HTML("<span> 0 " + currency + "</span>")


### PR DESCRIPTION
This PR changes the way the balance change is shown in the validator history table - in Gwei. With current reward levels, the value shown in the table before this PR is of limited value as only the last digit changes.

Addresses #1579


Before             |  After
:-------------------------:|:-------------------------:
<img width="350" alt="before" src="https://user-images.githubusercontent.com/70237279/195341421-1df3697e-5036-42f7-9d51-dc4903b32cb9.png"> | <img width="350" alt="after" src="https://user-images.githubusercontent.com/70237279/195341445-e179edb3-c1fb-4e0f-9e6b-0762cb8f7123.png">
<img width="350" alt="before-2" src="https://user-images.githubusercontent.com/70237279/195342258-4a6cd237-3d20-4166-a030-93ba9c913677.png"> | <img width="350" alt="after-2" src="https://user-images.githubusercontent.com/70237279/195342282-d467f95a-4d25-41ee-b4ad-62419f9a406c.png">
