### PR TITLE
(BIDS-1745) Remove "Yesterday" from validator page

### DIFF
--- a/templates/validator/tables.html
+++ b/templates/validator/tables.html
@@ -642,12 +642,14 @@
           </th>
           <td>{{ formatIncome .IncomeToday $.Rates.Currency }}</td>
         </tr>
+        <!--
         <tr>
           <th scope="row">
             Yesterday <span data-toggle="tooltip" title="Income during the last day, updated daily"><i class="far fa-question-circle"></i></span>
           </th>
           <td>{{ formatIncome .Income1d $.Rates.Currency }}</td>
         </tr>
+        --> 
         <tr>
           <th scope="row">
             Last Week <span data-toggle="tooltip" title="Income during the last 7 days, updated daily"><i class="far fa-question-circle"></i></span>


### PR DESCRIPTION
Unfortunately this shifts the whole validator design. It will be added in the next design