### PR TITLE
Returned search box in validators leaderboard template

### DIFF
--- a/templates/validators_leaderboard.html
+++ b/templates/validators_leaderboard.html
@@ -7,7 +7,7 @@
         processing: true,
         serverSide: true,
         ordering: true,
-        searching: false,
+        searching: true,
         stateSave: true,
         ajax: "/validators/leaderboard/data",
         pagingType: "input",


### PR DESCRIPTION
As talked with @Buttaa, this feature was very handy on Goerli network in order to roughly figure out the performance of a group of labeled validators. Hopefully, the search feature is optimized at some point, and this PR will be merged.