### PR TITLE
fix: avoid crashing the frontend when gas prices can't be calculated

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -192,7 +192,13 @@
               <div data-toggle="tooltip" title="" data-original-title="Gas Price" class="d-none d-lg-block">
                 <div id="banner-slot" class="info-item d-flex mr-2 mr-lg-3">
                   <div class="info-item-body">
-                    <a id="banner-gpo-data" href="/gasnow"><i class="fas fa-gas-pump mr-1"></i>{{ formatBalanceWei .GasNow.Data.Fast "GWei" 0 }}</a>
+                    <a id="banner-gpo-data" href="/gasnow"><i class="fas fa-gas-pump mr-1"></i>
+                      {{- if .GasNow }}
+                        {{ formatBalanceWei .GasNow.Data.Fast "GWei" 0 }}
+                      {{- else }}
+                        ?
+                      {{- end }}
+                    </a>
                   </div>
                 </div>
               </div>

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -190,13 +190,13 @@
               </div>
             {{ else }}
               {{- if .GasNow }}
-              <div data-toggle="tooltip" title="" data-original-title="Gas Price" class="d-none d-lg-block">
-                <div id="banner-slot" class="info-item d-flex mr-2 mr-lg-3">
-                  <div class="info-item-body">
-                    <a id="banner-gpo-data" href="/gasnow"><i class="fas fa-gas-pump mr-1"></i>{{ formatBalanceWei .GasNow.Data.Fast "GWei" 0 }}</a>
+                <div data-toggle="tooltip" title="" data-original-title="Gas Price" class="d-none d-lg-block">
+                  <div id="banner-slot" class="info-item d-flex mr-2 mr-lg-3">
+                    <div class="info-item-body">
+                      <a id="banner-gpo-data" href="/gasnow"><i class="fas fa-gas-pump mr-1"></i>{{ formatBalanceWei .GasNow.Data.Fast "GWei" 0 }}</a>
+                    </div>
                   </div>
                 </div>
-              </div>
               {{- end }}
             {{ end }}
             {{ if not .ShowSyncingMessage }}
@@ -561,9 +561,9 @@
                 </a>
               </li>
               <!-- <li class="nav-item {{ if eq .Active "services" }}active{{ end }} dropdown">
-                            <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">  
+                            <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                                 <span class="nav-icon"><i class="fas fa-tools"></i></span>
-                                <span class="nav-text">Services</span> 
+                                <span class="nav-text">Services</span>
                             </a>
                             <div class="dropdown-menu" aria-labelledby="navbarDropdown">
                                 <a class="dropdown-item" href="/stakingServices">
@@ -760,15 +760,15 @@
         </div> -->
 
         <!-- Discount banner
-            <div class="p-1" style="overflow-wrap: break-word; background-color: var(--bg-color-light); height: 40px; display: flex; justify-content: center; align-items: center;"> 
+            <div class="p-1" style="overflow-wrap: break-word; background-color: var(--bg-color-light); height: 40px; display: flex; justify-content: center; align-items: center;">
                 <span class="d-none d-md-block">
                 <span>
-                    <span>  
+                    <span>
                         Use voucher code
-                    </span> 
+                    </span>
                         <span>
                             <a style="color: #66bce9;">BEACONCHAIN</a>
-                        </span> 
+                        </span>
                         <span>
                             to get 69.42% off on the
                         </span>

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -189,19 +189,15 @@
                 </div>
               </div>
             {{ else }}
+              {{- if .GasNow }}
               <div data-toggle="tooltip" title="" data-original-title="Gas Price" class="d-none d-lg-block">
                 <div id="banner-slot" class="info-item d-flex mr-2 mr-lg-3">
                   <div class="info-item-body">
-                    <a id="banner-gpo-data" href="/gasnow"><i class="fas fa-gas-pump mr-1"></i>
-                      {{- if .GasNow }}
-                        {{ formatBalanceWei .GasNow.Data.Fast "GWei" 0 }}
-                      {{- else }}
-                        ?
-                      {{- end }}
-                    </a>
+                    <a id="banner-gpo-data" href="/gasnow"><i class="fas fa-gas-pump mr-1"></i>{{ formatBalanceWei .GasNow.Data.Fast "GWei" 0 }}</a>
                   </div>
                 </div>
               </div>
+              {{- end }}
             {{ end }}
             {{ if not .ShowSyncingMessage }}
               {{ if gt .FinalizationDelay 3 }}


### PR DESCRIPTION
Avoids the frontend crashing when it's not possible to calculate gas fees and we get "nil" instead. 
This was happening in our devnet setup as there are not pending transactions to get an estimate.

``` 
time="2022-11-23T12:39:48Z" level=error msg="error executing template for / route: template: layout.html:195:122: executing \"layout\" at <.GasNow.Data.Fast>: nil pointer evaluating *types.GasNowPageData.Data" module=handlers
2022/11/23 12:39:48 http: superfluous response.WriteHeader call from github.com/urfave/negroni.(*responseWriter).WriteHeader (response_writer.go:53)
``` 