### PR TITLE
(BIDS-1158) Prevent scam urls as token symbol

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -155,6 +155,7 @@ require (
 	github.com/multiformats/go-multihash v0.2.0 // indirect
 	github.com/multiformats/go-multistream v0.3.3 // indirect
 	github.com/multiformats/go-varint v0.0.6 // indirect
+	github.com/mvdan/xurls v1.1.0 // indirect
 	github.com/nxadm/tail v1.4.8 // indirect
 	github.com/onsi/ginkgo v1.16.5 // indirect
 	github.com/opencontainers/runtime-spec v1.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1132,6 +1132,8 @@ github.com/multiformats/go-varint v0.0.5/go.mod h1:3Ls8CIEsrijN6+B7PbrXRPxHRPuXS
 github.com/multiformats/go-varint v0.0.6 h1:gk85QWKxh3TazbLxED/NlDVv8+q+ReFJk7Y2W/KhfNY=
 github.com/multiformats/go-varint v0.0.6/go.mod h1:3Ls8CIEsrijN6+B7PbrXRPxHRPuXSrVKRY101jdMZYE=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
+github.com/mvdan/xurls v1.1.0 h1:OpuDelGQ1R1ueQ6sSryzi6P+1RtBpfQHM8fJwlE45ww=
+github.com/mvdan/xurls v1.1.0/go.mod h1:tQlNn3BED8bE/15hnSL2HLkDeLWpNPAwtw7wkEq44oU=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/naoina/go-stringutil v0.1.0/go.mod h1:XJ2SJL9jCtBh+P9q5btrd/Ylo8XwT/h1USek5+NqSA0=

--- a/handlers/api_eth1.go
+++ b/handlers/api_eth1.go
@@ -773,7 +773,7 @@ func ApiEth1AddressTokens(w http.ResponseWriter, r *http.Request) {
 			value := new(big.Int).SetBytes(tx.Value).String()
 			m, ok := tokenMeta[string(tx.TokenAddress)]
 			if ok {
-				value = utils.FormatErc20Deicmals(tx.Value, m).String()
+				value = utils.FormatErc20Decimals(tx.Value, m).String()
 			}
 
 			transactions = append(transactions, &types.Eth1TokenTxParsed{

--- a/templates/eth1tx.html
+++ b/templates/eth1tx.html
@@ -163,7 +163,7 @@
                           <span>{{ .To }}</span>
                           <span>For</span>
                           <span>{{ .Amount }}</span>
-                          <span>{{ .Token }}</span>
+                          <span>{{ .Token | formatTokenSymbolHTML }}</span>
                         </li>
                       {{ end }}
                     </ul>

--- a/templates/execution/token.html
+++ b/templates/execution/token.html
@@ -245,7 +245,7 @@
       <h1 class="h4 mb-1 mb-md-0 header-token text-truncate">
         <div class="my-md-3 font-weight-bold">
           <span class="d-flex">
-            <span class="mr-1 d-flex align-items-center" title={{ .Data.Metadata.Symbol | formatTokenSymbolTitle }}>
+            <span class="mr-1 d-flex align-items-center" title="{{ .Data.Metadata.Symbol | formatTokenSymbolTitle }}">
               {{ if .Data.Metadata.Logo }}
                 <img class="mr-1" style="height: 1.5rem;" src="data:image/png;base64, {{ toBase64 .Data.Metadata.Logo }}" />
               {{ else }}

--- a/templates/execution/token.html
+++ b/templates/execution/token.html
@@ -245,14 +245,14 @@
       <h1 class="h4 mb-1 mb-md-0 header-token text-truncate">
         <div class="my-md-3 font-weight-bold">
           <span class="d-flex">
-            <span class="mr-1 d-flex align-items-center">
+            <span class="mr-1 d-flex align-items-center" title={{ .Data.Metadata.Symbol | formatTokenSymbolTitle }}>
               {{ if .Data.Metadata.Logo }}
                 <img class="mr-1" style="height: 1.5rem;" src="data:image/png;base64, {{ toBase64 .Data.Metadata.Logo }}" />
               {{ else }}
                 <i class="fas fa-coins mr-1"></i>
               {{ end }}
               Token
-              {{ if .Data.Metadata.Symbol }}{{ .Data.Metadata.Symbol }}{{ end }}
+              {{ with .Data.Metadata.Symbol | formatTokenSymbol }}{{ . }}{{ end }}
             </span>
             <span data-toggle="tooltip" title="View address QR Code" class="mx-1">{{ template "QRCode" . }}</span>
             <span class="d-flex align-items-center"><i class="fa fa-copy text-muted text-white p-1 mx-1" style="vertical-align: text-bottom; font-size: .95rem; border-radius: 35%; background-color: var(--shadow-light);" role="button" data-toggle="tooltip" title="Copy to clipboard" data-clipboard-text="0x{{ .Data.Token }}"></i></span>

--- a/templates/execution/token.html
+++ b/templates/execution/token.html
@@ -292,9 +292,12 @@
                     <span>Symbol</span>
                   </div>
                   <div class="overview-col">
-                    <span class="d-flex align-items-center">
-                      {{ if .Data.Metadata.Logo }}
-                        <img class="mr-1" style="height: 1rem;" src="data:image/png;base64, {{ toBase64 .Data.Metadata.Logo }}" /> {{ if .Data.Metadata.Symbol }}{{ .Data.Metadata.Symbol }}{{ end }}
+                    <span class="d-flex align-items-center" title="{{ .Data.Metadata.Symbol | formatTokenSymbolTitle }}">
+                      {{ with .Data.Metadata.Logo }}
+                        <img class="mr-1" style="height: 1rem;" src="data:image/png;base64 , {{ toBase64 . }}" />
+                      {{ end }}
+                      {{ with .Data.Metadata.Symbol | formatTokenSymbol }}
+                        {{ . }}
                       {{ end }}
                     </span>
                   </div>

--- a/utils/format.go
+++ b/utils/format.go
@@ -1064,6 +1064,8 @@ func FormatTokenBalance(balance *types.Eth1AddressBalance) template.HTML {
 	if len(balance.Metadata.Logo) != 0 {
 		logo = fmt.Sprintf(`<img class="mr-1" style="height: 1.2rem;" src="data:image/png;base64, %s">`, base64.StdEncoding.EncodeToString(balance.Metadata.Logo))
 	}
+	symbolTitle := FormatTokenSymbolTitle(balance.Metadata.Symbol)
+	symbol := FormatTokenSymbol(balance.Metadata.Symbol)
 	pflt, _ := price.Float64()
 	flt, _ := num.Div(mul).Round(5).Float64()
 	bflt, _ := price.Mul(num.Div(mul)).Float64()
@@ -1071,7 +1073,7 @@ func FormatTokenBalance(balance *types.Eth1AddressBalance) template.HTML {
 	<div class="token-balance-col token-name text-truncate d-flex align-items-center justify-content-between flex-wrap">
 		<div class="token-icon p-1">
 			<a href='/token/0x%x?a=0x%x'>
-				<span>%s</span> <span>%s</span>
+				<span>%s</span> <span title="%s">%s</span>
 			</a> 
 		</div>
 		<div class="token-price-balance p-1">
@@ -1085,7 +1087,7 @@ func FormatTokenBalance(balance *types.Eth1AddressBalance) template.HTML {
 		<div class="token-price p-1">
 			<span class="text-muted" style="font-size: 90%%;">@ $%.2f</span>
 		</div>
-	</div>`, balance.Token, balance.Address, logo, balance.Metadata.Symbol, bflt, FormatThousandsEnglish(strconv.FormatFloat(flt, 'f', -1, 64)), pflt))
+	</div>`, balance.Token, balance.Address, logo, symbolTitle, symbol, bflt, FormatThousandsEnglish(strconv.FormatFloat(flt, 'f', -1, 64)), pflt))
 }
 
 func FormatAddressEthBalance(balance *types.Eth1AddressBalance) template.HTML {
@@ -1113,7 +1115,7 @@ func FormatTokenValue(balance *types.Eth1AddressBalance) template.HTML {
 	return template.HTML(p.Sprintf("%s", FormatThousandsEnglish(strconv.FormatFloat(f, 'f', -1, 64))))
 }
 
-func FormatErc20Deicmals(balance []byte, metadata *types.ERC20Metadata) decimal.Decimal {
+func FormatErc20Decimals(balance []byte, metadata *types.ERC20Metadata) decimal.Decimal {
 	decimals := new(big.Int).SetBytes(metadata.Decimals)
 	mul := decimal.NewFromFloat(float64(10)).Pow(decimal.NewFromBigInt(decimals, 0))
 	num := decimal.NewFromBigInt(new(big.Int).SetBytes(balance), 0)
@@ -1126,7 +1128,9 @@ func FormatTokenName(balance *types.Eth1AddressBalance) template.HTML {
 	if len(balance.Metadata.Logo) != 0 {
 		logo = fmt.Sprintf(`<img style="height: 20px;" src="data:image/png;base64, %s">`, base64.StdEncoding.EncodeToString(balance.Metadata.Logo))
 	}
-	return template.HTML(fmt.Sprintf("<a href='/token/0x%x?a=0x%x'>%s %s</a>", balance.Token, balance.Address, logo, balance.Metadata.Symbol))
+	symbolTitle := FormatTokenSymbolTitle(balance.Metadata.Symbol)
+	symbol := FormatTokenSymbol(balance.Metadata.Symbol)
+	return template.HTML(fmt.Sprintf(`<a href='/token/0x%x?a=0x%x' title="%s">%s %s</a>`, balance.Token, balance.Address, symbolTitle, logo, symbol))
 }
 
 func ToBase64(input []byte) string {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -928,17 +928,17 @@ func FormatTokenSymbolTitle(symbol string) string {
 	urls := xurls.Relaxed.FindAllString(symbol, -1)
 
 	if len(urls) > 0 {
-		return "The token symbol has been hidden because it might be a scam"
+		return "The token symbol has been hidden as it contains a URL which might be a scam"
 	}
 	return ""
 }
 
 func FormatTokenSymbol(symbol string) string {
 	urls := xurls.Relaxed.FindAllString(symbol, -1)
-	for _, url := range urls {
-		symbol = strings.ReplaceAll(symbol, url, "[hidden-url]")
-	}
 
+	if len(urls) > 0 {
+		return "[hidden-symbol]"
+	}
 	return symbol
 }
 


### PR DESCRIPTION
I found 4 places where the symbol of the token gets shown:

-  The address page top right where the list of all the tokens for this address is, see e.g. /address/0x78359e7df948834cafecbe0494b010c6f7f7fa74#erc20Txns
- The address page "Erc20 Token Txns" tab where the list of all the token transactions is, see e.g. same page as before
- The token page, see e.g. /token/0x620bf7f257055c14b6ef1826b2e913cbe7efa886?a=0x78359e7df948834cafecbe0494b010c6f7f7fa74
- Some transaction pages where tokens were transferred, see e.g. /tx/0xff34c1afe4757d3e0ba4ed3eceb7738b48160192551ecf00ec87daa100cb8db3

To test it I hardcoded something like "880$ Visit https://agbonus.site to claim reward." as the symbol.