### PR TITLE
Machine Metrics Error handling ignores single failed insert now

### DIFF
--- a/handlers/api.go
+++ b/handlers/api.go
@@ -2376,12 +2376,24 @@ func clientStatsPost(w http.ResponseWriter, r *http.Request, apiKey, machine str
 		return
 	}
 
+	var rateLimitErrs = 0
 	var result bool = false
 	for i := 0; i < len(jsonObjects); i++ {
-		result = insertStats(userData, machine, &jsonObjects[i], w, r)
+		result, err = insertStats(userData, machine, &jsonObjects[i], w, r)
 		if !result {
+			// ignore rate limit errors unless all are rate limit errors
+			if strings.HasPrefix(err.Error(), "ERROR: duplicate key value violates unique constraint") ||
+				strings.HasPrefix(err.Error(), "rate limit") {
+				rateLimitErrs++
+				continue
+			}
 			break
 		}
+	}
+
+	if rateLimitErrs >= len(jsonObjects) {
+		sendErrorWithCodeResponse(w, r.URL.String(), "rate limit too many metric requests, max 1 per user per machine per process", 429)
+		return
 	}
 
 	if result {
@@ -2390,26 +2402,26 @@ func clientStatsPost(w http.ResponseWriter, r *http.Request, apiKey, machine str
 	}
 }
 
