### PR TITLE
Bids 1537/prater exporter eden relay not working

### DIFF
--- a/tables.sql
+++ b/tables.sql
@@ -967,6 +967,9 @@ CREATE TABLE relays (
 	public_link varchar NULL,
 	is_censoring bool NULL,
 	is_ethical bool NULL,
+    export_failure_count INT NOT NULL DEFAULT 0,
+    last_export_try_ts timestamp without time zone NOT NULL DEFAULT NOW(),
+    last_export_success_ts timestamp without time zone NOT NULL DEFAULT NOW(),
 	PRIMARY KEY (tag_id, endpoint),
 	FOREIGN KEY (tag_id) REFERENCES tags(id)
 );

--- a/tables.sql
+++ b/tables.sql
@@ -968,8 +968,8 @@ CREATE TABLE relays (
 	is_censoring bool NULL,
 	is_ethical bool NULL,
     export_failure_count INT NOT NULL DEFAULT 0,
-    last_export_try_ts timestamp without time zone NOT NULL DEFAULT NOW(),
-    last_export_success_ts timestamp without time zone NOT NULL DEFAULT NOW(),
+    last_export_try_ts timestamp without time zone NOT NULL DEFAULT (NOW() AT TIME ZONE 'utc'),
+    last_export_success_ts timestamp without time zone NOT NULL DEFAULT (NOW() AT TIME ZONE 'utc'),
 	PRIMARY KEY (tag_id, endpoint),
 	FOREIGN KEY (tag_id) REFERENCES tags(id)
 );

--- a/types/exporter.go
+++ b/types/exporter.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/big"
+	"time"
 
 	"github.com/jackc/pgtype"
 	"github.com/pkg/errors"
@@ -513,13 +514,16 @@ type HistoricEthPrice struct {
 }
 
 type Relay struct {
-	ID          string         `db:"tag_id"`
-	Endpoint    string         `db:"endpoint"`
-	Link        sql.NullString `db:"public_link"`
-	IsCensoring sql.NullBool   `db:"is_censoring"`
-	IsEthical   sql.NullBool   `db:"is_ethical"`
-	Name        string         `db:"name"`
-	Logger      logrus.Entry
+	ID                  string         `db:"tag_id"`
+	Endpoint            string         `db:"endpoint"`
+	Link                sql.NullString `db:"public_link"`
+	IsCensoring         sql.NullBool   `db:"is_censoring"`
+	IsEthical           sql.NullBool   `db:"is_ethical"`
+	Name                string         `db:"name"`
+	ExportFailureCount  uint64         `db:"export_failure_count"`
+	LastExportTryTs     time.Time      `db:"last_export_try_ts"`
+	LastExportSuccessTs time.Time      `db:"last_export_success_ts"`
+	Logger              logrus.Entry
 }
 
 type RelayBlock struct {


### PR DESCRIPTION
We don't use `NOW() AT TIME ZONE 'utc'` anywhere else but it is important here so that we can use `time.Since(...)`.
Since every entry in the db is `timestamp without time zone` if you just save it with `NOW()` it will be the local time and then for `time.Since(...)` it will assume it to be UTC.

It was quite complicated to test this, I create relay entries in my own local prater db (not the normal prater one).