### PR TITLE
Update golang to 1.18 in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
             - --goerli # comment this out for mainnet
     postgres:
         image: postgres:12.0
-        container_name: postgres 
+        container_name: postgres
         restart: always
         environment:
             - POSTGRES_PASSWORD=pass
@@ -34,14 +34,14 @@ services:
 
     prysm:
         image: gcr.io/prysmaticlabs/prysm/beacon-chain:latest
-        container_name: prysm 
+        container_name: prysm
         restart: always
         volumes:
             - ./private/eth2_data:/data
             # - ./private/eth2_data/main:/data # use this for mainnet
             - ./private/eth1_node/.ethereum:/eth
         network_mode: host
-        command: 
+        command:
             - --datadir=/data
             - --rpc-host=0.0.0.0
             - --monitoring-host=0.0.0.0
@@ -53,8 +53,8 @@ services:
                 # condition: service_healthy
 
     go:
-        image: golang:1.15
-        container_name: golang 
+        image: golang:1.18
+        container_name: golang
         restart: always
         volumes:
             - ./:/usr/src/app
@@ -70,5 +70,5 @@ services:
         stdin_open: true
         tty: true
 
-volumes: 
+volumes:
     db:


### PR DESCRIPTION
The golang image in docker-compose points to the `1.15` version while go.mod requires `1.18`.
Because of this difference, the building step (`make all`) fails with the error:

```
root@ba79c3c6b6a8:/usr/src/app# make all
rm -rf bin/
mkdir -p bin/
go run cmd/bundle/main.go
go: downloading github.com/evanw/esbuild v0.8.23
...
config/config.go:3:8: package embed is not in GOROOT (/usr/local/go/src/embed)
make: *** [Makefile:19: explorer] Error 1
root@ba79c3c6b6a8:/usr/src/app# go version
go version go1.15.15 linux/arm64
```

Using the correct golang version in docker-compose fixes the issue.