-func insertStats(userData *types.UserWithPremium, machine string, body *map[string]interface{}, w http.ResponseWriter, r *http.Request) bool {
+func insertStats(userData *types.UserWithPremium, machine string, body *map[string]interface{}, w http.ResponseWriter, r *http.Request) (bool, error) {
 
 	var parsedMeta *types.StatsMeta
 	err := mapstructure.Decode(body, &parsedMeta)
 	if err != nil {
 		logger.Errorf("Could not parse stats (meta stats) | %v ", err)
 		sendErrorResponse(w, r.URL.String(), "could not parse meta")
-		return false
+		return false, err
 	}
 
 	parsedMeta.Machine = machine
 
 	if parsedMeta.Version > 2 || parsedMeta.Version <= 0 {
 		sendErrorResponse(w, r.URL.String(), "this version is not supported")
-		return false
+		return false, err
 	}
 
 	if parsedMeta.Process != "validator" && parsedMeta.Process != "beaconnode" && parsedMeta.Process != "slasher" && parsedMeta.Process != "system" {
 		sendErrorResponse(w, r.URL.String(), "unknown process")
-		return false
+		return false, err
 	}
 
 	maxNodes := GetUserPremiumByPackage(userData.Product.String).MaxNodes
@@ -2418,13 +2430,13 @@ func insertStats(userData *types.UserWithPremium, machine string, body *map[stri
 	if err != nil {
 		logger.Errorf("Could not get max machine count| %v", err)
 		sendErrorResponse(w, r.URL.String(), "could not get machine count")
-		return false
+		return false, err
 	}
 
 	if count > maxNodes {
 		logger.Errorf("User has reached max machine count | %v", err)
 		sendErrorResponse(w, r.URL.String(), "reached max machine count")
-		return false
+		return false, err
 	}
 
 	// old db
@@ -2434,7 +2446,7 @@ func insertStats(userData *types.UserWithPremium, machine string, body *map[stri
 	if err != nil {
 		logger.Errorf("Could not transact | %v", err)
 		sendErrorResponse(w, r.URL.String(), "could not store")
-		return false
+		return false, err
 	}
 	defer tx.Rollback()
 
@@ -2452,16 +2464,19 @@ func insertStats(userData *types.UserWithPremium, machine string, body *map[stri
 			if err != nil {
 				logger.Errorf("could not transact | %v", err)
 				sendErrorResponse(w, r.URL.String(), "could not store")
-				return false
+				return false, err
 			}
 			id, err = db.InsertStatsMeta(tx, userData.ID, parsedMeta)
 		}
 		if err != nil {
-			if !strings.HasPrefix(err.Error(), "ERROR: duplicate key value violates unique constraint") {
+			if strings.HasPrefix(err.Error(), "ERROR: duplicate key value violates unique constraint") {
+				return false, err
+			} else {
 				logger.Errorf("Could not store stats (meta stats) | %v", err)
+				sendErrorResponse(w, r.URL.String(), "could not store meta")
+				return false, err
 			}
-			sendErrorResponse(w, r.URL.String(), "could not store meta")
-			return false
+
 		}
 	}
 
@@ -2474,7 +2489,7 @@ func insertStats(userData *types.UserWithPremium, machine string, body *map[stri
 		if err != nil {
 			logger.Errorf("Could not parse stats (system stats) | %v", err)
 			sendErrorResponse(w, r.URL.String(), "could not parse system")
-			return false
+			return false, err
 		}
 		_, err := db.InsertStatsSystem(
 			tx,
@@ -2484,14 +2499,14 @@ func insertStats(userData *types.UserWithPremium, machine string, body *map[stri
 		if err != nil {
 			logger.Errorf("Could not store stats (system stats) | %v", err)
 			sendErrorResponse(w, r.URL.String(), "could not store system")
-			return false
+			return false, err
 		}
 
 		err = tx.Commit()
 		if err != nil {
 			logger.Errorf("Could not store (tx commit) | %v", err)
 			sendErrorResponse(w, r.URL.String(), "could not store")
-			return false
+			return false, err
 		}
 		isSystem = true
 	}
@@ -2504,7 +2519,7 @@ func insertStats(userData *types.UserWithPremium, machine string, body *map[stri
 		if err != nil {
 			logger.Errorf("Could not parse stats (process stats) | %v", err)
 			sendErrorResponse(w, r.URL.String(), "could not parse process")
-			return false
+			return false, err
 		}
 
 		processGeneralID, err := db.InsertStatsProcessGeneral(
@@ -2515,7 +2530,7 @@ func insertStats(userData *types.UserWithPremium, machine string, body *map[stri
 		if err != nil {
 			logger.Errorf("Could not store stats (global process stats) | %v", err)
 			sendErrorResponse(w, r.URL.String(), "could not store global process")
-			return false
+			return false, err
 		}
 
 		if parsedMeta.Process == "validator" {
@@ -2525,7 +2540,7 @@ func insertStats(userData *types.UserWithPremium, machine string, body *map[stri
 			if err != nil {
 				logger.Errorf("Could not parse stats (validator stats) | %v", err)
 				sendErrorResponse(w, r.URL.String(), "could not parse validator")
-				return false
+				return false, err
 			}
 
 			_, err := db.InsertStatsValidator(
@@ -2536,7 +2551,7 @@ func insertStats(userData *types.UserWithPremium, machine string, body *map[stri
 			if err != nil {
 				logger.Errorf("Could not store stats (validatorstats) | %v", err)
 				sendErrorResponse(w, r.URL.String(), "could not store validator")
-				return false
+				return false, err
 			}
 
 		} else if parsedMeta.Process == "beaconnode" {
@@ -2546,7 +2561,7 @@ func insertStats(userData *types.UserWithPremium, machine string, body *map[stri
 			if err != nil {
 				logger.Errorf("Could not parse stats (node stats) | %v", err)
 				sendErrorResponse(w, r.URL.String(), "could not parse node")
-				return false
+				return false, err
 			}
 
 			_, err := db.InsertStatsBeaconnode(
@@ -2557,7 +2572,7 @@ func insertStats(userData *types.UserWithPremium, machine string, body *map[stri
 			if err != nil {
 				logger.Errorf("Could not store stats (beaconnode) | %v", err)
 				sendErrorResponse(w, r.URL.String(), "could not store beaconnode")
-				return false
+				return false, err
 			}
 		}
 
@@ -2565,7 +2580,7 @@ func insertStats(userData *types.UserWithPremium, machine string, body *map[stri
 		if err != nil {
 			logger.Errorf("Could not store (tx commit) | %v", err)
 			sendErrorResponse(w, r.URL.String(), "could not store")
-			return false
+			return false, err
 		}
 	}
 	// ^ remove above if migrated
@@ -2579,13 +2594,13 @@ func insertStats(userData *types.UserWithPremium, machine string, body *map[stri
 		if err != nil {
 			logger.Errorf("Could not parse stats (system stats) | %v", err)
 			sendErrorResponse(w, r.URL.String(), "could not parse system")
-			return false
+			return false, err
 		}
 		data, err = proto.Marshal(parsedResponse)
 		if err != nil {
 			logger.Errorf("Could not parse stats (system stats) | %v", err)
 			sendErrorResponse(w, r.URL.String(), "could marshal system")
-			return false
+			return false, err
 		}
 	} else if parsedMeta.Process == "validator" {
 		var parsedResponse *types.MachineMetricValidator
@@ -2593,13 +2608,13 @@ func insertStats(userData *types.UserWithPremium, machine string, body *map[stri
 		if err != nil {
 			logger.Errorf("Could not parse stats (validator stats) | %v", err)
 			sendErrorResponse(w, r.URL.String(), "could marshal validator")
-			return false
+			return false, err
 		}
 		data, err = proto.Marshal(parsedResponse)
 		if err != nil {
 			logger.Errorf("Could not parse stats (validator stats) | %v", err)
 			sendErrorResponse(w, r.URL.String(), "could marshal validator")
-			return false
+			return false, err
 		}
 	} else if parsedMeta.Process == "beaconnode" {
 		var parsedResponse *types.MachineMetricNode
@@ -2607,23 +2622,26 @@ func insertStats(userData *types.UserWithPremium, machine string, body *map[stri
 		if err != nil {
 			logger.Errorf("Could not parse stats (beaconnode stats) | %v", err)
 			sendErrorResponse(w, r.URL.String(), "could not parse beaconnode")
-			return false
+			return false, err
 		}
 		data, err = proto.Marshal(parsedResponse)
 		if err != nil {
 			logger.Errorf("Could not parse stats (beaconnode stats) | %v", err)
 			sendErrorResponse(w, r.URL.String(), "could not parse beaconnode")
-			return false
+			return false, err
 		}
 	}
 
 	err = db.BigtableClient.SaveMachineMetric(parsedMeta.Process, userData.ID, machine, data)
 	if err != nil {
+		if strings.HasPrefix(err.Error(), "rate limit") {
+			return false, err
+		}
 		logger.Errorf("Could not store stats | %v", err)
 		sendErrorResponse(w, r.URL.String(), fmt.Sprintf("could not store stats: %v", err))
-		return false
+		return false, err
 	}
-	return true
+	return true, nil
 }
 
 func DecodeMapStructure(input interface{}, output interface{}) error {
@@ -2771,7 +2789,11 @@ func SendErrorResponse(w http.ResponseWriter, route, message string) {
 }
 
 func sendErrorResponse(w http.ResponseWriter, route, message string) {
-	w.WriteHeader(400)
+	sendErrorWithCodeResponse(w, route, message, 400)
+}
+
+func sendErrorWithCodeResponse(w http.ResponseWriter, route, message string, errorcode int) {
+	w.WriteHeader(errorcode)
 	j := json.NewEncoder(w)
 	response := &types.ApiResponse{}
 	response.Status = "ERROR: " + message

--- a/services/notifications.go
+++ b/services/notifications.go
@@ -2159,7 +2159,7 @@ func collectMonitoringMachineOffline(notificationsByUserID map[uint64]map[types.
 	return collectMonitoringMachine(notificationsByUserID, types.MonitoringMachineOfflineEventName, 120,
 		// notify condition
 		func(_ *MachineEvents, machineData *types.MachineMetricSystemUser) bool {
-			if machineData.CurrentDataInsertTs < nowTs-4*60 && machineData.CurrentDataInsertTs > nowTs-90*60 {
+			if machineData.CurrentDataInsertTs < nowTs-5*60 && machineData.CurrentDataInsertTs > nowTs-90*60 {
 				return true
 			}
 			return false


### PR DESCRIPTION
In order to mitigate double system stats being inserted by lighthouse and teku, we simply ignore a singular metric rate limit fail in a batched request as long as not all metrics in the batched request are rate limit errors. This is a temporary measure until we can improve implementation in consensus clients.

Rate limit requests now return HTTP 429 instead of HTTP 400