### PR TITLE
feat(eth1indexer): get chainId directly from config

### DIFF
--- a/cmd/eth1indexer/main.go
+++ b/cmd/eth1indexer/main.go
@@ -31,9 +31,11 @@ import (
 
 func main() {
 
+	var chainId string
+
+	flag.StringVar(&chainId, "chainId", "", "Chain Identifier")
 	erigonEndpoint := flag.String("erigon", "", "Erigon archive node enpoint")
 	network := flag.String("network", "", "Network to use for exporting (mainnet or goerli")
-
 	block := flag.Int64("block", 0, "Index a specific block")
 
 	reorgDepth := flag.Int("reorg.depth", 20, "Lookback to check and handle chain reorgs")
@@ -108,14 +110,17 @@ func main() {
 		logrus.Fatal(err)
 	}
 
-	chainId := ""
+	if chainId != "" && *network != "" {
+		logrus.Fatalf("only one of both should be provided: chainId, network")
+	}
+
 	if *network == "mainnet" {
 		chainId = "1"
 	} else if *network == "goerli" {
 		chainId = "5"
 	} else if *network == "sepolia" {
 		chainId = "11155111"
-	} else {
+	} else if chainId == "" {
 		logrus.Fatalf("unsupported network name %v provided", *network)
 	}
 	balanceUpdaterPrefix := chainId + ":B:"

--- a/cmd/eth1indexer/main.go
+++ b/cmd/eth1indexer/main.go
@@ -17,6 +17,7 @@ import (
 	"io/ioutil"
 	"math/big"
 	"net/http"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -30,12 +31,7 @@ import (
 )
 
 func main() {
-
-	var chainId string
-
-	flag.StringVar(&chainId, "chainId", "", "Chain Identifier")
 	erigonEndpoint := flag.String("erigon", "", "Erigon archive node enpoint")
-	network := flag.String("network", "", "Network to use for exporting (mainnet or goerli")
 	block := flag.Int64("block", 0, "Index a specific block")
 
 	reorgDepth := flag.Int("reorg.depth", 20, "Lookback to check and handle chain reorgs")
@@ -110,19 +106,8 @@ func main() {
 		logrus.Fatal(err)
 	}
 
-	if chainId != "" && *network != "" {
-		logrus.Fatalf("only one of both should be provided: chainId, network")
-	}
+	chainId := strconv.FormatUint(utils.Config.Chain.Config.DepositChainID, 10)
 
-	if *network == "mainnet" {
-		chainId = "1"
-	} else if *network == "goerli" {
-		chainId = "5"
-	} else if *network == "sepolia" {
-		chainId = "11155111"
-	} else if chainId == "" {
-		logrus.Fatalf("unsupported network name %v provided", *network)
-	}
 	balanceUpdaterPrefix := chainId + ":B:"
 
 	nodeChainId, err := client.GetNativeClient().ChainID(context.Background())


### PR DESCRIPTION
We're running some temporary testnets that all have different chainIds, so this make it possible to directly pass it in. 