### PR TITLE
Add votes to block API

### DIFF
--- a/handlers/api.go
+++ b/handlers/api.go
@@ -328,16 +328,49 @@ func ApiBlock(w http.ResponseWriter, r *http.Request) {
 
 	rows, err := db.ReaderDb.Query(`
 	SELECT
-		b.*,
+		blocks.epoch,
+		blocks.slot,
+		blocks.blockroot,
+		blocks.parentroot,
+		blocks.stateroot,
+		blocks.signature,
+		blocks.randaoreveal,
+		blocks.graffiti,
+		blocks.graffiti_text,
+		blocks.eth1data_depositroot,
+		blocks.eth1data_depositcount,
+		blocks.eth1data_blockhash,
+		blocks.proposerslashingscount,
+		blocks.attesterslashingscount,
+		blocks.attestationscount,
+		blocks.depositscount,
+		blocks.voluntaryexitscount,
+		blocks.proposer,
+		blocks.status,
+		blocks.syncaggregate_bits,
+		blocks.syncaggregate_signature,
+		blocks.syncaggregate_participation,
+		blocks.exec_parent_hash,
+		blocks.exec_fee_recipient,
+		blocks.exec_state_root,
+		blocks.exec_receipts_root,
+		blocks.exec_logs_bloom,
+		blocks.exec_random,
+		blocks.exec_block_number,
+		blocks.exec_gas_limit,
+		blocks.exec_gas_used,
+		blocks.exec_timestamp,
+		blocks.exec_extra_data,
+		blocks.exec_base_fee_per_gas,
+		blocks.exec_block_hash,     
+		blocks.exec_transactions_count,
 		ba.votes
 	FROM
-		(SELECT * from blocks) b
+		blocks
 	LEFT JOIN
-		(SELECT beaconblockroot, sum(array_length(validators, 1)) AS votes FROM blocks_attestations GROUP BY beaconblockroot) ba
-	ON
-		(b.blockroot = ba.beaconblockroot)
+		(SELECT beaconblockroot, sum(array_length(validators, 1)) AS votes FROM blocks_attestations GROUP BY beaconblockroot) ba ON (blocks.blockroot = ba.beaconblockroot)
 	WHERE
-		b.blockroot = $1;`, blockRootHash)
+		blocks.blockroot = $1;`, blockRootHash)
 
 	if err != nil {
 		sendErrorResponse(w, r.URL.String(), "could not retrieve db results")

--- a/handlers/api.go
+++ b/handlers/api.go
@@ -2590,7 +2590,6 @@ func SendErrorResponse(w http.ResponseWriter, route, message string) {
 }
 
 func sendErrorResponse(w http.ResponseWriter, route, message string) {
-	logger.Errorf("API error: " + message)
 	w.WriteHeader(400)
 	j := json.NewEncoder(w)
 	response := &types.ApiResponse{}


### PR DESCRIPTION
Rather than calculating the vote count in Go (as done `func GetSlotPageData),` I created a single SQL statement to calculate the vote count and join it with the original results. It requires to use the `blockRootHash` though as using the `blockSlot` retrieves different vote counts than shown in the UI.

I have tested this locally with several slots, here is an example:
- http://localhost:8081/slot/1058275
Shows 9483 votes right next to the "Votes" tab
- http://localhost:8081/api/v1/block/1058275
Now includes "votes: 9483" right at the end

Dear reviewer, as many areas touched by my changes are quite new to me, please let me know whether the path I took is reasonable or not.