### PR TITLE
Add Lodestar to mobile app client monitoring setup guides

### DIFF
--- a/templates/user/settings.html
+++ b/templates/user/settings.html
@@ -29,6 +29,10 @@
         {
             id: 'teku-graffiti',
             config: "--metrics-publish-endpoint https://beaconcha.in/api/v1/client/metrics?apikey={apiKey}{machineName}"
+        },
+        {
+            id: 'lodestar-graffiti',
+            config: "--monitoring.endpoint 'https://beaconcha.in/api/v1/client/metrics?apikey={apiKey}{machineName}' --metrics"
         }
     ]
 
@@ -619,6 +623,29 @@
                                 </div>
                                 <div style="float: right;">
                                   <a id="copy-teku-graffiti" data-toggle="tooltip" data-original-title="Copy Command" data-clipboard-text="" class="d-none btn btn-primary ml-2 btn-icon-inside btn-sm text-white"> <span class="fa fa-copy icon-inside"></span> </a>
+                                </div>
+                              </div>
+                              <div style="clear: both;"></div>
+                              <br />
+                            </div>
+                          </div>
+                        </div>
+                        <div class="card" style="box-shadow: none; ">
+                          <h2 class="card-header" id="headingOne">
+                            <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#collapseOne" aria-expanded="true" aria-controls="collapseOne">Lodestar Setup Guide</button>
+                          </h2>
+                          <div id="collapseOne" class="collapse" aria-labelledby="headingOne" data-parent="#accordionExample" style="margin: 15px;">
+                            <div class="accordion-body">
+                              Copy & Paste the following flags to your Lodestar validator <strong>and</strong> beaconnode:<br /><br />
+
+                              <div style="margin-left: 5px; margin-right: 5px;">
+                                <div style="float: left;  width: 90%;">
+                                  <code>
+                                    <span id="lodestar-graffiti"></span>
+                                  </code>
+                                </div>
+                                <div style="float: right;">
+                                  <a id="copy-lodestar-graffiti" data-toggle="tooltip" data-original-title="Copy Command" data-clipboard-text="" class="d-none btn btn-primary ml-2 btn-icon-inside btn-sm text-white"> <span class="fa fa-copy icon-inside"></span> </a>
                                 </div>
                               </div>
                               <div style="clear: both;"></div>

--- a/templates/user/settings.html
+++ b/templates/user/settings.html
@@ -486,9 +486,9 @@
                       <div class="accordion" id="accordionExample" style="padding-top: 7px;">
                         <div class="card" style="box-shadow: none; ">
                           <h2 class="card-header" id="headingOne">
-                            <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#collapseOne" aria-expanded="true" aria-controls="collapseOne">Lighthouse Setup Guide</button>
+                            <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#collapseLighthouse" aria-expanded="true" aria-controls="collapseLighthouse">Lighthouse Setup Guide</button>
                           </h2>
-                          <div id="collapseOne" class="collapse" aria-labelledby="headingOne" data-parent="#accordionExample" style="margin: 15px;">
+                          <div id="collapseLighthouse" class="collapse" aria-labelledby="headingOne" data-parent="#accordionExample" style="margin: 15px;">
                             <div class="accordion-body">
                               Copy & Paste the following flags to your Lighthouse validator <strong>and</strong> beaconnode:<br /><br />
 
@@ -509,9 +509,9 @@
                         </div>
                         <div class="card" style="box-shadow: none;">
                           <h2 class="card-header" id="headingTwo">
-                            <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#collapseTwo" aria-expanded="false" aria-controls="collapseTwo">Prysm Setup Guide</button>
+                            <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#collapsePrysm" aria-expanded="false" aria-controls="collapsePrysm">Prysm Setup Guide</button>
                           </h2>
-                          <div id="collapseTwo" class="collapse" aria-labelledby="headingTwo" data-parent="#accordionExample" style="margin: 15px;">
+                          <div id="collapsePrysm" class="collapse" aria-labelledby="headingTwo" data-parent="#accordionExample" style="margin: 15px;">
                             <div class="accordion-body">
                               <h4>1. Install Metric Exporter</h4>
                               Download the latest beaconcha.in metrics exporter on your machine:<br /><br />
@@ -551,9 +551,9 @@
                         </div>
                         <div class="card" style="box-shadow: none;">
                           <h2 class="card-header" id="headingThree">
-                            <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#collapseThree" aria-expanded="false" aria-controls="collapseThree">Nimbus Setup Guide</button>
+                            <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#collapseNimbus" aria-expanded="false" aria-controls="collapseNimbus">Nimbus Setup Guide</button>
                           </h2>
-                          <div id="collapseThree" class="collapse" aria-labelledby="headingThree" data-parent="#accordionExample" style="margin: 15px;">
+                          <div id="collapseNimbus" class="collapse" aria-labelledby="headingThree" data-parent="#accordionExample" style="margin: 15px;">
                             <div class="accordion-body">
                               <h4>1. Run Nimbus Client</h4>
                               Copy & Paste the following flags to your Nimbus node:<br /><br />
@@ -609,9 +609,9 @@
                         </div>
                         <div class="card" style="box-shadow: none;">
                           <h2 class="card-header" id="headingFour">
-                            <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#collapseFour" aria-expanded="false" aria-controls="collapseFour">Teku Setup Guide</button>
+                            <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#collapseTeku" aria-expanded="false" aria-controls="collapseTeku">Teku Setup Guide</button>
                           </h2>
-                          <div id="collapseFour" class="collapse" aria-labelledby="headingFour" data-parent="#accordionExample" style="margin: 15px;">
+                          <div id="collapseTeku" class="collapse" aria-labelledby="headingFour" data-parent="#accordionExample" style="margin: 15px;">
                             <div class="accordion-body">
                               Copy & Paste the following flags to your Teku validator client:<br /><br />
 
@@ -632,9 +632,9 @@
                         </div>
                         <div class="card" style="box-shadow: none; ">
                           <h2 class="card-header" id="headingOne">
-                            <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#collapseOne" aria-expanded="true" aria-controls="collapseOne">Lodestar Setup Guide</button>
+                            <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#collapseLodestar" aria-expanded="true" aria-controls="collapseLodestar">Lodestar Setup Guide</button>
                           </h2>
-                          <div id="collapseOne" class="collapse" aria-labelledby="headingOne" data-parent="#accordionExample" style="margin: 15px;">
+                          <div id="collapseLodestar" class="collapse" aria-labelledby="headingOne" data-parent="#accordionExample" style="margin: 15px;">
                             <div class="accordion-body">
                               Copy & Paste the following flags to your Lodestar validator <strong>and</strong> beaconnode:<br /><br />
 


### PR DESCRIPTION
Adds lodestar to mobile app client monitoring setup guides.

I tried to align it with how Lighthouse is documented, as technically their setup is the same.

I did not find a quick way to properly test this, so might be worth to check if this renders as expected.