### PR TITLE
Execution APIs: Blocks & Execution Rewards in Charts & MEV-Boost Client Updates

### DIFF
--- a/cmd/explorer/main.go
+++ b/cmd/explorer/main.go
@@ -404,6 +404,7 @@ func main() {
 			router.HandleFunc("/dashboard", handlers.Dashboard).Methods("GET")
 			router.HandleFunc("/dashboard/save", handlers.UserDashboardWatchlistAdd).Methods("POST")
 
+			router.HandleFunc("/dashboard/data/allbalances", handlers.DashboardDataBalanceCombined).Methods("GET")
 			router.HandleFunc("/dashboard/data/balance", handlers.DashboardDataBalance).Methods("GET")
 			router.HandleFunc("/dashboard/data/proposals", handlers.DashboardDataProposals).Methods("GET")
 			router.HandleFunc("/dashboard/data/proposalshistory", handlers.DashboardDataProposalsHistory).Methods("GET")

--- a/cmd/explorer/main.go
+++ b/cmd/explorer/main.go
@@ -272,6 +272,8 @@ func main() {
 		apiV1Router.HandleFunc("/rocketpool/stats", handlers.ApiRocketpoolStats).Methods("GET", "OPTIONS")
 		apiV1Router.HandleFunc("/rocketpool/validator/{indexOrPubkey}", handlers.ApiRocketpoolValidators).Methods("GET", "OPTIONS")
 		apiV1Router.HandleFunc("/ethstore/{day}", handlers.ApiEthStoreDay).Methods("GET", "OPTIONS")
+		apiV1Router.HandleFunc("/execution/{addressIndexOrPubkey}/produced", handlers.ApiETH1AccountProducedBlocks).Methods("GET", "OPTIONS")
+		apiV1Router.HandleFunc("/execution/block/{blockNumber}", handlers.ApiETH1ExecBlocks).Methods("GET", "OPTIONS")
 
 		apiV1Router.HandleFunc("/validator/{indexOrPubkey}/widget", handlers.GetMobileWidgetStatsGet).Methods("GET")
 		apiV1Router.HandleFunc("/dashboard/widget", handlers.GetMobileWidgetStatsPost).Methods("POST")

--- a/cmd/explorer/main.go
+++ b/cmd/explorer/main.go
@@ -261,8 +261,9 @@ func main() {
 		apiV1Router.HandleFunc("/graffitiwall", handlers.ApiGraffitiwall).Methods("GET", "OPTIONS")
 		apiV1Router.HandleFunc("/chart/{chart}", handlers.ApiChart).Methods("GET", "OPTIONS")
 		apiV1Router.HandleFunc("/user/token", handlers.APIGetToken).Methods("POST", "OPTIONS")
-		apiV1Router.HandleFunc("/dashboard/data/balances", handlers.DashboardDataBalance).Methods("GET", "OPTIONS")   // new app versions
-		apiV1Router.HandleFunc("/dashboard/data/balance", handlers.APIDashboardDataBalance).Methods("GET", "OPTIONS") // old app versions
+		apiV1Router.HandleFunc("/dashboard/data/allbalances", handlers.DashboardDataBalanceCombined).Methods("GET", "OPTIONS") // consensus & execution
+		apiV1Router.HandleFunc("/dashboard/data/balances", handlers.DashboardDataBalance).Methods("GET", "OPTIONS")            // new app versions
+		apiV1Router.HandleFunc("/dashboard/data/balance", handlers.APIDashboardDataBalance).Methods("GET", "OPTIONS")          // old app versions
 		apiV1Router.HandleFunc("/dashboard/data/proposals", handlers.DashboardDataProposals).Methods("GET", "OPTIONS")
 		apiV1Router.HandleFunc("/stripe/webhook", handlers.StripeWebhook).Methods("POST")
 		apiV1Router.HandleFunc("/stats/{apiKey}/{machine}", handlers.ClientStatsPostOld).Methods("POST", "OPTIONS")

--- a/ethClients/ethClients.go
+++ b/ethClients/ethClients.go
@@ -64,6 +64,7 @@ type EthClientServicesPageData struct {
 	Lighthouse          EthClients
 	Erigon              EthClients
 	RocketpoolSmartnode EthClients
+	MevBoost            EthClients
 	Banner              string
 	CsrfField           template.HTML
 }
@@ -248,6 +249,7 @@ func updateEthClient() {
 	ethClients.Lighthouse.ClientReleaseVersion, ethClients.Lighthouse.ClientReleaseDate = prepareEthClientData("/sigp/lighthouse", "Lighthouse", curTime)
 
 	ethClients.RocketpoolSmartnode.ClientReleaseVersion, ethClients.RocketpoolSmartnode.ClientReleaseDate = prepareEthClientData("/rocket-pool/smartnode-install", "Rocketpool", curTime)
+	ethClients.MevBoost.ClientReleaseVersion, ethClients.MevBoost.ClientReleaseDate = prepareEthClientData("/flashbots/mev-boost", "MEV-Boost", curTime)
 
 	ethClients.LastUpdate = curTime
 }

--- a/handlers/api.go
+++ b/handlers/api.go
@@ -15,7 +15,6 @@ import (
 	"eth2-exporter/utils"
 	"fmt"
 	"io/ioutil"
-	"math/big"
 	"net/http"
 	"sort"
 	"strconv"
@@ -1045,7 +1044,7 @@ func ApiValidatorPerformance(w http.ResponseWriter, r *http.Request) {
 }
 
 // ApiValidatorExecutionPerformance godoc
-// @Summary Get the current execution reward performance of up to 100 validators
+// @Summary Get the current execution reward performance of up to 100 validators. If block was produced via mev relayer, this endpoint will use the relayer data as block reward instead of the normal block reward.
 // @Tags Validator
 // @Produce  json
 // @Param  indexOrPubkey path string true "Up to 100 validator indicesOrPubkeys, comma separated"
@@ -1073,87 +1072,6 @@ func ApiValidatorExecutionPerformance(w http.ResponseWriter, r *http.Request) {
 	}
 
 	sendOKResponse(j, r.URL.String(), []any{result})
-}
-
-func getValidatorExecutionPerformance(queryIndices []uint64) ([]types.ExecutionPerformanceResponse, error) {
-	type ExecBlockProposer struct {
-		ExecBlock uint64 `db:"exec_block_number"`
-		Proposer  uint64 `db:"proposer"`
-	}
-
-	latestEpoch := services.LatestEpoch()
-	last30dTimestamp := time.Now().Add(-31 * 24 * time.Hour)
-	last7dTimestamp := time.Now().Add(-7 * 24 * time.Hour)
-	last1dTimestamp := time.Now().Add(-1 * 24 * time.Hour)
-
-	var execBlocks []ExecBlockProposer
-	err := db.ReaderDb.Select(&execBlocks,
-		`SELECT 
-			exec_block_number, 
-			proposer 
-			FROM blocks 
-		WHERE proposer = ANY($1) 
-		AND exec_block_number IS NOT NULL 
-		AND exec_block_number > 0 
-		AND epoch > $2`,
-		pq.Array(queryIndices),
-		latestEpoch-7200, // 32d range
-	)
-	if err != nil {
-		logger.WithError(err).Error("can not load proposed blocks from db")
-		return nil, err
-	}
-
-	blockList := []uint64{}
-	blockToProposerMap := make(map[uint64]uint64)
-	for _, execBlock := range execBlocks {
-		blockList = append(blockList, execBlock.ExecBlock)
-		blockToProposerMap[execBlock.ExecBlock] = execBlock.Proposer
-	}
-
-	blocks, err := db.BigtableClient.GetBlocksIndexedMultiple(blockList, 10000)
-	if err != nil {
-		logger.WithError(err).Errorf("can not load mined blocks by GetBlocksIndexedMultiple")
-		return nil, err
-	}
-
-	resultPerProposer := make(map[uint64]types.ExecutionPerformanceResponse)
-
-	for _, block := range blocks {
-		proposer := blockToProposerMap[block.Number]
-		result, ok := resultPerProposer[proposer]
-		if !ok {
-			result = types.ExecutionPerformanceResponse{
-				Performance1d:  big.NewInt(0),
-				Performance7d:  big.NewInt(0),
-				Performance31d: big.NewInt(0),
-				ValidatorIndex: proposer,
-			}
-		}
-
-		txFees := big.NewInt(0).SetBytes(block.TxReward)
-		mev := big.NewInt(0).SetBytes(block.Mev)
-		income := big.NewInt(0).Add(txFees, mev)
-
-		if block.Time.AsTime().After(last30dTimestamp) {
-			result.Performance31d = result.Performance31d.Add(result.Performance31d, income)
-		}
-		if block.Time.AsTime().After(last7dTimestamp) {
-			result.Performance7d = result.Performance7d.Add(result.Performance7d, income)
-		}
-		if block.Time.AsTime().After(last1dTimestamp) {
-			result.Performance1d = result.Performance1d.Add(result.Performance1d, income)
-		}
-
-		resultPerProposer[proposer] = result
-	}
-
-	results := []types.ExecutionPerformanceResponse{}
-	for _, resultPerProposer := range resultPerProposer {
-		results = append(results, resultPerProposer)
-	}
-
-	return results, nil
 }
 
 // ApiValidatorAttestationEffectiveness godoc

--- a/handlers/api_eth1.go
+++ b/handlers/api_eth1.go
@@ -1,0 +1,485 @@
+package handlers
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"eth2-exporter/db"
+	"eth2-exporter/services"
+	"eth2-exporter/types"
+	"eth2-exporter/utils"
+	"fmt"
+	"math/big"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/gorilla/mux"
+	"github.com/lib/pq"
+	"golang.org/x/exp/maps"
+)
+
+// ApiETH1ExecBlocks godoc
+// @Summary Get Execution Blocks
+// @Tags Execution
+// @Description Get execution blocks by execution block number
+// @Produce json
+// @Param blockNumber path string true "Provide one or more execution block numbers. Coma separated up to max 100. "
+// @Success 200 {object} string
+// @Failure 400 {object} types.ApiResponse
+// @Router /api/v1/execution/block/{blockNumber} [get]
+func ApiETH1ExecBlocks(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	vars := mux.Vars(r)
+
+	var blockList []uint64
+	splits := strings.Split(vars["blockNumber"], ",")
+	for _, split := range splits {
+		temp, err := strconv.ParseUint(split, 10, 64)
+		if err != nil {
+			sendErrorResponse(w, r.URL.String(), "invalid block number")
+			return
+		}
+		blockList = append(blockList, temp)
+	}
+
+	blocks, err := db.BigtableClient.GetBlocksIndexedMultiple(blockList, uint64(100))
+	if err != nil {
+		logger.Errorf("Can not retrieve blocks from bigtable %v", err)
+		sendErrorResponse(w, r.URL.String(), "can not retrieve blocks from bigtable")
+		return
+	}
+
+	_, beaconDataMap, err := findExecBlockNumbersByExecBlockNumber(blockList, 0, 100)
+	if err != nil {
+		sendErrorResponse(w, r.URL.String(), "can not retrieve proposer information")
+		return
+	}
+
+	relaysData, err := getRelayDataForIndexedBlocks(blocks)
+	if err != nil {
+		logger.Errorf("can not load mev data %v", err)
+		sendErrorResponse(w, r.URL.String(), "can not retrieve mev data")
+		return
+	}
+
+	results := formatBlocksForApiResponse(blocks, relaysData, beaconDataMap)
+
+	j := json.NewEncoder(w)
+	sendOKResponse(j, r.URL.String(), []interface{}{results})
+}
+
+// ApiETH1AccountProposedBlocks godoc
+// @Summary Get Proposed Blocks
+// @Tags Execution
+// @Description Get a list of proposed or mined blocks from a given fee recipient address, proposer index or proposer pubkey
+// @Produce json
+// @Param addressIndexOrPubkey path string true "Either the fee recipient address, the proposer index or proposer pubkey. You can provide multiple by seperating them with ',' up to max 20."
+// @Param offset query int false "Offset"
+// @Param limit query int false "Limit, amount of entries you wish to receive"
+// @Success 200 {object} string
+// @Failure 400 {object} types.ApiResponse
+// @Router /api/v1/execution/{addressIndexOrPubkey}/proposed [get]
+func ApiETH1AccountProducedBlocks(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	vars := mux.Vars(r)
+
+	addresses, indices, err := getAddressesOrIndicesFromAddressIndexOrPubkey(vars["addressIndexOrPubkey"])
+	if err != nil {
+		sendErrorResponse(w, r.URL.String(), "invalid address, validator index or pubkey or exceeded max of 20 params")
+		return
+	}
+
+	var offset uint64 = 0
+	var limit uint64 = 10
+
+	offsetString := r.URL.Query().Get("offset")
+	offset, err = strconv.ParseUint(offsetString, 10, 64)
+	if err != nil {
+		offset = 0
+	}
+
+	limitString := r.URL.Query().Get("limit")
+	limit, err = strconv.ParseUint(limitString, 10, 64)
+	if err != nil {
+		limit = 10
+	}
+
+	var blockList []uint64
+	var beaconDataMap = map[uint64]types.ExecBlockProposer{}
+	if len(addresses) > 0 {
+		blockListSub, beaconDataMapSub, err := findExecBlockNumbersByFeeRecipient(addresses, offset, limit)
+		if err != nil {
+			sendErrorResponse(w, r.URL.String(), "can not retrieve blocks from database")
+			return
+		}
+		blockList = append(blockList, blockListSub...)
+		for key, val := range beaconDataMapSub {
+			beaconDataMap[key] = val
+		}
+	}
+
+	if len(indices) > 0 {
+		blockListSub, beaconDataMapSub, err := findExecBlockNumbersByProposerIndex(indices, offset, limit)
+		if err != nil {
+			sendErrorResponse(w, r.URL.String(), "can not retrieve blocks from database")
+			return
+		}
+		blockList = append(blockList, blockListSub...)
+		for key, val := range beaconDataMapSub {
+			beaconDataMap[key] = val
+		}
+	}
+
+	blocks, err := db.BigtableClient.GetBlocksIndexedMultiple(blockList, uint64(limit))
+	if err != nil {
+		logger.Errorf("Can not retrieve blocks from bigtable %v", err)
+		sendErrorResponse(w, r.URL.String(), "can not retrieve blocks from bigtable")
+		return
+	}
+
+	relaysData, err := getRelayDataForIndexedBlocks(blocks)
+	if err != nil {
+		logger.Errorf("can not load mev data %v", err)
+		sendErrorResponse(w, r.URL.String(), "can not retrieve mev data")
+		return
+	}
+
+	results := formatBlocksForApiResponse(blocks, relaysData, beaconDataMap)
+
+	j := json.NewEncoder(w)
+	sendOKResponse(j, r.URL.String(), []interface{}{results})
+}
+
+func getRelayDataForIndexedBlocks(blocks []*types.Eth1BlockIndexed) (map[common.Hash]types.RelaysData, error) {
+	var execBlockHashes [][]byte
+	var relaysData []types.RelaysData
+
+	for _, block := range blocks {
+		execBlockHashes = append(execBlockHashes, block.Hash)
+	}
+	// try to get mev rewards from relys_blocks table
+	err := db.ReaderDb.Select(&relaysData,
+		`SELECT proposer_fee_recipient, value, exec_block_hash, tag_id, builder_pubkey FROM relays_blocks WHERE relays_blocks.exec_block_hash = ANY($1)`,
+		pq.ByteaArray(execBlockHashes),
+	)
+	if err != nil {
+		return nil, err
+	}
+	var relaysDataMap = make(map[common.Hash]types.RelaysData)
+	for _, relayData := range relaysData {
+		relaysDataMap[common.BytesToHash(relayData.ExecBlockHash)] = relayData
+	}
+
+	return relaysDataMap, nil
+}
+
+func formatBlocksForApiResponse(blocks []*types.Eth1BlockIndexed, relaysData map[common.Hash]types.RelaysData, beaconDataMap map[uint64]types.ExecBlockProposer) []types.ExecutionBlockApiResponse {
+	results := []types.ExecutionBlockApiResponse{}
+
+	latestFinalized := services.LatestFinalizedEpoch()
+
+	for _, block := range blocks {
+
+		totalReward := utils.Eth1TotalReward(block)
+
+		baseFee := big.NewInt(0).SetBytes(block.GetBaseFee())
+		difficulty := big.NewInt(0).SetBytes(block.GetDifficulty())
+
+		posData, ok := beaconDataMap[block.GetNumber()]
+		var posDataPt *types.ExecBlockProposer = nil
+		if ok {
+			posData.Finalized = latestFinalized >= posData.Epoch
+			posDataPt = &posData
+		}
+
+		consensusAlgorithm := "pos"
+		if len(block.GetDifficulty()) != 0 {
+			consensusAlgorithm = "pow"
+		}
+
+		var mevBribe *big.Int = big.NewInt(0)
+		relayData, ok := relaysData[common.BytesToHash(block.Hash)]
+		var relayDataResponse *types.RelayDataApiResponse = nil
+		if ok {
+			mevBribe = relayData.MevBribe.BigInt()
+			relayDataResponse = &types.RelayDataApiResponse{
+				TagID:                relayData.TagID,
+				BuilderPubKey:        fmt.Sprintf("0x%v", hex.EncodeToString(relayData.BuilderPubKey)),
+				ProposerFeeRecipient: fmt.Sprintf("0x%v", hex.EncodeToString(relayData.MevRecipient)),
+			}
+		}
+
+		var producerReward *big.Int
+		if mevBribe.Int64() == 0 {
+			producerReward = totalReward
+		} else {
+			producerReward = mevBribe
+		}
+
+		results = append(results, types.ExecutionBlockApiResponse{
+			Hash:               fmt.Sprintf("0x%v", hex.EncodeToString(block.GetHash())),
+			BlockNumber:        block.GetNumber(),
+			Timestamp:          uint64(block.GetTime().AsTime().Unix()),
+			BlockReward:        totalReward,
+			BlockMevReward:     mevBribe,
+			FeeRecipientReward: producerReward,
+			FeeRecipient:       fmt.Sprintf("0x%v", hex.EncodeToString(block.GetCoinbase())),
+			GasLimit:           block.GetGasLimit(),
+			GasUsed:            block.GetGasUsed(),
+			BaseFee:            baseFee,
+			TxCount:            block.GetTransactionCount(),
+			InternalTxCount:    block.GetInternalTransactionCount(),
+			UncleCount:         block.GetUncleCount(),
+			ParentHash:         fmt.Sprintf("0x%v", hex.EncodeToString(block.GetParentHash())),
+			UncleHash:          fmt.Sprintf("0x%v", hex.EncodeToString(block.GetUncleHash())),
+			Difficulty:         difficulty,
+			PoSData:            posDataPt,
+			RelayData:          relayDataResponse,
+			ConsensusAlgorithm: consensusAlgorithm,
+		})
+	}
+
+	return results
+}
+
+func getValidatorExecutionPerformance(queryIndices []uint64) ([]types.ExecutionPerformanceResponse, error) {
+	latestEpoch := services.LatestEpoch()
+	last30dTimestamp := time.Now().Add(-31 * 24 * time.Hour)
+	last7dTimestamp := time.Now().Add(-7 * 24 * time.Hour)
+	last1dTimestamp := time.Now().Add(-1 * 24 * time.Hour)
+
+	var execBlocks []types.ExecBlockProposer
+	err := db.ReaderDb.Select(&execBlocks,
+		`SELECT 
+			exec_block_number, 
+			proposer 
+			FROM blocks 
+		WHERE proposer = ANY($1) 
+		AND exec_block_number IS NOT NULL 
+		AND exec_block_number > 0 
+		AND epoch > $2`,
+		pq.Array(queryIndices),
+		latestEpoch-7200, // 32d range
+	)
+	if err != nil {
+		logger.WithError(err).Error("can not load proposed blocks from db")
+		return nil, err
+	}
+
+	blockList, blockToProposerMap := getBlockNumbersAndMapProposer(execBlocks)
+
+	blocks, err := db.BigtableClient.GetBlocksIndexedMultiple(blockList, 10000)
+	if err != nil {
+		logger.WithError(err).Errorf("can not load mined blocks by GetBlocksIndexedMultiple")
+		return nil, err
+	}
+
+	resultPerProposer := make(map[uint64]types.ExecutionPerformanceResponse)
+
+	relaysData, err := getRelayDataForIndexedBlocks(blocks)
+	if err != nil {
+		logger.WithError(err).Errorf("can not get relays data")
+		return nil, err
+	}
+
+	for _, block := range blocks {
+		proposer := blockToProposerMap[block.Number].Proposer
+		result, ok := resultPerProposer[proposer]
+		if !ok {
+			result = types.ExecutionPerformanceResponse{
+				Performance1d:  big.NewInt(0),
+				Performance7d:  big.NewInt(0),
+				Performance31d: big.NewInt(0),
+				ValidatorIndex: proposer,
+			}
+		}
+
+		txFees := big.NewInt(0).SetBytes(block.TxReward)
+		mev := big.NewInt(0).SetBytes(block.Mev)
+		income := big.NewInt(0).Add(txFees, mev)
+
+		var mevBribe *big.Int = big.NewInt(0)
+		relayData, ok := relaysData[common.BytesToHash(block.Hash)]
+		if ok {
+			mevBribe = relayData.MevBribe.BigInt()
+		}
+
+		var producerReward *big.Int
+		if mevBribe.Int64() == 0 {
+			producerReward = income
+		} else {
+			producerReward = mevBribe
+		}
+
+		if block.Time.AsTime().After(last30dTimestamp) {
+			result.Performance31d = result.Performance31d.Add(result.Performance31d, producerReward)
+		}
+		if block.Time.AsTime().After(last7dTimestamp) {
+			result.Performance7d = result.Performance7d.Add(result.Performance7d, producerReward)
+		}
+		if block.Time.AsTime().After(last1dTimestamp) {
+			result.Performance1d = result.Performance1d.Add(result.Performance1d, producerReward)
+		}
+
+		resultPerProposer[proposer] = result
+	}
+
+	return maps.Values(resultPerProposer), nil
+}
+
+func findExecBlockNumbersByProposerIndex(indices []uint64, offset, limit uint64) ([]uint64, map[uint64]types.ExecBlockProposer, error) {
+	var blockListSub []types.ExecBlockProposer
+	err := db.ReaderDb.Select(&blockListSub,
+		`SELECT 
+			exec_block_number,
+			proposer,
+			slot,
+			epoch  
+		FROM blocks 
+		WHERE proposer = ANY($1)
+		AND exec_block_number IS NOT NULL AND exec_block_number > 0 
+		ORDER BY exec_block_number DESC
+		OFFSET $2 LIMIT $3`,
+		pq.Array(indices),
+		offset,
+		limit,
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+	blockList, blockProposerMap := getBlockNumbersAndMapProposer(blockListSub)
+	return blockList, blockProposerMap, nil
+}
+
+func findExecBlockNumbersByFeeRecipient(addresses [][]byte, offset, limit uint64) ([]uint64, map[uint64]types.ExecBlockProposer, error) {
+	var blockListSub []types.ExecBlockProposer
+	err := db.ReaderDb.Select(&blockListSub,
+		`SELECT 
+				exec_block_number,
+				proposer,
+				slot,
+				epoch  
+			FROM blocks 
+			WHERE exec_fee_recipient = ANY($1)
+			AND exec_block_number IS NOT NULL AND exec_block_number > 0 
+			ORDER BY exec_block_number DESC
+			OFFSET $2 LIMIT $3`,
+		pq.ByteaArray(addresses),
+		offset,
+		limit,
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+	blockList, blockProposerMap := getBlockNumbersAndMapProposer(blockListSub)
+	return blockList, blockProposerMap, nil
+}
+
+func findExecBlockNumbersByExecBlockNumber(execBlocks []uint64, offset, limit uint64) ([]uint64, map[uint64]types.ExecBlockProposer, error) {
+	var blockListSub []types.ExecBlockProposer
+	err := db.ReaderDb.Select(&blockListSub,
+		`SELECT 
+			exec_block_number,
+			proposer,
+			slot,
+			epoch  
+		FROM blocks 
+		WHERE exec_block_number = ANY($1)
+		AND exec_block_number IS NOT NULL AND exec_block_number > 0 
+		ORDER BY exec_block_number DESC
+		OFFSET $2 LIMIT $3`,
+		pq.Array(execBlocks),
+		offset,
+		limit,
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+	blockList, blockProposerMap := getBlockNumbersAndMapProposer(blockListSub)
+	return blockList, blockProposerMap, nil
+}
+
+func getBlockNumbersAndMapProposer(data []types.ExecBlockProposer) ([]uint64, map[uint64]types.ExecBlockProposer) {
+	blockList := []uint64{}
+	blockToProposerMap := make(map[uint64]types.ExecBlockProposer)
+	for _, execBlock := range data {
+		blockList = append(blockList, execBlock.ExecBlock)
+		blockToProposerMap[execBlock.ExecBlock] = execBlock
+	}
+	return blockList, blockToProposerMap
+}
+
+func getAddressesOrIndicesFromAddressIndexOrPubkey(search string) ([][]byte, []uint64, error) {
+	individuals := strings.Split(search, ",")
+	if len(individuals) > 20 {
+		return nil, nil, fmt.Errorf("only a maximum of 20 query parameters are allowed")
+	}
+	var resultAddresses [][]byte
+
+	var indices []uint64
+	var pubkeys [][]byte
+	for _, individual := range individuals {
+		addInPub, err := parseFromAddressIndexOrPubkey(individual)
+		if err != nil {
+			return nil, nil, err
+		}
+		if len(addInPub.Address) > 0 {
+			resultAddresses = append(resultAddresses, addInPub.Address)
+		} else if len(addInPub.Pubkey) > 0 {
+			pubkeys = append(pubkeys, addInPub.Pubkey)
+		} else if addInPub.Index > 0 {
+			indices = append(indices, addInPub.Index)
+		}
+	}
+
+	// resolve pubkeys to index
+	if len(pubkeys) > 0 {
+		indicesFromPubkeys := []uint64{}
+		err := db.ReaderDb.Select(&indicesFromPubkeys,
+			"SELECT validatorindex FROM validators WHERE pubkey = ANY($1)",
+			pq.ByteaArray(pubkeys),
+		)
+		if err != nil {
+			return nil, nil, err
+		}
+		indices = append(indices, indicesFromPubkeys...)
+	}
+
+	if len(indices) > 0 {
+		return resultAddresses, indices, nil
+	}
+
+	return resultAddresses, nil, nil
+}
+
+func parseFromAddressIndexOrPubkey(search string) (types.AddressIndexOrPubkey, error) {
+	if strings.Contains(search, "0x") && len(search) == 42 {
+		address, err := hex.DecodeString(search[2:])
+		if err != nil {
+			return types.AddressIndexOrPubkey{}, err
+		}
+		return types.AddressIndexOrPubkey{
+			Address: address,
+		}, nil
+	} else if strings.Contains(search, "0x") || len(search) == 96 {
+		pubkey, err := hex.DecodeString(search[2:])
+		if err != nil {
+			return types.AddressIndexOrPubkey{}, err
+		}
+		return types.AddressIndexOrPubkey{
+			Pubkey: pubkey,
+		}, nil
+	} else {
+		index, err := strconv.ParseUint(search, 10, 64)
+		if err != nil {
+			return types.AddressIndexOrPubkey{}, err
+		}
+		return types.AddressIndexOrPubkey{
+			Index: index,
+		}, nil
+	}
+}

--- a/handlers/api_eth1.go
+++ b/handlers/api_eth1.go
@@ -21,7 +21,7 @@ import (
 )
 
 // ApiETH1ExecBlocks godoc
-// @Summary Get Execution Blocks
+// @Summary Get execution blocks
 // @Tags Execution
 // @Description Get execution blocks by execution block number
 // @Produce json
@@ -72,7 +72,7 @@ func ApiETH1ExecBlocks(w http.ResponseWriter, r *http.Request) {
 }
 
 // ApiETH1AccountProposedBlocks godoc
-// @Summary Get Proposed Blocks
+// @Summary Get proposed or mined blocks
 // @Tags Execution
 // @Description Get a list of proposed or mined blocks from a given fee recipient address, proposer index or proposer pubkey
 // @Produce json
@@ -81,7 +81,7 @@ func ApiETH1ExecBlocks(w http.ResponseWriter, r *http.Request) {
 // @Param limit query int false "Limit, amount of entries you wish to receive"
 // @Success 200 {object} string
 // @Failure 400 {object} types.ApiResponse
-// @Router /api/v1/execution/{addressIndexOrPubkey}/proposed [get]
+// @Router /api/v1/execution/{addressIndexOrPubkey}/produced [get]
 func ApiETH1AccountProducedBlocks(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 

--- a/handlers/ethClientsServices.go
+++ b/handlers/ethClientsServices.go
@@ -55,6 +55,8 @@ func EthClientsServices(w http.ResponseWriter, r *http.Request) {
 				pageData.Erigon.IsUserSubscribed = true
 			case "rocketpool":
 				pageData.RocketpoolSmartnode.IsUserSubscribed = true
+			case "mev-boost":
+				pageData.MevBoost.IsUserSubscribed = true
 			default:
 				continue
 			}

--- a/services/notifications.go
+++ b/services/notifications.go
@@ -2105,6 +2105,8 @@ func (n *ethClientNotification) GetInfo(includeUrl bool) string {
 			url = "https://github.com/ledgerwatch/erigon/releases"
 		case "Rocketpool":
 			url = "https://github.com/rocket-pool/smartnode-install/releases"
+		case "MEV-Boost":
+			url = "https://github.com/flashbots/mev-boost/releases"
 		default:
 			url = "https://beaconcha.in/ethClients"
 		}
@@ -2143,6 +2145,8 @@ func (n *ethClientNotification) GetInfoMarkdown() string {
 		url = "https://github.com/ledgerwatch/erigon/releases"
 	case "Rocketpool":
 		url = "https://github.com/rocket-pool/smartnode-install/releases"
+	case "MEV-Boost":
+		url = "https://github.com/flashbots/mev-boost/releases"
 	default:
 		url = "https://beaconcha.in/ethClients"
 	}

--- a/static/js/dashboard.js
+++ b/static/js/dashboard.js
@@ -1060,7 +1060,7 @@ $(document).ready(function () {
           //     prevDay=day
           //   }
           // }
-          
+
           var t2 = Date.now()
           createBalanceChart(result.consensusChartData, result.executionChartData)
           var t3 = Date.now()
@@ -1106,20 +1106,18 @@ function createBalanceChart(income, executionIncomeHistory) {
     },
     plotOptions: {
       column: {
-          stacking: 'stacked',
-          dataLabels: {
-              enabled: false
-          },
-          pointInterval: 24 * 3600 * 1000,
-          // pointIntervalUnit: 'day',
-          dataGrouping: {
-              forced: true,
-              units: [
-                  ['day', [1]]
-              ]
-          }
-      }
-  },
+        stacking: "stacked",
+        dataLabels: {
+          enabled: false,
+        },
+        pointInterval: 24 * 3600 * 1000,
+        // pointIntervalUnit: 'day',
+        dataGrouping: {
+          forced: true,
+          units: [["day", [1]]],
+        },
+      },
+    },
     xAxis: {
       type: "datetime",
       range: 31 * 24 * 60 * 60 * 1000,
@@ -1167,12 +1165,12 @@ function createBalanceChart(income, executionIncomeHistory) {
       {
         name: "Daily Consensus Income",
         data: income,
-        index: 2
+        index: 2,
       },
       {
         name: "Daily Execution Income",
         data: executionIncomeHistory,
-        index: 1
+        index: 1,
       },
     ],
   })

--- a/static/js/dashboard.js
+++ b/static/js/dashboard.js
@@ -1039,7 +1039,7 @@ $(document).ready(function () {
     if (state.validators && state.validators.length) {
       var qryStr = "?validators=" + state.validators.join(",")
       $.ajax({
-        url: "/dashboard/data/balance" + qryStr,
+        url: "/dashboard/data/allbalances" + qryStr,
         success: function (result) {
           var t1 = Date.now()
           // let prevDayIncome = 0
@@ -1060,9 +1060,9 @@ $(document).ready(function () {
           //     prevDay=day
           //   }
           // }
-
+          
           var t2 = Date.now()
-          createBalanceChart(result)
+          createBalanceChart(result.consensusChartData, result.executionChartData)
           var t3 = Date.now()
           console.log(`loaded balance-data: length: ${result.length}, fetch: ${t1 - t0}ms, aggregate: ${t2 - t1}ms, render: ${t3 - t2}ms`)
         },
@@ -1083,7 +1083,8 @@ $(document).ready(function () {
   }
 })
 
-function createBalanceChart(income) {
+function createBalanceChart(income, executionIncomeHistory) {
+  executionIncomeHistory = executionIncomeHistory || []
   // console.log("u", utilization)
   Highcharts.stockChart("balance-chart", {
     exporting: {
@@ -1095,6 +1096,7 @@ function createBalanceChart(income) {
     chart: {
       type: "column",
       height: "500px",
+      pointInterval: 24 * 3600 * 1000,
     },
     legend: {
       enabled: true,
@@ -1102,6 +1104,22 @@ function createBalanceChart(income) {
     title: {
       text: "Daily Income for all Validators",
     },
+    plotOptions: {
+      column: {
+          stacking: 'stacked',
+          dataLabels: {
+              enabled: false
+          },
+          pointInterval: 24 * 3600 * 1000,
+          // pointIntervalUnit: 'day',
+          dataGrouping: {
+              forced: true,
+              units: [
+                  ['day', [1]]
+              ]
+          }
+      }
+  },
     xAxis: {
       type: "datetime",
       range: 31 * 24 * 60 * 60 * 1000,
@@ -1147,8 +1165,14 @@ function createBalanceChart(income) {
     ],
     series: [
       {
-        name: "Daily Income",
+        name: "Daily Consensus Income",
         data: income,
+        index: 2
+      },
+      {
+        name: "Daily Execution Income",
+        data: executionIncomeHistory,
+        index: 1
       },
     ],
   })

--- a/templates/ethClientsServices.html
+++ b/templates/ethClientsServices.html
@@ -268,6 +268,18 @@
                       <td><input id="rocketpool-checkbox" type="checkbox" data-toggle="toggle" {{ if .RocketpoolSmartnode.IsUserSubscribed }}checked{{ end }} onchange="updateUserSubscription('rocketpool-checkbox', 'eth_client_update', 'rocketpool')" /></td>
                     {{ end }}
                   </tr>
+                  <tr>
+                    <td data-column="Name"><a href="https://rocketpool.net">MEV-Boost</a></td>
+                    <td data-column="Language">Go</td>
+                    <td data-column="Latest update"><a href="https://github.com/flashbots/mev-boost/releases">{{ .MevBoost.ClientReleaseVersion }}</a> - {{ .MevBoost.ClientReleaseDate }}</td>
+                    <td data-column="Social media">
+                      <a href="http://discord.gg/flashbots" target="_blank"> <i class="fab fa-discord ml-1 mr-1"></i></a>
+                    </td>
+                    <td data-column="Support">N/A</td>
+                    {{ if $.User.Authenticated }}
+                      <td><input id="mevboost-checkbox" type="checkbox" data-toggle="toggle" {{ if .MevBoost.IsUserSubscribed }}checked{{ end }} onchange="updateUserSubscription('mevboost-checkbox', 'eth_client_update', 'mev-boost')" /></td>
+                    {{ end }}
+                  </tr>
                 </tbody>
               </table>
             </div>

--- a/templates/validator/charts.html
+++ b/templates/validator/charts.html
@@ -155,6 +155,7 @@
     {{ if .IncomeHistoryChartData }}
         <script>
             var incomeHistory = {{.IncomeHistoryChartData}}
+            var executionIncomeHistory = {{ .ExecutionIncomeHistoryData }}
             var currency = {{$.Rates.Currency}}
                 window.addEventListener('load', function () {
                     Highcharts.stockChart('income-chart', {
@@ -164,13 +165,30 @@
                         },
                         chart: {
                             type: 'column',
-                            height: '500px'
+                            height: '500px',
+                            pointInterval: 24 * 3600 * 1000
                         },
                         title: {
                             text: 'Daily Income'
                         },
                         legend: {
                             enabled: true
+                        },
+                        plotOptions: {
+                            column: {
+                                stacking: 'stacked',
+                                dataLabels: {
+                                    enabled: false
+                                },
+                                pointInterval: 24 * 3600 * 1000,
+                                // pointIntervalUnit: 'day',
+                                dataGrouping: {
+                                    forced: true,
+                                    units: [
+                                        ['day', [1]]
+                                    ]
+                                }
+                            }
                         },
                         xAxis: {
                             type: 'datetime',
@@ -199,8 +217,14 @@
                             }
                         }],
                         series: [{
-                            name: "Daily Income",
-                            data: incomeHistory
+                            name: "Daily Consensus Income",
+                            data: incomeHistory,
+                            index: 2
+                        },
+                        {
+                            name: "Daily Execution Income",
+                            data: executionIncomeHistory,
+                            index: 1
                         },
                             // {
                             //     name: "Effective Balance",

--- a/types/api.go
+++ b/types/api.go
@@ -145,6 +145,56 @@ type ExecutionPerformanceResponse struct {
 	ValidatorIndex uint64   `json:"validatorindex"`
 }
 
+type ExecutionBlockApiResponse struct {
+	Hash               string                `json:"blockHash"`
+	BlockNumber        uint64                `json:"blockNumber"`
+	Timestamp          uint64                `json:"timestamp"`
+	BlockReward        *big.Int              `json:"blockReward"`
+	BlockMevReward     *big.Int              `json:"blockMevReward"`
+	FeeRecipientReward *big.Int              `json:"producerReward"`
+	FeeRecipient       string                `json:"feeRecipient"`
+	GasLimit           uint64                `json:"gasLimit"`
+	GasUsed            uint64                `json:"gasUsed"`
+	BaseFee            *big.Int              `json:"baseFee"`
+	TxCount            uint64                `json:"txCount"`
+	InternalTxCount    uint64                `json:"internalTxCount"`
+	UncleCount         uint64                `json:"uncleCount"`
+	ParentHash         string                `json:"parentHash"`
+	UncleHash          string                `json:"uncleHash"`
+	Difficulty         *big.Int              `json:"difficulty"`
+	PoSData            *ExecBlockProposer    `json:"posConsensus"`
+	RelayData          *RelayDataApiResponse `json:"relay"`
+	ConsensusAlgorithm string                `json:"consensusAlgorithm"`
+}
+
+type RelayDataApiResponse struct {
+	TagID                string `json:"tag"`
+	BuilderPubKey        string `json:"builderPubkey"`
+	ProposerFeeRecipient string `json:"producerFeeRecipient"`
+}
+
+type AddressIndexOrPubkey struct {
+	Address []byte
+	Index   uint64
+	Pubkey  []byte
+}
+
+type RelaysData struct {
+	MevRecipient  []byte    `db:"proposer_fee_recipient"`
+	MevBribe      WeiString `db:"value"`
+	ExecBlockHash []byte    `db:"exec_block_hash"`
+	TagID         string    `db:"tag_id"`
+	BuilderPubKey []byte    `db:"builder_pubkey"`
+}
+
+type ExecBlockProposer struct {
+	ExecBlock uint64 `db:"exec_block_number" json:"executionBlockNumber"`
+	Proposer  uint64 `db:"proposer" json:"proposerIndex"`
+	Slot      uint64 `db:"slot" json:"slot"`
+	Epoch     uint64 `db:"epoch" json:"epoch"`
+	Finalized bool   `json:"finalized"`
+}
+
 func (e *DiscordReq) Scan(value interface{}) error {
 	b, ok := value.([]byte)
 	if !ok {

--- a/types/templates.go
+++ b/types/templates.go
@@ -342,6 +342,7 @@ type ValidatorPageData struct {
 	Apr                                 float64
 	Proposals                           [][]uint64
 	IncomeHistoryChartData              []*ChartDataPoint
+	ExecutionIncomeHistoryData          []*ChartDataPoint
 	Deposits                            *ValidatorDeposits
 	Eth1DepositAddress                  []byte
 	FlashMessage                        string

--- a/utils/eth1.go
+++ b/utils/eth1.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/base64"
 	"encoding/hex"
+	"eth2-exporter/types"
 	"fmt"
 	"html/template"
 	"math/big"
@@ -32,6 +33,15 @@ func Eth1BlockReward(blockNumber uint64, difficulty []byte) *big.Int {
 	} else {
 		return big.NewInt(2e+18)
 	}
+}
+
+func Eth1TotalReward(block *types.Eth1BlockIndexed) *big.Int {
+	blockReward := Eth1BlockReward(block.GetNumber(), block.GetDifficulty())
+	uncleReward := big.NewInt(0).SetBytes(block.GetUncleReward())
+	txFees := big.NewInt(0).SetBytes(block.GetTxReward())
+
+	totalReward := big.NewInt(0).Add(blockReward, txFees)
+	return totalReward.Add(totalReward, uncleReward)
 }
 
 func StripPrefix(hexStr string) string {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -34,6 +34,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/params"
 	"github.com/kataras/i18n"
 	"github.com/kelseyhightower/envconfig"
 	"github.com/lib/pq"
@@ -294,6 +295,10 @@ func TimeToEpoch(ts time.Time) int64 {
 		return 0
 	}
 	return (ts.Unix() - int64(Config.Chain.GenesisTimestamp)) / int64(Config.Chain.Config.SecondsPerSlot) / int64(Config.Chain.Config.SlotsPerEpoch)
+}
+
+func WeiToEther(wei *big.Int) *big.Float {
+	return new(big.Float).Quo(new(big.Float).SetInt(wei), big.NewFloat(params.Ether))
 }
 
 // WaitForCtrlC will block/wait until a control-c is pressed


### PR DESCRIPTION
- Adds /execution/block/{execBlockNum} execution blocks endpoint
- Adds /execution/{addressOrIndexOrPubkey}/produced execution blocks endpoint
- /validator/{indexOrPubkey}/execution/performance now returns mev reward if block was found via relay
- New api endpoint /dashboard/data/allbalances to get balance history chart that includes both cons rewards and exec rewards
- Added mev-boost to client updates page & enabled mev-boost update notification
- Add Execution Rewards to validator and dashboard page