### PR TITLE
Nobids/add chainlink price feed

### DIFF
--- a/cmd/explorer/main.go
+++ b/cmd/explorer/main.go
@@ -390,7 +390,7 @@ func main() {
 		// logrus.Infof("frontend services initiated")
 
 		logrus.Infof("initializing prices")
-		price.Init(utils.Config.Chain.Config.DepositChainID)
+		price.Init(utils.Config.Chain.Config.DepositChainID, utils.Config.Eth1ErigonEndpoint)
 		logrus.Infof("prices initialized")
 		if !utils.Config.Frontend.Debug {
 			logrus.Infof("initializing ethclients")

--- a/cmd/statistics/main.go
+++ b/cmd/statistics/main.go
@@ -91,7 +91,7 @@ func main() {
 
 	db.InitBigtable(cfg.Bigtable.Project, cfg.Bigtable.Instance, fmt.Sprintf("%d", utils.Config.Chain.Config.DepositChainID))
 
-	price.Init(utils.Config.Chain.Config.DepositChainID)
+	price.Init(utils.Config.Chain.Config.DepositChainID, utils.Config.Eth1ErigonEndpoint)
 
 	if *statisticsDaysToExport != "" {
 		s := strings.Split(*statisticsDaysToExport, "-")

--- a/contracts/chainlink_feed/chainlink_feed.go
+++ b/contracts/chainlink_feed/chainlink_feed.go
@@ -1,0 +1,1573 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package chainlink_feed
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+)
+
+// FeedMetaData contains all meta data concerning the Feed contract.
+var FeedMetaData = &bind.MetaData{
+	ABI: "[{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_aggregator\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"_accessController\",\"type\":\"address\"}],\"stateMutability\":\"nonpayable\",\"type\":\"constructor\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"int256\",\"name\":\"current\",\"type\":\"int256\"},{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"roundId\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"updatedAt\",\"type\":\"uint256\"}],\"name\":\"AnswerUpdated\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"roundId\",\"type\":\"uint256\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"startedBy\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"startedAt\",\"type\":\"uint256\"}],\"name\":\"NewRound\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"from\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"}],\"name\":\"OwnershipTransferRequested\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"from\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"}],\"name\":\"OwnershipTransferred\",\"type\":\"event\"},{\"inputs\":[],\"name\":\"acceptOwnership\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"accessController\",\"outputs\":[{\"internalType\":\"contractAccessControllerInterface\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"aggregator\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_aggregator\",\"type\":\"address\"}],\"name\":\"confirmAggregator\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"decimals\",\"outputs\":[{\"internalType\":\"uint8\",\"name\":\"\",\"type\":\"uint8\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"description\",\"outputs\":[{\"internalType\":\"string\",\"name\":\"\",\"type\":\"string\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"_roundId\",\"type\":\"uint256\"}],\"name\":\"getAnswer\",\"outputs\":[{\"internalType\":\"int256\",\"name\":\"\",\"type\":\"int256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint80\",\"name\":\"_roundId\",\"type\":\"uint80\"}],\"name\":\"getRoundData\",\"outputs\":[{\"internalType\":\"uint80\",\"name\":\"roundId\",\"type\":\"uint80\"},{\"internalType\":\"int256\",\"name\":\"answer\",\"type\":\"int256\"},{\"internalType\":\"uint256\",\"name\":\"startedAt\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"updatedAt\",\"type\":\"uint256\"},{\"internalType\":\"uint80\",\"name\":\"answeredInRound\",\"type\":\"uint80\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"_roundId\",\"type\":\"uint256\"}],\"name\":\"getTimestamp\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"latestAnswer\",\"outputs\":[{\"internalType\":\"int256\",\"name\":\"\",\"type\":\"int256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"latestRound\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"latestRoundData\",\"outputs\":[{\"internalType\":\"uint80\",\"name\":\"roundId\",\"type\":\"uint80\"},{\"internalType\":\"int256\",\"name\":\"answer\",\"type\":\"int256\"},{\"internalType\":\"uint256\",\"name\":\"startedAt\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"updatedAt\",\"type\":\"uint256\"},{\"internalType\":\"uint80\",\"name\":\"answeredInRound\",\"type\":\"uint80\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"latestTimestamp\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"owner\",\"outputs\":[{\"internalType\":\"addresspayable\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint16\",\"name\":\"\",\"type\":\"uint16\"}],\"name\":\"phaseAggregators\",\"outputs\":[{\"internalType\":\"contractAggregatorV2V3Interface\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"phaseId\",\"outputs\":[{\"internalType\":\"uint16\",\"name\":\"\",\"type\":\"uint16\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_aggregator\",\"type\":\"address\"}],\"name\":\"proposeAggregator\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"proposedAggregator\",\"outputs\":[{\"internalType\":\"contractAggregatorV2V3Interface\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint80\",\"name\":\"_roundId\",\"type\":\"uint80\"}],\"name\":\"proposedGetRoundData\",\"outputs\":[{\"internalType\":\"uint80\",\"name\":\"roundId\",\"type\":\"uint80\"},{\"internalType\":\"int256\",\"name\":\"answer\",\"type\":\"int256\"},{\"internalType\":\"uint256\",\"name\":\"startedAt\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"updatedAt\",\"type\":\"uint256\"},{\"internalType\":\"uint80\",\"name\":\"answeredInRound\",\"type\":\"uint80\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"proposedLatestRoundData\",\"outputs\":[{\"internalType\":\"uint80\",\"name\":\"roundId\",\"type\":\"uint80\"},{\"internalType\":\"int256\",\"name\":\"answer\",\"type\":\"int256\"},{\"internalType\":\"uint256\",\"name\":\"startedAt\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"updatedAt\",\"type\":\"uint256\"},{\"internalType\":\"uint80\",\"name\":\"answeredInRound\",\"type\":\"uint80\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_accessController\",\"type\":\"address\"}],\"name\":\"setController\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_to\",\"type\":\"address\"}],\"name\":\"transferOwnership\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"version\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"}]",
+}
+
+// FeedABI is the input ABI used to generate the binding from.
+// Deprecated: Use FeedMetaData.ABI instead.
+var FeedABI = FeedMetaData.ABI
+
+// Feed is an auto generated Go binding around an Ethereum contract.
+type Feed struct {
+	FeedCaller     // Read-only binding to the contract
+	FeedTransactor // Write-only binding to the contract
+	FeedFilterer   // Log filterer for contract events
+}
+
+// FeedCaller is an auto generated read-only Go binding around an Ethereum contract.
+type FeedCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// FeedTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type FeedTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// FeedFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type FeedFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// FeedSession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type FeedSession struct {
+	Contract     *Feed             // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts     // Call options to use throughout this session
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// FeedCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type FeedCallerSession struct {
+	Contract *FeedCaller   // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts // Call options to use throughout this session
+}
+
+// FeedTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type FeedTransactorSession struct {
+	Contract     *FeedTransactor   // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// FeedRaw is an auto generated low-level Go binding around an Ethereum contract.
+type FeedRaw struct {
+	Contract *Feed // Generic contract binding to access the raw methods on
+}
+
+// FeedCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type FeedCallerRaw struct {
+	Contract *FeedCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// FeedTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type FeedTransactorRaw struct {
+	Contract *FeedTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewFeed creates a new instance of Feed, bound to a specific deployed contract.
+func NewFeed(address common.Address, backend bind.ContractBackend) (*Feed, error) {
+	contract, err := bindFeed(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &Feed{FeedCaller: FeedCaller{contract: contract}, FeedTransactor: FeedTransactor{contract: contract}, FeedFilterer: FeedFilterer{contract: contract}}, nil
+}
+
+// NewFeedCaller creates a new read-only instance of Feed, bound to a specific deployed contract.
+func NewFeedCaller(address common.Address, caller bind.ContractCaller) (*FeedCaller, error) {
+	contract, err := bindFeed(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &FeedCaller{contract: contract}, nil
+}
+
+// NewFeedTransactor creates a new write-only instance of Feed, bound to a specific deployed contract.
+func NewFeedTransactor(address common.Address, transactor bind.ContractTransactor) (*FeedTransactor, error) {
+	contract, err := bindFeed(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &FeedTransactor{contract: contract}, nil
+}
+
+// NewFeedFilterer creates a new log filterer instance of Feed, bound to a specific deployed contract.
+func NewFeedFilterer(address common.Address, filterer bind.ContractFilterer) (*FeedFilterer, error) {
+	contract, err := bindFeed(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &FeedFilterer{contract: contract}, nil
+}
+
+// bindFeed binds a generic wrapper to an already deployed contract.
+func bindFeed(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := abi.JSON(strings.NewReader(FeedABI))
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_Feed *FeedRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _Feed.Contract.FeedCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_Feed *FeedRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Feed.Contract.FeedTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_Feed *FeedRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _Feed.Contract.FeedTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_Feed *FeedCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _Feed.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_Feed *FeedTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Feed.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_Feed *FeedTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _Feed.Contract.contract.Transact(opts, method, params...)
+}
+
+// AccessController is a free data retrieval call binding the contract method 0xbc43cbaf.
+//
+// Solidity: function accessController() view returns(address)
+func (_Feed *FeedCaller) AccessController(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _Feed.contract.Call(opts, &out, "accessController")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// AccessController is a free data retrieval call binding the contract method 0xbc43cbaf.
+//
+// Solidity: function accessController() view returns(address)
+func (_Feed *FeedSession) AccessController() (common.Address, error) {
+	return _Feed.Contract.AccessController(&_Feed.CallOpts)
+}
+
+// AccessController is a free data retrieval call binding the contract method 0xbc43cbaf.
+//
+// Solidity: function accessController() view returns(address)
+func (_Feed *FeedCallerSession) AccessController() (common.Address, error) {
+	return _Feed.Contract.AccessController(&_Feed.CallOpts)
+}
+
+// Aggregator is a free data retrieval call binding the contract method 0x245a7bfc.
+//
+// Solidity: function aggregator() view returns(address)
+func (_Feed *FeedCaller) Aggregator(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _Feed.contract.Call(opts, &out, "aggregator")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// Aggregator is a free data retrieval call binding the contract method 0x245a7bfc.
+//
+// Solidity: function aggregator() view returns(address)
+func (_Feed *FeedSession) Aggregator() (common.Address, error) {
+	return _Feed.Contract.Aggregator(&_Feed.CallOpts)
+}
+
+// Aggregator is a free data retrieval call binding the contract method 0x245a7bfc.
+//
+// Solidity: function aggregator() view returns(address)
+func (_Feed *FeedCallerSession) Aggregator() (common.Address, error) {
+	return _Feed.Contract.Aggregator(&_Feed.CallOpts)
+}
+
+// Decimals is a free data retrieval call binding the contract method 0x313ce567.
+//
+// Solidity: function decimals() view returns(uint8)
+func (_Feed *FeedCaller) Decimals(opts *bind.CallOpts) (uint8, error) {
+	var out []interface{}
+	err := _Feed.contract.Call(opts, &out, "decimals")
+
+	if err != nil {
+		return *new(uint8), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(uint8)).(*uint8)
+
+	return out0, err
+
+}
+
+// Decimals is a free data retrieval call binding the contract method 0x313ce567.
+//
+// Solidity: function decimals() view returns(uint8)
+func (_Feed *FeedSession) Decimals() (uint8, error) {
+	return _Feed.Contract.Decimals(&_Feed.CallOpts)
+}
+
+// Decimals is a free data retrieval call binding the contract method 0x313ce567.
+//
+// Solidity: function decimals() view returns(uint8)
+func (_Feed *FeedCallerSession) Decimals() (uint8, error) {
+	return _Feed.Contract.Decimals(&_Feed.CallOpts)
+}
+
+// Description is a free data retrieval call binding the contract method 0x7284e416.
+//
+// Solidity: function description() view returns(string)
+func (_Feed *FeedCaller) Description(opts *bind.CallOpts) (string, error) {
+	var out []interface{}
+	err := _Feed.contract.Call(opts, &out, "description")
+
+	if err != nil {
+		return *new(string), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(string)).(*string)
+
+	return out0, err
+
+}
+
+// Description is a free data retrieval call binding the contract method 0x7284e416.
+//
+// Solidity: function description() view returns(string)
+func (_Feed *FeedSession) Description() (string, error) {
+	return _Feed.Contract.Description(&_Feed.CallOpts)
+}
+
+// Description is a free data retrieval call binding the contract method 0x7284e416.
+//
+// Solidity: function description() view returns(string)
+func (_Feed *FeedCallerSession) Description() (string, error) {
+	return _Feed.Contract.Description(&_Feed.CallOpts)
+}
+
+// GetAnswer is a free data retrieval call binding the contract method 0xb5ab58dc.
+//
+// Solidity: function getAnswer(uint256 _roundId) view returns(int256)
+func (_Feed *FeedCaller) GetAnswer(opts *bind.CallOpts, _roundId *big.Int) (*big.Int, error) {
+	var out []interface{}
+	err := _Feed.contract.Call(opts, &out, "getAnswer", _roundId)
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// GetAnswer is a free data retrieval call binding the contract method 0xb5ab58dc.
+//
+// Solidity: function getAnswer(uint256 _roundId) view returns(int256)
+func (_Feed *FeedSession) GetAnswer(_roundId *big.Int) (*big.Int, error) {
+	return _Feed.Contract.GetAnswer(&_Feed.CallOpts, _roundId)
+}
+
+// GetAnswer is a free data retrieval call binding the contract method 0xb5ab58dc.
+//
+// Solidity: function getAnswer(uint256 _roundId) view returns(int256)
+func (_Feed *FeedCallerSession) GetAnswer(_roundId *big.Int) (*big.Int, error) {
+	return _Feed.Contract.GetAnswer(&_Feed.CallOpts, _roundId)
+}
+
+// GetRoundData is a free data retrieval call binding the contract method 0x9a6fc8f5.
+//
+// Solidity: function getRoundData(uint80 _roundId) view returns(uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound)
+func (_Feed *FeedCaller) GetRoundData(opts *bind.CallOpts, _roundId *big.Int) (struct {
+	RoundId         *big.Int
+	Answer          *big.Int
+	StartedAt       *big.Int
+	UpdatedAt       *big.Int
+	AnsweredInRound *big.Int
+}, error) {
+	var out []interface{}
+	err := _Feed.contract.Call(opts, &out, "getRoundData", _roundId)
+
+	outstruct := new(struct {
+		RoundId         *big.Int
+		Answer          *big.Int
+		StartedAt       *big.Int
+		UpdatedAt       *big.Int
+		AnsweredInRound *big.Int
+	})
+	if err != nil {
+		return *outstruct, err
+	}
+
+	outstruct.RoundId = *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+	outstruct.Answer = *abi.ConvertType(out[1], new(*big.Int)).(**big.Int)
+	outstruct.StartedAt = *abi.ConvertType(out[2], new(*big.Int)).(**big.Int)
+	outstruct.UpdatedAt = *abi.ConvertType(out[3], new(*big.Int)).(**big.Int)
+	outstruct.AnsweredInRound = *abi.ConvertType(out[4], new(*big.Int)).(**big.Int)
+
+	return *outstruct, err
+
+}
+
+// GetRoundData is a free data retrieval call binding the contract method 0x9a6fc8f5.
+//
+// Solidity: function getRoundData(uint80 _roundId) view returns(uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound)
+func (_Feed *FeedSession) GetRoundData(_roundId *big.Int) (struct {
+	RoundId         *big.Int
+	Answer          *big.Int
+	StartedAt       *big.Int
+	UpdatedAt       *big.Int
+	AnsweredInRound *big.Int
+}, error) {
+	return _Feed.Contract.GetRoundData(&_Feed.CallOpts, _roundId)
+}
+
+// GetRoundData is a free data retrieval call binding the contract method 0x9a6fc8f5.
+//
+// Solidity: function getRoundData(uint80 _roundId) view returns(uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound)
+func (_Feed *FeedCallerSession) GetRoundData(_roundId *big.Int) (struct {
+	RoundId         *big.Int
+	Answer          *big.Int
+	StartedAt       *big.Int
+	UpdatedAt       *big.Int
+	AnsweredInRound *big.Int
+}, error) {
+	return _Feed.Contract.GetRoundData(&_Feed.CallOpts, _roundId)
+}
+
+// GetTimestamp is a free data retrieval call binding the contract method 0xb633620c.
+//
+// Solidity: function getTimestamp(uint256 _roundId) view returns(uint256)
+func (_Feed *FeedCaller) GetTimestamp(opts *bind.CallOpts, _roundId *big.Int) (*big.Int, error) {
+	var out []interface{}
+	err := _Feed.contract.Call(opts, &out, "getTimestamp", _roundId)
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// GetTimestamp is a free data retrieval call binding the contract method 0xb633620c.
+//
+// Solidity: function getTimestamp(uint256 _roundId) view returns(uint256)
+func (_Feed *FeedSession) GetTimestamp(_roundId *big.Int) (*big.Int, error) {
+	return _Feed.Contract.GetTimestamp(&_Feed.CallOpts, _roundId)
+}
+
+// GetTimestamp is a free data retrieval call binding the contract method 0xb633620c.
+//
+// Solidity: function getTimestamp(uint256 _roundId) view returns(uint256)
+func (_Feed *FeedCallerSession) GetTimestamp(_roundId *big.Int) (*big.Int, error) {
+	return _Feed.Contract.GetTimestamp(&_Feed.CallOpts, _roundId)
+}
+
+// LatestAnswer is a free data retrieval call binding the contract method 0x50d25bcd.
+//
+// Solidity: function latestAnswer() view returns(int256)
+func (_Feed *FeedCaller) LatestAnswer(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _Feed.contract.Call(opts, &out, "latestAnswer")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// LatestAnswer is a free data retrieval call binding the contract method 0x50d25bcd.
+//
+// Solidity: function latestAnswer() view returns(int256)
+func (_Feed *FeedSession) LatestAnswer() (*big.Int, error) {
+	return _Feed.Contract.LatestAnswer(&_Feed.CallOpts)
+}
+
+// LatestAnswer is a free data retrieval call binding the contract method 0x50d25bcd.
+//
+// Solidity: function latestAnswer() view returns(int256)
+func (_Feed *FeedCallerSession) LatestAnswer() (*big.Int, error) {
+	return _Feed.Contract.LatestAnswer(&_Feed.CallOpts)
+}
+
+// LatestRound is a free data retrieval call binding the contract method 0x668a0f02.
+//
+// Solidity: function latestRound() view returns(uint256)
+func (_Feed *FeedCaller) LatestRound(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _Feed.contract.Call(opts, &out, "latestRound")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// LatestRound is a free data retrieval call binding the contract method 0x668a0f02.
+//
+// Solidity: function latestRound() view returns(uint256)
+func (_Feed *FeedSession) LatestRound() (*big.Int, error) {
+	return _Feed.Contract.LatestRound(&_Feed.CallOpts)
+}
+
+// LatestRound is a free data retrieval call binding the contract method 0x668a0f02.
+//
+// Solidity: function latestRound() view returns(uint256)
+func (_Feed *FeedCallerSession) LatestRound() (*big.Int, error) {
+	return _Feed.Contract.LatestRound(&_Feed.CallOpts)
+}
+
+// LatestRoundData is a free data retrieval call binding the contract method 0xfeaf968c.
+//
+// Solidity: function latestRoundData() view returns(uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound)
+func (_Feed *FeedCaller) LatestRoundData(opts *bind.CallOpts) (struct {
+	RoundId         *big.Int
+	Answer          *big.Int
+	StartedAt       *big.Int
+	UpdatedAt       *big.Int
+	AnsweredInRound *big.Int
+}, error) {
+	var out []interface{}
+	err := _Feed.contract.Call(opts, &out, "latestRoundData")
+
+	outstruct := new(struct {
+		RoundId         *big.Int
+		Answer          *big.Int
+		StartedAt       *big.Int
+		UpdatedAt       *big.Int
+		AnsweredInRound *big.Int
+	})
+	if err != nil {
+		return *outstruct, err
+	}
+
+	outstruct.RoundId = *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+	outstruct.Answer = *abi.ConvertType(out[1], new(*big.Int)).(**big.Int)
+	outstruct.StartedAt = *abi.ConvertType(out[2], new(*big.Int)).(**big.Int)
+	outstruct.UpdatedAt = *abi.ConvertType(out[3], new(*big.Int)).(**big.Int)
+	outstruct.AnsweredInRound = *abi.ConvertType(out[4], new(*big.Int)).(**big.Int)
+
+	return *outstruct, err
+
+}
+
+// LatestRoundData is a free data retrieval call binding the contract method 0xfeaf968c.
+//
+// Solidity: function latestRoundData() view returns(uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound)
+func (_Feed *FeedSession) LatestRoundData() (struct {
+	RoundId         *big.Int
+	Answer          *big.Int
+	StartedAt       *big.Int
+	UpdatedAt       *big.Int
+	AnsweredInRound *big.Int
+}, error) {
+	return _Feed.Contract.LatestRoundData(&_Feed.CallOpts)
+}
+
+// LatestRoundData is a free data retrieval call binding the contract method 0xfeaf968c.
+//
+// Solidity: function latestRoundData() view returns(uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound)
+func (_Feed *FeedCallerSession) LatestRoundData() (struct {
+	RoundId         *big.Int
+	Answer          *big.Int
+	StartedAt       *big.Int
+	UpdatedAt       *big.Int
+	AnsweredInRound *big.Int
+}, error) {
+	return _Feed.Contract.LatestRoundData(&_Feed.CallOpts)
+}
+
+// LatestTimestamp is a free data retrieval call binding the contract method 0x8205bf6a.
+//
+// Solidity: function latestTimestamp() view returns(uint256)
+func (_Feed *FeedCaller) LatestTimestamp(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _Feed.contract.Call(opts, &out, "latestTimestamp")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// LatestTimestamp is a free data retrieval call binding the contract method 0x8205bf6a.
+//
+// Solidity: function latestTimestamp() view returns(uint256)
+func (_Feed *FeedSession) LatestTimestamp() (*big.Int, error) {
+	return _Feed.Contract.LatestTimestamp(&_Feed.CallOpts)
+}
+
+// LatestTimestamp is a free data retrieval call binding the contract method 0x8205bf6a.
+//
+// Solidity: function latestTimestamp() view returns(uint256)
+func (_Feed *FeedCallerSession) LatestTimestamp() (*big.Int, error) {
+	return _Feed.Contract.LatestTimestamp(&_Feed.CallOpts)
+}
+
+// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
+//
+// Solidity: function owner() view returns(address)
+func (_Feed *FeedCaller) Owner(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _Feed.contract.Call(opts, &out, "owner")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
+//
+// Solidity: function owner() view returns(address)
+func (_Feed *FeedSession) Owner() (common.Address, error) {
+	return _Feed.Contract.Owner(&_Feed.CallOpts)
+}
+
+// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
+//
+// Solidity: function owner() view returns(address)
+func (_Feed *FeedCallerSession) Owner() (common.Address, error) {
+	return _Feed.Contract.Owner(&_Feed.CallOpts)
+}
+
+// PhaseAggregators is a free data retrieval call binding the contract method 0xc1597304.
+//
+// Solidity: function phaseAggregators(uint16 ) view returns(address)
+func (_Feed *FeedCaller) PhaseAggregators(opts *bind.CallOpts, arg0 uint16) (common.Address, error) {
+	var out []interface{}
+	err := _Feed.contract.Call(opts, &out, "phaseAggregators", arg0)
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// PhaseAggregators is a free data retrieval call binding the contract method 0xc1597304.
+//
+// Solidity: function phaseAggregators(uint16 ) view returns(address)
+func (_Feed *FeedSession) PhaseAggregators(arg0 uint16) (common.Address, error) {
+	return _Feed.Contract.PhaseAggregators(&_Feed.CallOpts, arg0)
+}
+
+// PhaseAggregators is a free data retrieval call binding the contract method 0xc1597304.
+//
+// Solidity: function phaseAggregators(uint16 ) view returns(address)
+func (_Feed *FeedCallerSession) PhaseAggregators(arg0 uint16) (common.Address, error) {
+	return _Feed.Contract.PhaseAggregators(&_Feed.CallOpts, arg0)
+}
+
+// PhaseId is a free data retrieval call binding the contract method 0x58303b10.
+//
+// Solidity: function phaseId() view returns(uint16)
+func (_Feed *FeedCaller) PhaseId(opts *bind.CallOpts) (uint16, error) {
+	var out []interface{}
+	err := _Feed.contract.Call(opts, &out, "phaseId")
+
+	if err != nil {
+		return *new(uint16), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(uint16)).(*uint16)
+
+	return out0, err
+
+}
+
+// PhaseId is a free data retrieval call binding the contract method 0x58303b10.
+//
+// Solidity: function phaseId() view returns(uint16)
+func (_Feed *FeedSession) PhaseId() (uint16, error) {
+	return _Feed.Contract.PhaseId(&_Feed.CallOpts)
+}
+
+// PhaseId is a free data retrieval call binding the contract method 0x58303b10.
+//
+// Solidity: function phaseId() view returns(uint16)
+func (_Feed *FeedCallerSession) PhaseId() (uint16, error) {
+	return _Feed.Contract.PhaseId(&_Feed.CallOpts)
+}
+
+// ProposedAggregator is a free data retrieval call binding the contract method 0xe8c4be30.
+//
+// Solidity: function proposedAggregator() view returns(address)
+func (_Feed *FeedCaller) ProposedAggregator(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _Feed.contract.Call(opts, &out, "proposedAggregator")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// ProposedAggregator is a free data retrieval call binding the contract method 0xe8c4be30.
+//
+// Solidity: function proposedAggregator() view returns(address)
+func (_Feed *FeedSession) ProposedAggregator() (common.Address, error) {
+	return _Feed.Contract.ProposedAggregator(&_Feed.CallOpts)
+}
+
+// ProposedAggregator is a free data retrieval call binding the contract method 0xe8c4be30.
+//
+// Solidity: function proposedAggregator() view returns(address)
+func (_Feed *FeedCallerSession) ProposedAggregator() (common.Address, error) {
+	return _Feed.Contract.ProposedAggregator(&_Feed.CallOpts)
+}
+
+// ProposedGetRoundData is a free data retrieval call binding the contract method 0x6001ac53.
+//
+// Solidity: function proposedGetRoundData(uint80 _roundId) view returns(uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound)
+func (_Feed *FeedCaller) ProposedGetRoundData(opts *bind.CallOpts, _roundId *big.Int) (struct {
+	RoundId         *big.Int
+	Answer          *big.Int
+	StartedAt       *big.Int
+	UpdatedAt       *big.Int
+	AnsweredInRound *big.Int
+}, error) {
+	var out []interface{}
+	err := _Feed.contract.Call(opts, &out, "proposedGetRoundData", _roundId)
+
+	outstruct := new(struct {
+		RoundId         *big.Int
+		Answer          *big.Int
+		StartedAt       *big.Int
+		UpdatedAt       *big.Int
+		AnsweredInRound *big.Int
+	})
+	if err != nil {
+		return *outstruct, err
+	}
+
+	outstruct.RoundId = *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+	outstruct.Answer = *abi.ConvertType(out[1], new(*big.Int)).(**big.Int)
+	outstruct.StartedAt = *abi.ConvertType(out[2], new(*big.Int)).(**big.Int)
+	outstruct.UpdatedAt = *abi.ConvertType(out[3], new(*big.Int)).(**big.Int)
+	outstruct.AnsweredInRound = *abi.ConvertType(out[4], new(*big.Int)).(**big.Int)
+
+	return *outstruct, err
+
+}
+
+// ProposedGetRoundData is a free data retrieval call binding the contract method 0x6001ac53.
+//
+// Solidity: function proposedGetRoundData(uint80 _roundId) view returns(uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound)
+func (_Feed *FeedSession) ProposedGetRoundData(_roundId *big.Int) (struct {
+	RoundId         *big.Int
+	Answer          *big.Int
+	StartedAt       *big.Int
+	UpdatedAt       *big.Int
+	AnsweredInRound *big.Int
+}, error) {
+	return _Feed.Contract.ProposedGetRoundData(&_Feed.CallOpts, _roundId)
+}
+
+// ProposedGetRoundData is a free data retrieval call binding the contract method 0x6001ac53.
+//
+// Solidity: function proposedGetRoundData(uint80 _roundId) view returns(uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound)
+func (_Feed *FeedCallerSession) ProposedGetRoundData(_roundId *big.Int) (struct {
+	RoundId         *big.Int
+	Answer          *big.Int
+	StartedAt       *big.Int
+	UpdatedAt       *big.Int
+	AnsweredInRound *big.Int
+}, error) {
+	return _Feed.Contract.ProposedGetRoundData(&_Feed.CallOpts, _roundId)
+}
+
+// ProposedLatestRoundData is a free data retrieval call binding the contract method 0x8f6b4d91.
+//
+// Solidity: function proposedLatestRoundData() view returns(uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound)
+func (_Feed *FeedCaller) ProposedLatestRoundData(opts *bind.CallOpts) (struct {
+	RoundId         *big.Int
+	Answer          *big.Int
+	StartedAt       *big.Int
+	UpdatedAt       *big.Int
+	AnsweredInRound *big.Int
+}, error) {
+	var out []interface{}
+	err := _Feed.contract.Call(opts, &out, "proposedLatestRoundData")
+
+	outstruct := new(struct {
+		RoundId         *big.Int
+		Answer          *big.Int
+		StartedAt       *big.Int
+		UpdatedAt       *big.Int
+		AnsweredInRound *big.Int
+	})
+	if err != nil {
+		return *outstruct, err
+	}
+
+	outstruct.RoundId = *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+	outstruct.Answer = *abi.ConvertType(out[1], new(*big.Int)).(**big.Int)
+	outstruct.StartedAt = *abi.ConvertType(out[2], new(*big.Int)).(**big.Int)
+	outstruct.UpdatedAt = *abi.ConvertType(out[3], new(*big.Int)).(**big.Int)
+	outstruct.AnsweredInRound = *abi.ConvertType(out[4], new(*big.Int)).(**big.Int)
+
+	return *outstruct, err
+
+}
+
+// ProposedLatestRoundData is a free data retrieval call binding the contract method 0x8f6b4d91.
+//
+// Solidity: function proposedLatestRoundData() view returns(uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound)
+func (_Feed *FeedSession) ProposedLatestRoundData() (struct {
+	RoundId         *big.Int
+	Answer          *big.Int
+	StartedAt       *big.Int
+	UpdatedAt       *big.Int
+	AnsweredInRound *big.Int
+}, error) {
+	return _Feed.Contract.ProposedLatestRoundData(&_Feed.CallOpts)
+}
+
+// ProposedLatestRoundData is a free data retrieval call binding the contract method 0x8f6b4d91.
+//
+// Solidity: function proposedLatestRoundData() view returns(uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound)
+func (_Feed *FeedCallerSession) ProposedLatestRoundData() (struct {
+	RoundId         *big.Int
+	Answer          *big.Int
+	StartedAt       *big.Int
+	UpdatedAt       *big.Int
+	AnsweredInRound *big.Int
+}, error) {
+	return _Feed.Contract.ProposedLatestRoundData(&_Feed.CallOpts)
+}
+
+// Version is a free data retrieval call binding the contract method 0x54fd4d50.
+//
+// Solidity: function version() view returns(uint256)
+func (_Feed *FeedCaller) Version(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _Feed.contract.Call(opts, &out, "version")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// Version is a free data retrieval call binding the contract method 0x54fd4d50.
+//
+// Solidity: function version() view returns(uint256)
+func (_Feed *FeedSession) Version() (*big.Int, error) {
+	return _Feed.Contract.Version(&_Feed.CallOpts)
+}
+
+// Version is a free data retrieval call binding the contract method 0x54fd4d50.
+//
+// Solidity: function version() view returns(uint256)
+func (_Feed *FeedCallerSession) Version() (*big.Int, error) {
+	return _Feed.Contract.Version(&_Feed.CallOpts)
+}
+
+// AcceptOwnership is a paid mutator transaction binding the contract method 0x79ba5097.
+//
+// Solidity: function acceptOwnership() returns()
+func (_Feed *FeedTransactor) AcceptOwnership(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Feed.contract.Transact(opts, "acceptOwnership")
+}
+
+// AcceptOwnership is a paid mutator transaction binding the contract method 0x79ba5097.
+//
+// Solidity: function acceptOwnership() returns()
+func (_Feed *FeedSession) AcceptOwnership() (*types.Transaction, error) {
+	return _Feed.Contract.AcceptOwnership(&_Feed.TransactOpts)
+}
+
+// AcceptOwnership is a paid mutator transaction binding the contract method 0x79ba5097.
+//
+// Solidity: function acceptOwnership() returns()
+func (_Feed *FeedTransactorSession) AcceptOwnership() (*types.Transaction, error) {
+	return _Feed.Contract.AcceptOwnership(&_Feed.TransactOpts)
+}
+
+// ConfirmAggregator is a paid mutator transaction binding the contract method 0xa928c096.
+//
+// Solidity: function confirmAggregator(address _aggregator) returns()
+func (_Feed *FeedTransactor) ConfirmAggregator(opts *bind.TransactOpts, _aggregator common.Address) (*types.Transaction, error) {
+	return _Feed.contract.Transact(opts, "confirmAggregator", _aggregator)
+}
+
+// ConfirmAggregator is a paid mutator transaction binding the contract method 0xa928c096.
+//
+// Solidity: function confirmAggregator(address _aggregator) returns()
+func (_Feed *FeedSession) ConfirmAggregator(_aggregator common.Address) (*types.Transaction, error) {
+	return _Feed.Contract.ConfirmAggregator(&_Feed.TransactOpts, _aggregator)
+}
+
+// ConfirmAggregator is a paid mutator transaction binding the contract method 0xa928c096.
+//
+// Solidity: function confirmAggregator(address _aggregator) returns()
+func (_Feed *FeedTransactorSession) ConfirmAggregator(_aggregator common.Address) (*types.Transaction, error) {
+	return _Feed.Contract.ConfirmAggregator(&_Feed.TransactOpts, _aggregator)
+}
+
+// ProposeAggregator is a paid mutator transaction binding the contract method 0xf8a2abd3.
+//
+// Solidity: function proposeAggregator(address _aggregator) returns()
+func (_Feed *FeedTransactor) ProposeAggregator(opts *bind.TransactOpts, _aggregator common.Address) (*types.Transaction, error) {
+	return _Feed.contract.Transact(opts, "proposeAggregator", _aggregator)
+}
+
+// ProposeAggregator is a paid mutator transaction binding the contract method 0xf8a2abd3.
+//
+// Solidity: function proposeAggregator(address _aggregator) returns()
+func (_Feed *FeedSession) ProposeAggregator(_aggregator common.Address) (*types.Transaction, error) {
+	return _Feed.Contract.ProposeAggregator(&_Feed.TransactOpts, _aggregator)
+}
+
+// ProposeAggregator is a paid mutator transaction binding the contract method 0xf8a2abd3.
+//
+// Solidity: function proposeAggregator(address _aggregator) returns()
+func (_Feed *FeedTransactorSession) ProposeAggregator(_aggregator common.Address) (*types.Transaction, error) {
+	return _Feed.Contract.ProposeAggregator(&_Feed.TransactOpts, _aggregator)
+}
+
+// SetController is a paid mutator transaction binding the contract method 0x92eefe9b.
+//
+// Solidity: function setController(address _accessController) returns()
+func (_Feed *FeedTransactor) SetController(opts *bind.TransactOpts, _accessController common.Address) (*types.Transaction, error) {
+	return _Feed.contract.Transact(opts, "setController", _accessController)
+}
+
+// SetController is a paid mutator transaction binding the contract method 0x92eefe9b.
+//
+// Solidity: function setController(address _accessController) returns()
+func (_Feed *FeedSession) SetController(_accessController common.Address) (*types.Transaction, error) {
+	return _Feed.Contract.SetController(&_Feed.TransactOpts, _accessController)
+}
+
+// SetController is a paid mutator transaction binding the contract method 0x92eefe9b.
+//
+// Solidity: function setController(address _accessController) returns()
+func (_Feed *FeedTransactorSession) SetController(_accessController common.Address) (*types.Transaction, error) {
+	return _Feed.Contract.SetController(&_Feed.TransactOpts, _accessController)
+}
+
+// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
+//
+// Solidity: function transferOwnership(address _to) returns()
+func (_Feed *FeedTransactor) TransferOwnership(opts *bind.TransactOpts, _to common.Address) (*types.Transaction, error) {
+	return _Feed.contract.Transact(opts, "transferOwnership", _to)
+}
+
+// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
+//
+// Solidity: function transferOwnership(address _to) returns()
+func (_Feed *FeedSession) TransferOwnership(_to common.Address) (*types.Transaction, error) {
+	return _Feed.Contract.TransferOwnership(&_Feed.TransactOpts, _to)
+}
+
+// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
+//
+// Solidity: function transferOwnership(address _to) returns()
+func (_Feed *FeedTransactorSession) TransferOwnership(_to common.Address) (*types.Transaction, error) {
+	return _Feed.Contract.TransferOwnership(&_Feed.TransactOpts, _to)
+}
+
+// FeedAnswerUpdatedIterator is returned from FilterAnswerUpdated and is used to iterate over the raw logs and unpacked data for AnswerUpdated events raised by the Feed contract.
+type FeedAnswerUpdatedIterator struct {
+	Event *FeedAnswerUpdated // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *FeedAnswerUpdatedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(FeedAnswerUpdated)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(FeedAnswerUpdated)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *FeedAnswerUpdatedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *FeedAnswerUpdatedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// FeedAnswerUpdated represents a AnswerUpdated event raised by the Feed contract.
+type FeedAnswerUpdated struct {
+	Current   *big.Int
+	RoundId   *big.Int
+	UpdatedAt *big.Int
+	Raw       types.Log // Blockchain specific contextual infos
+}
+
+// FilterAnswerUpdated is a free log retrieval operation binding the contract event 0x0559884fd3a460db3073b7fc896cc77986f16e378210ded43186175bf646fc5f.
+//
+// Solidity: event AnswerUpdated(int256 indexed current, uint256 indexed roundId, uint256 updatedAt)
+func (_Feed *FeedFilterer) FilterAnswerUpdated(opts *bind.FilterOpts, current []*big.Int, roundId []*big.Int) (*FeedAnswerUpdatedIterator, error) {
+
+	var currentRule []interface{}
+	for _, currentItem := range current {
+		currentRule = append(currentRule, currentItem)
+	}
+	var roundIdRule []interface{}
+	for _, roundIdItem := range roundId {
+		roundIdRule = append(roundIdRule, roundIdItem)
+	}
+
+	logs, sub, err := _Feed.contract.FilterLogs(opts, "AnswerUpdated", currentRule, roundIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return &FeedAnswerUpdatedIterator{contract: _Feed.contract, event: "AnswerUpdated", logs: logs, sub: sub}, nil
+}
+
+// WatchAnswerUpdated is a free log subscription operation binding the contract event 0x0559884fd3a460db3073b7fc896cc77986f16e378210ded43186175bf646fc5f.
+//
+// Solidity: event AnswerUpdated(int256 indexed current, uint256 indexed roundId, uint256 updatedAt)
+func (_Feed *FeedFilterer) WatchAnswerUpdated(opts *bind.WatchOpts, sink chan<- *FeedAnswerUpdated, current []*big.Int, roundId []*big.Int) (event.Subscription, error) {
+
+	var currentRule []interface{}
+	for _, currentItem := range current {
+		currentRule = append(currentRule, currentItem)
+	}
+	var roundIdRule []interface{}
+	for _, roundIdItem := range roundId {
+		roundIdRule = append(roundIdRule, roundIdItem)
+	}
+
+	logs, sub, err := _Feed.contract.WatchLogs(opts, "AnswerUpdated", currentRule, roundIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(FeedAnswerUpdated)
+				if err := _Feed.contract.UnpackLog(event, "AnswerUpdated", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseAnswerUpdated is a log parse operation binding the contract event 0x0559884fd3a460db3073b7fc896cc77986f16e378210ded43186175bf646fc5f.
+//
+// Solidity: event AnswerUpdated(int256 indexed current, uint256 indexed roundId, uint256 updatedAt)
+func (_Feed *FeedFilterer) ParseAnswerUpdated(log types.Log) (*FeedAnswerUpdated, error) {
+	event := new(FeedAnswerUpdated)
+	if err := _Feed.contract.UnpackLog(event, "AnswerUpdated", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// FeedNewRoundIterator is returned from FilterNewRound and is used to iterate over the raw logs and unpacked data for NewRound events raised by the Feed contract.
+type FeedNewRoundIterator struct {
+	Event *FeedNewRound // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *FeedNewRoundIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(FeedNewRound)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(FeedNewRound)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *FeedNewRoundIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *FeedNewRoundIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// FeedNewRound represents a NewRound event raised by the Feed contract.
+type FeedNewRound struct {
+	RoundId   *big.Int
+	StartedBy common.Address
+	StartedAt *big.Int
+	Raw       types.Log // Blockchain specific contextual infos
+}
+
+// FilterNewRound is a free log retrieval operation binding the contract event 0x0109fc6f55cf40689f02fbaad7af7fe7bbac8a3d2186600afc7d3e10cac60271.
+//
+// Solidity: event NewRound(uint256 indexed roundId, address indexed startedBy, uint256 startedAt)
+func (_Feed *FeedFilterer) FilterNewRound(opts *bind.FilterOpts, roundId []*big.Int, startedBy []common.Address) (*FeedNewRoundIterator, error) {
+
+	var roundIdRule []interface{}
+	for _, roundIdItem := range roundId {
+		roundIdRule = append(roundIdRule, roundIdItem)
+	}
+	var startedByRule []interface{}
+	for _, startedByItem := range startedBy {
+		startedByRule = append(startedByRule, startedByItem)
+	}
+
+	logs, sub, err := _Feed.contract.FilterLogs(opts, "NewRound", roundIdRule, startedByRule)
+	if err != nil {
+		return nil, err
+	}
+	return &FeedNewRoundIterator{contract: _Feed.contract, event: "NewRound", logs: logs, sub: sub}, nil
+}
+
+// WatchNewRound is a free log subscription operation binding the contract event 0x0109fc6f55cf40689f02fbaad7af7fe7bbac8a3d2186600afc7d3e10cac60271.
+//
+// Solidity: event NewRound(uint256 indexed roundId, address indexed startedBy, uint256 startedAt)
+func (_Feed *FeedFilterer) WatchNewRound(opts *bind.WatchOpts, sink chan<- *FeedNewRound, roundId []*big.Int, startedBy []common.Address) (event.Subscription, error) {
+
+	var roundIdRule []interface{}
+	for _, roundIdItem := range roundId {
+		roundIdRule = append(roundIdRule, roundIdItem)
+	}
+	var startedByRule []interface{}
+	for _, startedByItem := range startedBy {
+		startedByRule = append(startedByRule, startedByItem)
+	}
+
+	logs, sub, err := _Feed.contract.WatchLogs(opts, "NewRound", roundIdRule, startedByRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(FeedNewRound)
+				if err := _Feed.contract.UnpackLog(event, "NewRound", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseNewRound is a log parse operation binding the contract event 0x0109fc6f55cf40689f02fbaad7af7fe7bbac8a3d2186600afc7d3e10cac60271.
+//
+// Solidity: event NewRound(uint256 indexed roundId, address indexed startedBy, uint256 startedAt)
+func (_Feed *FeedFilterer) ParseNewRound(log types.Log) (*FeedNewRound, error) {
+	event := new(FeedNewRound)
+	if err := _Feed.contract.UnpackLog(event, "NewRound", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// FeedOwnershipTransferRequestedIterator is returned from FilterOwnershipTransferRequested and is used to iterate over the raw logs and unpacked data for OwnershipTransferRequested events raised by the Feed contract.
+type FeedOwnershipTransferRequestedIterator struct {
+	Event *FeedOwnershipTransferRequested // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *FeedOwnershipTransferRequestedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(FeedOwnershipTransferRequested)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(FeedOwnershipTransferRequested)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *FeedOwnershipTransferRequestedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *FeedOwnershipTransferRequestedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// FeedOwnershipTransferRequested represents a OwnershipTransferRequested event raised by the Feed contract.
+type FeedOwnershipTransferRequested struct {
+	From common.Address
+	To   common.Address
+	Raw  types.Log // Blockchain specific contextual infos
+}
+
+// FilterOwnershipTransferRequested is a free log retrieval operation binding the contract event 0xed8889f560326eb138920d842192f0eb3dd22b4f139c87a2c57538e05bae1278.
+//
+// Solidity: event OwnershipTransferRequested(address indexed from, address indexed to)
+func (_Feed *FeedFilterer) FilterOwnershipTransferRequested(opts *bind.FilterOpts, from []common.Address, to []common.Address) (*FeedOwnershipTransferRequestedIterator, error) {
+
+	var fromRule []interface{}
+	for _, fromItem := range from {
+		fromRule = append(fromRule, fromItem)
+	}
+	var toRule []interface{}
+	for _, toItem := range to {
+		toRule = append(toRule, toItem)
+	}
+
+	logs, sub, err := _Feed.contract.FilterLogs(opts, "OwnershipTransferRequested", fromRule, toRule)
+	if err != nil {
+		return nil, err
+	}
+	return &FeedOwnershipTransferRequestedIterator{contract: _Feed.contract, event: "OwnershipTransferRequested", logs: logs, sub: sub}, nil
+}
+
+// WatchOwnershipTransferRequested is a free log subscription operation binding the contract event 0xed8889f560326eb138920d842192f0eb3dd22b4f139c87a2c57538e05bae1278.
+//
+// Solidity: event OwnershipTransferRequested(address indexed from, address indexed to)
+func (_Feed *FeedFilterer) WatchOwnershipTransferRequested(opts *bind.WatchOpts, sink chan<- *FeedOwnershipTransferRequested, from []common.Address, to []common.Address) (event.Subscription, error) {
+
+	var fromRule []interface{}
+	for _, fromItem := range from {
+		fromRule = append(fromRule, fromItem)
+	}
+	var toRule []interface{}
+	for _, toItem := range to {
+		toRule = append(toRule, toItem)
+	}
+
+	logs, sub, err := _Feed.contract.WatchLogs(opts, "OwnershipTransferRequested", fromRule, toRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(FeedOwnershipTransferRequested)
+				if err := _Feed.contract.UnpackLog(event, "OwnershipTransferRequested", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseOwnershipTransferRequested is a log parse operation binding the contract event 0xed8889f560326eb138920d842192f0eb3dd22b4f139c87a2c57538e05bae1278.
+//
+// Solidity: event OwnershipTransferRequested(address indexed from, address indexed to)
+func (_Feed *FeedFilterer) ParseOwnershipTransferRequested(log types.Log) (*FeedOwnershipTransferRequested, error) {
+	event := new(FeedOwnershipTransferRequested)
+	if err := _Feed.contract.UnpackLog(event, "OwnershipTransferRequested", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// FeedOwnershipTransferredIterator is returned from FilterOwnershipTransferred and is used to iterate over the raw logs and unpacked data for OwnershipTransferred events raised by the Feed contract.
+type FeedOwnershipTransferredIterator struct {
+	Event *FeedOwnershipTransferred // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *FeedOwnershipTransferredIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(FeedOwnershipTransferred)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(FeedOwnershipTransferred)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *FeedOwnershipTransferredIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *FeedOwnershipTransferredIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// FeedOwnershipTransferred represents a OwnershipTransferred event raised by the Feed contract.
+type FeedOwnershipTransferred struct {
+	From common.Address
+	To   common.Address
+	Raw  types.Log // Blockchain specific contextual infos
+}
+
+// FilterOwnershipTransferred is a free log retrieval operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
+//
+// Solidity: event OwnershipTransferred(address indexed from, address indexed to)
+func (_Feed *FeedFilterer) FilterOwnershipTransferred(opts *bind.FilterOpts, from []common.Address, to []common.Address) (*FeedOwnershipTransferredIterator, error) {
+
+	var fromRule []interface{}
+	for _, fromItem := range from {
+		fromRule = append(fromRule, fromItem)
+	}
+	var toRule []interface{}
+	for _, toItem := range to {
+		toRule = append(toRule, toItem)
+	}
+
+	logs, sub, err := _Feed.contract.FilterLogs(opts, "OwnershipTransferred", fromRule, toRule)
+	if err != nil {
+		return nil, err
+	}
+	return &FeedOwnershipTransferredIterator{contract: _Feed.contract, event: "OwnershipTransferred", logs: logs, sub: sub}, nil
+}
+
+// WatchOwnershipTransferred is a free log subscription operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
+//
+// Solidity: event OwnershipTransferred(address indexed from, address indexed to)
+func (_Feed *FeedFilterer) WatchOwnershipTransferred(opts *bind.WatchOpts, sink chan<- *FeedOwnershipTransferred, from []common.Address, to []common.Address) (event.Subscription, error) {
+
+	var fromRule []interface{}
+	for _, fromItem := range from {
+		fromRule = append(fromRule, fromItem)
+	}
+	var toRule []interface{}
+	for _, toItem := range to {
+		toRule = append(toRule, toItem)
+	}
+
+	logs, sub, err := _Feed.contract.WatchLogs(opts, "OwnershipTransferred", fromRule, toRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(FeedOwnershipTransferred)
+				if err := _Feed.contract.UnpackLog(event, "OwnershipTransferred", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseOwnershipTransferred is a log parse operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
+//
+// Solidity: event OwnershipTransferred(address indexed from, address indexed to)
+func (_Feed *FeedFilterer) ParseOwnershipTransferred(log types.Log) (*FeedOwnershipTransferred, error) {
+	event := new(FeedOwnershipTransferred)
+	if err := _Feed.contract.UnpackLog(event, "OwnershipTransferred", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}

--- a/price/chainlink_feed/chainlink_feed.go
+++ b/price/chainlink_feed/chainlink_feed.go
@@ -1,0 +1,1573 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package chainlink_feed
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+)
+
+// FeedMetaData contains all meta data concerning the Feed contract.
+var FeedMetaData = &bind.MetaData{
+	ABI: "[{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_aggregator\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"_accessController\",\"type\":\"address\"}],\"stateMutability\":\"nonpayable\",\"type\":\"constructor\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"int256\",\"name\":\"current\",\"type\":\"int256\"},{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"roundId\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"updatedAt\",\"type\":\"uint256\"}],\"name\":\"AnswerUpdated\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"roundId\",\"type\":\"uint256\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"startedBy\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"startedAt\",\"type\":\"uint256\"}],\"name\":\"NewRound\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"from\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"}],\"name\":\"OwnershipTransferRequested\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"from\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"}],\"name\":\"OwnershipTransferred\",\"type\":\"event\"},{\"inputs\":[],\"name\":\"acceptOwnership\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"accessController\",\"outputs\":[{\"internalType\":\"contractAccessControllerInterface\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"aggregator\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_aggregator\",\"type\":\"address\"}],\"name\":\"confirmAggregator\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"decimals\",\"outputs\":[{\"internalType\":\"uint8\",\"name\":\"\",\"type\":\"uint8\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"description\",\"outputs\":[{\"internalType\":\"string\",\"name\":\"\",\"type\":\"string\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"_roundId\",\"type\":\"uint256\"}],\"name\":\"getAnswer\",\"outputs\":[{\"internalType\":\"int256\",\"name\":\"\",\"type\":\"int256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint80\",\"name\":\"_roundId\",\"type\":\"uint80\"}],\"name\":\"getRoundData\",\"outputs\":[{\"internalType\":\"uint80\",\"name\":\"roundId\",\"type\":\"uint80\"},{\"internalType\":\"int256\",\"name\":\"answer\",\"type\":\"int256\"},{\"internalType\":\"uint256\",\"name\":\"startedAt\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"updatedAt\",\"type\":\"uint256\"},{\"internalType\":\"uint80\",\"name\":\"answeredInRound\",\"type\":\"uint80\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"_roundId\",\"type\":\"uint256\"}],\"name\":\"getTimestamp\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"latestAnswer\",\"outputs\":[{\"internalType\":\"int256\",\"name\":\"\",\"type\":\"int256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"latestRound\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"latestRoundData\",\"outputs\":[{\"internalType\":\"uint80\",\"name\":\"roundId\",\"type\":\"uint80\"},{\"internalType\":\"int256\",\"name\":\"answer\",\"type\":\"int256\"},{\"internalType\":\"uint256\",\"name\":\"startedAt\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"updatedAt\",\"type\":\"uint256\"},{\"internalType\":\"uint80\",\"name\":\"answeredInRound\",\"type\":\"uint80\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"latestTimestamp\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"owner\",\"outputs\":[{\"internalType\":\"addresspayable\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint16\",\"name\":\"\",\"type\":\"uint16\"}],\"name\":\"phaseAggregators\",\"outputs\":[{\"internalType\":\"contractAggregatorV2V3Interface\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"phaseId\",\"outputs\":[{\"internalType\":\"uint16\",\"name\":\"\",\"type\":\"uint16\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_aggregator\",\"type\":\"address\"}],\"name\":\"proposeAggregator\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"proposedAggregator\",\"outputs\":[{\"internalType\":\"contractAggregatorV2V3Interface\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint80\",\"name\":\"_roundId\",\"type\":\"uint80\"}],\"name\":\"proposedGetRoundData\",\"outputs\":[{\"internalType\":\"uint80\",\"name\":\"roundId\",\"type\":\"uint80\"},{\"internalType\":\"int256\",\"name\":\"answer\",\"type\":\"int256\"},{\"internalType\":\"uint256\",\"name\":\"startedAt\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"updatedAt\",\"type\":\"uint256\"},{\"internalType\":\"uint80\",\"name\":\"answeredInRound\",\"type\":\"uint80\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"proposedLatestRoundData\",\"outputs\":[{\"internalType\":\"uint80\",\"name\":\"roundId\",\"type\":\"uint80\"},{\"internalType\":\"int256\",\"name\":\"answer\",\"type\":\"int256\"},{\"internalType\":\"uint256\",\"name\":\"startedAt\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"updatedAt\",\"type\":\"uint256\"},{\"internalType\":\"uint80\",\"name\":\"answeredInRound\",\"type\":\"uint80\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_accessController\",\"type\":\"address\"}],\"name\":\"setController\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_to\",\"type\":\"address\"}],\"name\":\"transferOwnership\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"version\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"}]",
+}
+
+// FeedABI is the input ABI used to generate the binding from.
+// Deprecated: Use FeedMetaData.ABI instead.
+var FeedABI = FeedMetaData.ABI
+
+// Feed is an auto generated Go binding around an Ethereum contract.
+type Feed struct {
+	FeedCaller     // Read-only binding to the contract
+	FeedTransactor // Write-only binding to the contract
+	FeedFilterer   // Log filterer for contract events
+}
+
+// FeedCaller is an auto generated read-only Go binding around an Ethereum contract.
+type FeedCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// FeedTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type FeedTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// FeedFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type FeedFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// FeedSession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type FeedSession struct {
+	Contract     *Feed             // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts     // Call options to use throughout this session
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// FeedCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type FeedCallerSession struct {
+	Contract *FeedCaller   // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts // Call options to use throughout this session
+}
+
+// FeedTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type FeedTransactorSession struct {
+	Contract     *FeedTransactor   // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// FeedRaw is an auto generated low-level Go binding around an Ethereum contract.
+type FeedRaw struct {
+	Contract *Feed // Generic contract binding to access the raw methods on
+}
+
+// FeedCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type FeedCallerRaw struct {
+	Contract *FeedCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// FeedTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type FeedTransactorRaw struct {
+	Contract *FeedTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewFeed creates a new instance of Feed, bound to a specific deployed contract.
+func NewFeed(address common.Address, backend bind.ContractBackend) (*Feed, error) {
+	contract, err := bindFeed(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &Feed{FeedCaller: FeedCaller{contract: contract}, FeedTransactor: FeedTransactor{contract: contract}, FeedFilterer: FeedFilterer{contract: contract}}, nil
+}
+
+// NewFeedCaller creates a new read-only instance of Feed, bound to a specific deployed contract.
+func NewFeedCaller(address common.Address, caller bind.ContractCaller) (*FeedCaller, error) {
+	contract, err := bindFeed(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &FeedCaller{contract: contract}, nil
+}
+
+// NewFeedTransactor creates a new write-only instance of Feed, bound to a specific deployed contract.
+func NewFeedTransactor(address common.Address, transactor bind.ContractTransactor) (*FeedTransactor, error) {
+	contract, err := bindFeed(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &FeedTransactor{contract: contract}, nil
+}
+
+// NewFeedFilterer creates a new log filterer instance of Feed, bound to a specific deployed contract.
+func NewFeedFilterer(address common.Address, filterer bind.ContractFilterer) (*FeedFilterer, error) {
+	contract, err := bindFeed(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &FeedFilterer{contract: contract}, nil
+}
+
+// bindFeed binds a generic wrapper to an already deployed contract.
+func bindFeed(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := abi.JSON(strings.NewReader(FeedABI))
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_Feed *FeedRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _Feed.Contract.FeedCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_Feed *FeedRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Feed.Contract.FeedTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_Feed *FeedRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _Feed.Contract.FeedTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_Feed *FeedCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _Feed.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_Feed *FeedTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Feed.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_Feed *FeedTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _Feed.Contract.contract.Transact(opts, method, params...)
+}
+
+// AccessController is a free data retrieval call binding the contract method 0xbc43cbaf.
+//
+// Solidity: function accessController() view returns(address)
+func (_Feed *FeedCaller) AccessController(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _Feed.contract.Call(opts, &out, "accessController")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// AccessController is a free data retrieval call binding the contract method 0xbc43cbaf.
+//
+// Solidity: function accessController() view returns(address)
+func (_Feed *FeedSession) AccessController() (common.Address, error) {
+	return _Feed.Contract.AccessController(&_Feed.CallOpts)
+}
+
+// AccessController is a free data retrieval call binding the contract method 0xbc43cbaf.
+//
+// Solidity: function accessController() view returns(address)
+func (_Feed *FeedCallerSession) AccessController() (common.Address, error) {
+	return _Feed.Contract.AccessController(&_Feed.CallOpts)
+}
+
+// Aggregator is a free data retrieval call binding the contract method 0x245a7bfc.
+//
+// Solidity: function aggregator() view returns(address)
+func (_Feed *FeedCaller) Aggregator(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _Feed.contract.Call(opts, &out, "aggregator")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// Aggregator is a free data retrieval call binding the contract method 0x245a7bfc.
+//
+// Solidity: function aggregator() view returns(address)
+func (_Feed *FeedSession) Aggregator() (common.Address, error) {
+	return _Feed.Contract.Aggregator(&_Feed.CallOpts)
+}
+
+// Aggregator is a free data retrieval call binding the contract method 0x245a7bfc.
+//
+// Solidity: function aggregator() view returns(address)
+func (_Feed *FeedCallerSession) Aggregator() (common.Address, error) {
+	return _Feed.Contract.Aggregator(&_Feed.CallOpts)
+}
+
+// Decimals is a free data retrieval call binding the contract method 0x313ce567.
+//
+// Solidity: function decimals() view returns(uint8)
+func (_Feed *FeedCaller) Decimals(opts *bind.CallOpts) (uint8, error) {
+	var out []interface{}
+	err := _Feed.contract.Call(opts, &out, "decimals")
+
+	if err != nil {
+		return *new(uint8), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(uint8)).(*uint8)
+
+	return out0, err
+
+}
+
+// Decimals is a free data retrieval call binding the contract method 0x313ce567.
+//
+// Solidity: function decimals() view returns(uint8)
+func (_Feed *FeedSession) Decimals() (uint8, error) {
+	return _Feed.Contract.Decimals(&_Feed.CallOpts)
+}
+
+// Decimals is a free data retrieval call binding the contract method 0x313ce567.
+//
+// Solidity: function decimals() view returns(uint8)
+func (_Feed *FeedCallerSession) Decimals() (uint8, error) {
+	return _Feed.Contract.Decimals(&_Feed.CallOpts)
+}
+
+// Description is a free data retrieval call binding the contract method 0x7284e416.
+//
+// Solidity: function description() view returns(string)
+func (_Feed *FeedCaller) Description(opts *bind.CallOpts) (string, error) {
+	var out []interface{}
+	err := _Feed.contract.Call(opts, &out, "description")
+
+	if err != nil {
+		return *new(string), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(string)).(*string)
+
+	return out0, err
+
+}
+
+// Description is a free data retrieval call binding the contract method 0x7284e416.
+//
+// Solidity: function description() view returns(string)
+func (_Feed *FeedSession) Description() (string, error) {
+	return _Feed.Contract.Description(&_Feed.CallOpts)
+}
+
+// Description is a free data retrieval call binding the contract method 0x7284e416.
+//
+// Solidity: function description() view returns(string)
+func (_Feed *FeedCallerSession) Description() (string, error) {
+	return _Feed.Contract.Description(&_Feed.CallOpts)
+}
+
+// GetAnswer is a free data retrieval call binding the contract method 0xb5ab58dc.
+//
+// Solidity: function getAnswer(uint256 _roundId) view returns(int256)
+func (_Feed *FeedCaller) GetAnswer(opts *bind.CallOpts, _roundId *big.Int) (*big.Int, error) {
+	var out []interface{}
+	err := _Feed.contract.Call(opts, &out, "getAnswer", _roundId)
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// GetAnswer is a free data retrieval call binding the contract method 0xb5ab58dc.
+//
+// Solidity: function getAnswer(uint256 _roundId) view returns(int256)
+func (_Feed *FeedSession) GetAnswer(_roundId *big.Int) (*big.Int, error) {
+	return _Feed.Contract.GetAnswer(&_Feed.CallOpts, _roundId)
+}
+
+// GetAnswer is a free data retrieval call binding the contract method 0xb5ab58dc.
+//
+// Solidity: function getAnswer(uint256 _roundId) view returns(int256)
+func (_Feed *FeedCallerSession) GetAnswer(_roundId *big.Int) (*big.Int, error) {
+	return _Feed.Contract.GetAnswer(&_Feed.CallOpts, _roundId)
+}
+
+// GetRoundData is a free data retrieval call binding the contract method 0x9a6fc8f5.
+//
+// Solidity: function getRoundData(uint80 _roundId) view returns(uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound)
+func (_Feed *FeedCaller) GetRoundData(opts *bind.CallOpts, _roundId *big.Int) (struct {
+	RoundId         *big.Int
+	Answer          *big.Int
+	StartedAt       *big.Int
+	UpdatedAt       *big.Int
+	AnsweredInRound *big.Int
+}, error) {
+	var out []interface{}
+	err := _Feed.contract.Call(opts, &out, "getRoundData", _roundId)
+
+	outstruct := new(struct {
+		RoundId         *big.Int
+		Answer          *big.Int
+		StartedAt       *big.Int
+		UpdatedAt       *big.Int
+		AnsweredInRound *big.Int
+	})
+	if err != nil {
+		return *outstruct, err
+	}
+
+	outstruct.RoundId = *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+	outstruct.Answer = *abi.ConvertType(out[1], new(*big.Int)).(**big.Int)
+	outstruct.StartedAt = *abi.ConvertType(out[2], new(*big.Int)).(**big.Int)
+	outstruct.UpdatedAt = *abi.ConvertType(out[3], new(*big.Int)).(**big.Int)
+	outstruct.AnsweredInRound = *abi.ConvertType(out[4], new(*big.Int)).(**big.Int)
+
+	return *outstruct, err
+
+}
+
+// GetRoundData is a free data retrieval call binding the contract method 0x9a6fc8f5.
+//
+// Solidity: function getRoundData(uint80 _roundId) view returns(uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound)
+func (_Feed *FeedSession) GetRoundData(_roundId *big.Int) (struct {
+	RoundId         *big.Int
+	Answer          *big.Int
+	StartedAt       *big.Int
+	UpdatedAt       *big.Int
+	AnsweredInRound *big.Int
+}, error) {
+	return _Feed.Contract.GetRoundData(&_Feed.CallOpts, _roundId)
+}
+
+// GetRoundData is a free data retrieval call binding the contract method 0x9a6fc8f5.
+//
+// Solidity: function getRoundData(uint80 _roundId) view returns(uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound)
+func (_Feed *FeedCallerSession) GetRoundData(_roundId *big.Int) (struct {
+	RoundId         *big.Int
+	Answer          *big.Int
+	StartedAt       *big.Int
+	UpdatedAt       *big.Int
+	AnsweredInRound *big.Int
+}, error) {
+	return _Feed.Contract.GetRoundData(&_Feed.CallOpts, _roundId)
+}
+
+// GetTimestamp is a free data retrieval call binding the contract method 0xb633620c.
+//
+// Solidity: function getTimestamp(uint256 _roundId) view returns(uint256)
+func (_Feed *FeedCaller) GetTimestamp(opts *bind.CallOpts, _roundId *big.Int) (*big.Int, error) {
+	var out []interface{}
+	err := _Feed.contract.Call(opts, &out, "getTimestamp", _roundId)
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// GetTimestamp is a free data retrieval call binding the contract method 0xb633620c.
+//
+// Solidity: function getTimestamp(uint256 _roundId) view returns(uint256)
+func (_Feed *FeedSession) GetTimestamp(_roundId *big.Int) (*big.Int, error) {
+	return _Feed.Contract.GetTimestamp(&_Feed.CallOpts, _roundId)
+}
+
+// GetTimestamp is a free data retrieval call binding the contract method 0xb633620c.
+//
+// Solidity: function getTimestamp(uint256 _roundId) view returns(uint256)
+func (_Feed *FeedCallerSession) GetTimestamp(_roundId *big.Int) (*big.Int, error) {
+	return _Feed.Contract.GetTimestamp(&_Feed.CallOpts, _roundId)
+}
+
+// LatestAnswer is a free data retrieval call binding the contract method 0x50d25bcd.
+//
+// Solidity: function latestAnswer() view returns(int256)
+func (_Feed *FeedCaller) LatestAnswer(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _Feed.contract.Call(opts, &out, "latestAnswer")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// LatestAnswer is a free data retrieval call binding the contract method 0x50d25bcd.
+//
+// Solidity: function latestAnswer() view returns(int256)
+func (_Feed *FeedSession) LatestAnswer() (*big.Int, error) {
+	return _Feed.Contract.LatestAnswer(&_Feed.CallOpts)
+}
+
+// LatestAnswer is a free data retrieval call binding the contract method 0x50d25bcd.
+//
+// Solidity: function latestAnswer() view returns(int256)
+func (_Feed *FeedCallerSession) LatestAnswer() (*big.Int, error) {
+	return _Feed.Contract.LatestAnswer(&_Feed.CallOpts)
+}
+
+// LatestRound is a free data retrieval call binding the contract method 0x668a0f02.
+//
+// Solidity: function latestRound() view returns(uint256)
+func (_Feed *FeedCaller) LatestRound(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _Feed.contract.Call(opts, &out, "latestRound")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// LatestRound is a free data retrieval call binding the contract method 0x668a0f02.
+//
+// Solidity: function latestRound() view returns(uint256)
+func (_Feed *FeedSession) LatestRound() (*big.Int, error) {
+	return _Feed.Contract.LatestRound(&_Feed.CallOpts)
+}
+
+// LatestRound is a free data retrieval call binding the contract method 0x668a0f02.
+//
+// Solidity: function latestRound() view returns(uint256)
+func (_Feed *FeedCallerSession) LatestRound() (*big.Int, error) {
+	return _Feed.Contract.LatestRound(&_Feed.CallOpts)
+}
+
+// LatestRoundData is a free data retrieval call binding the contract method 0xfeaf968c.
+//
+// Solidity: function latestRoundData() view returns(uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound)
+func (_Feed *FeedCaller) LatestRoundData(opts *bind.CallOpts) (struct {
+	RoundId         *big.Int
+	Answer          *big.Int
+	StartedAt       *big.Int
+	UpdatedAt       *big.Int
+	AnsweredInRound *big.Int
+}, error) {
+	var out []interface{}
+	err := _Feed.contract.Call(opts, &out, "latestRoundData")
+
+	outstruct := new(struct {
+		RoundId         *big.Int
+		Answer          *big.Int
+		StartedAt       *big.Int
+		UpdatedAt       *big.Int
+		AnsweredInRound *big.Int
+	})
+	if err != nil {
+		return *outstruct, err
+	}
+
+	outstruct.RoundId = *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+	outstruct.Answer = *abi.ConvertType(out[1], new(*big.Int)).(**big.Int)
+	outstruct.StartedAt = *abi.ConvertType(out[2], new(*big.Int)).(**big.Int)
+	outstruct.UpdatedAt = *abi.ConvertType(out[3], new(*big.Int)).(**big.Int)
+	outstruct.AnsweredInRound = *abi.ConvertType(out[4], new(*big.Int)).(**big.Int)
+
+	return *outstruct, err
+
+}
+
+// LatestRoundData is a free data retrieval call binding the contract method 0xfeaf968c.
+//
+// Solidity: function latestRoundData() view returns(uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound)
+func (_Feed *FeedSession) LatestRoundData() (struct {
+	RoundId         *big.Int
+	Answer          *big.Int
+	StartedAt       *big.Int
+	UpdatedAt       *big.Int
+	AnsweredInRound *big.Int
+}, error) {
+	return _Feed.Contract.LatestRoundData(&_Feed.CallOpts)
+}
+
+// LatestRoundData is a free data retrieval call binding the contract method 0xfeaf968c.
+//
+// Solidity: function latestRoundData() view returns(uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound)
+func (_Feed *FeedCallerSession) LatestRoundData() (struct {
+	RoundId         *big.Int
+	Answer          *big.Int
+	StartedAt       *big.Int
+	UpdatedAt       *big.Int
+	AnsweredInRound *big.Int
+}, error) {
+	return _Feed.Contract.LatestRoundData(&_Feed.CallOpts)
+}
+
+// LatestTimestamp is a free data retrieval call binding the contract method 0x8205bf6a.
+//
+// Solidity: function latestTimestamp() view returns(uint256)
+func (_Feed *FeedCaller) LatestTimestamp(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _Feed.contract.Call(opts, &out, "latestTimestamp")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// LatestTimestamp is a free data retrieval call binding the contract method 0x8205bf6a.
+//
+// Solidity: function latestTimestamp() view returns(uint256)
+func (_Feed *FeedSession) LatestTimestamp() (*big.Int, error) {
+	return _Feed.Contract.LatestTimestamp(&_Feed.CallOpts)
+}
+
+// LatestTimestamp is a free data retrieval call binding the contract method 0x8205bf6a.
+//
+// Solidity: function latestTimestamp() view returns(uint256)
+func (_Feed *FeedCallerSession) LatestTimestamp() (*big.Int, error) {
+	return _Feed.Contract.LatestTimestamp(&_Feed.CallOpts)
+}
+
+// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
+//
+// Solidity: function owner() view returns(address)
+func (_Feed *FeedCaller) Owner(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _Feed.contract.Call(opts, &out, "owner")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
+//
+// Solidity: function owner() view returns(address)
+func (_Feed *FeedSession) Owner() (common.Address, error) {
+	return _Feed.Contract.Owner(&_Feed.CallOpts)
+}
+
+// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
+//
+// Solidity: function owner() view returns(address)
+func (_Feed *FeedCallerSession) Owner() (common.Address, error) {
+	return _Feed.Contract.Owner(&_Feed.CallOpts)
+}
+
+// PhaseAggregators is a free data retrieval call binding the contract method 0xc1597304.
+//
+// Solidity: function phaseAggregators(uint16 ) view returns(address)
+func (_Feed *FeedCaller) PhaseAggregators(opts *bind.CallOpts, arg0 uint16) (common.Address, error) {
+	var out []interface{}
+	err := _Feed.contract.Call(opts, &out, "phaseAggregators", arg0)
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// PhaseAggregators is a free data retrieval call binding the contract method 0xc1597304.
+//
+// Solidity: function phaseAggregators(uint16 ) view returns(address)
+func (_Feed *FeedSession) PhaseAggregators(arg0 uint16) (common.Address, error) {
+	return _Feed.Contract.PhaseAggregators(&_Feed.CallOpts, arg0)
+}
+
+// PhaseAggregators is a free data retrieval call binding the contract method 0xc1597304.
+//
+// Solidity: function phaseAggregators(uint16 ) view returns(address)
+func (_Feed *FeedCallerSession) PhaseAggregators(arg0 uint16) (common.Address, error) {
+	return _Feed.Contract.PhaseAggregators(&_Feed.CallOpts, arg0)
+}
+
+// PhaseId is a free data retrieval call binding the contract method 0x58303b10.
+//
+// Solidity: function phaseId() view returns(uint16)
+func (_Feed *FeedCaller) PhaseId(opts *bind.CallOpts) (uint16, error) {
+	var out []interface{}
+	err := _Feed.contract.Call(opts, &out, "phaseId")
+
+	if err != nil {
+		return *new(uint16), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(uint16)).(*uint16)
+
+	return out0, err
+
+}
+
+// PhaseId is a free data retrieval call binding the contract method 0x58303b10.
+//
+// Solidity: function phaseId() view returns(uint16)
+func (_Feed *FeedSession) PhaseId() (uint16, error) {
+	return _Feed.Contract.PhaseId(&_Feed.CallOpts)
+}
+
+// PhaseId is a free data retrieval call binding the contract method 0x58303b10.
+//
+// Solidity: function phaseId() view returns(uint16)
+func (_Feed *FeedCallerSession) PhaseId() (uint16, error) {
+	return _Feed.Contract.PhaseId(&_Feed.CallOpts)
+}
+
+// ProposedAggregator is a free data retrieval call binding the contract method 0xe8c4be30.
+//
+// Solidity: function proposedAggregator() view returns(address)
+func (_Feed *FeedCaller) ProposedAggregator(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _Feed.contract.Call(opts, &out, "proposedAggregator")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// ProposedAggregator is a free data retrieval call binding the contract method 0xe8c4be30.
+//
+// Solidity: function proposedAggregator() view returns(address)
+func (_Feed *FeedSession) ProposedAggregator() (common.Address, error) {
+	return _Feed.Contract.ProposedAggregator(&_Feed.CallOpts)
+}
+
+// ProposedAggregator is a free data retrieval call binding the contract method 0xe8c4be30.
+//
+// Solidity: function proposedAggregator() view returns(address)
+func (_Feed *FeedCallerSession) ProposedAggregator() (common.Address, error) {
+	return _Feed.Contract.ProposedAggregator(&_Feed.CallOpts)
+}
+
+// ProposedGetRoundData is a free data retrieval call binding the contract method 0x6001ac53.
+//
+// Solidity: function proposedGetRoundData(uint80 _roundId) view returns(uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound)
+func (_Feed *FeedCaller) ProposedGetRoundData(opts *bind.CallOpts, _roundId *big.Int) (struct {
+	RoundId         *big.Int
+	Answer          *big.Int
+	StartedAt       *big.Int
+	UpdatedAt       *big.Int
+	AnsweredInRound *big.Int
+}, error) {
+	var out []interface{}
+	err := _Feed.contract.Call(opts, &out, "proposedGetRoundData", _roundId)
+
+	outstruct := new(struct {
+		RoundId         *big.Int
+		Answer          *big.Int
+		StartedAt       *big.Int
+		UpdatedAt       *big.Int
+		AnsweredInRound *big.Int
+	})
+	if err != nil {
+		return *outstruct, err
+	}
+
+	outstruct.RoundId = *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+	outstruct.Answer = *abi.ConvertType(out[1], new(*big.Int)).(**big.Int)
+	outstruct.StartedAt = *abi.ConvertType(out[2], new(*big.Int)).(**big.Int)
+	outstruct.UpdatedAt = *abi.ConvertType(out[3], new(*big.Int)).(**big.Int)
+	outstruct.AnsweredInRound = *abi.ConvertType(out[4], new(*big.Int)).(**big.Int)
+
+	return *outstruct, err
+
+}
+
+// ProposedGetRoundData is a free data retrieval call binding the contract method 0x6001ac53.
+//
+// Solidity: function proposedGetRoundData(uint80 _roundId) view returns(uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound)
+func (_Feed *FeedSession) ProposedGetRoundData(_roundId *big.Int) (struct {
+	RoundId         *big.Int
+	Answer          *big.Int
+	StartedAt       *big.Int
+	UpdatedAt       *big.Int
+	AnsweredInRound *big.Int
+}, error) {
+	return _Feed.Contract.ProposedGetRoundData(&_Feed.CallOpts, _roundId)
+}
+
+// ProposedGetRoundData is a free data retrieval call binding the contract method 0x6001ac53.
+//
+// Solidity: function proposedGetRoundData(uint80 _roundId) view returns(uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound)
+func (_Feed *FeedCallerSession) ProposedGetRoundData(_roundId *big.Int) (struct {
+	RoundId         *big.Int
+	Answer          *big.Int
+	StartedAt       *big.Int
+	UpdatedAt       *big.Int
+	AnsweredInRound *big.Int
+}, error) {
+	return _Feed.Contract.ProposedGetRoundData(&_Feed.CallOpts, _roundId)
+}
+
+// ProposedLatestRoundData is a free data retrieval call binding the contract method 0x8f6b4d91.
+//
+// Solidity: function proposedLatestRoundData() view returns(uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound)
+func (_Feed *FeedCaller) ProposedLatestRoundData(opts *bind.CallOpts) (struct {
+	RoundId         *big.Int
+	Answer          *big.Int
+	StartedAt       *big.Int
+	UpdatedAt       *big.Int
+	AnsweredInRound *big.Int
+}, error) {
+	var out []interface{}
+	err := _Feed.contract.Call(opts, &out, "proposedLatestRoundData")
+
+	outstruct := new(struct {
+		RoundId         *big.Int
+		Answer          *big.Int
+		StartedAt       *big.Int
+		UpdatedAt       *big.Int
+		AnsweredInRound *big.Int
+	})
+	if err != nil {
+		return *outstruct, err
+	}
+
+	outstruct.RoundId = *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+	outstruct.Answer = *abi.ConvertType(out[1], new(*big.Int)).(**big.Int)
+	outstruct.StartedAt = *abi.ConvertType(out[2], new(*big.Int)).(**big.Int)
+	outstruct.UpdatedAt = *abi.ConvertType(out[3], new(*big.Int)).(**big.Int)
+	outstruct.AnsweredInRound = *abi.ConvertType(out[4], new(*big.Int)).(**big.Int)
+
+	return *outstruct, err
+
+}
+
+// ProposedLatestRoundData is a free data retrieval call binding the contract method 0x8f6b4d91.
+//
+// Solidity: function proposedLatestRoundData() view returns(uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound)
+func (_Feed *FeedSession) ProposedLatestRoundData() (struct {
+	RoundId         *big.Int
+	Answer          *big.Int
+	StartedAt       *big.Int
+	UpdatedAt       *big.Int
+	AnsweredInRound *big.Int
+}, error) {
+	return _Feed.Contract.ProposedLatestRoundData(&_Feed.CallOpts)
+}
+
+// ProposedLatestRoundData is a free data retrieval call binding the contract method 0x8f6b4d91.
+//
+// Solidity: function proposedLatestRoundData() view returns(uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound)
+func (_Feed *FeedCallerSession) ProposedLatestRoundData() (struct {
+	RoundId         *big.Int
+	Answer          *big.Int
+	StartedAt       *big.Int
+	UpdatedAt       *big.Int
+	AnsweredInRound *big.Int
+}, error) {
+	return _Feed.Contract.ProposedLatestRoundData(&_Feed.CallOpts)
+}
+
+// Version is a free data retrieval call binding the contract method 0x54fd4d50.
+//
+// Solidity: function version() view returns(uint256)
+func (_Feed *FeedCaller) Version(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _Feed.contract.Call(opts, &out, "version")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// Version is a free data retrieval call binding the contract method 0x54fd4d50.
+//
+// Solidity: function version() view returns(uint256)
+func (_Feed *FeedSession) Version() (*big.Int, error) {
+	return _Feed.Contract.Version(&_Feed.CallOpts)
+}
+
+// Version is a free data retrieval call binding the contract method 0x54fd4d50.
+//
+// Solidity: function version() view returns(uint256)
+func (_Feed *FeedCallerSession) Version() (*big.Int, error) {
+	return _Feed.Contract.Version(&_Feed.CallOpts)
+}
+
+// AcceptOwnership is a paid mutator transaction binding the contract method 0x79ba5097.
+//
+// Solidity: function acceptOwnership() returns()
+func (_Feed *FeedTransactor) AcceptOwnership(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Feed.contract.Transact(opts, "acceptOwnership")
+}
+
+// AcceptOwnership is a paid mutator transaction binding the contract method 0x79ba5097.
+//
+// Solidity: function acceptOwnership() returns()
+func (_Feed *FeedSession) AcceptOwnership() (*types.Transaction, error) {
+	return _Feed.Contract.AcceptOwnership(&_Feed.TransactOpts)
+}
+
+// AcceptOwnership is a paid mutator transaction binding the contract method 0x79ba5097.
+//
+// Solidity: function acceptOwnership() returns()
+func (_Feed *FeedTransactorSession) AcceptOwnership() (*types.Transaction, error) {
+	return _Feed.Contract.AcceptOwnership(&_Feed.TransactOpts)
+}
+
+// ConfirmAggregator is a paid mutator transaction binding the contract method 0xa928c096.
+//
+// Solidity: function confirmAggregator(address _aggregator) returns()
+func (_Feed *FeedTransactor) ConfirmAggregator(opts *bind.TransactOpts, _aggregator common.Address) (*types.Transaction, error) {
+	return _Feed.contract.Transact(opts, "confirmAggregator", _aggregator)
+}
+
+// ConfirmAggregator is a paid mutator transaction binding the contract method 0xa928c096.
+//
+// Solidity: function confirmAggregator(address _aggregator) returns()
+func (_Feed *FeedSession) ConfirmAggregator(_aggregator common.Address) (*types.Transaction, error) {
+	return _Feed.Contract.ConfirmAggregator(&_Feed.TransactOpts, _aggregator)
+}
+
+// ConfirmAggregator is a paid mutator transaction binding the contract method 0xa928c096.
+//
+// Solidity: function confirmAggregator(address _aggregator) returns()
+func (_Feed *FeedTransactorSession) ConfirmAggregator(_aggregator common.Address) (*types.Transaction, error) {
+	return _Feed.Contract.ConfirmAggregator(&_Feed.TransactOpts, _aggregator)
+}
+
+// ProposeAggregator is a paid mutator transaction binding the contract method 0xf8a2abd3.
+//
+// Solidity: function proposeAggregator(address _aggregator) returns()
+func (_Feed *FeedTransactor) ProposeAggregator(opts *bind.TransactOpts, _aggregator common.Address) (*types.Transaction, error) {
+	return _Feed.contract.Transact(opts, "proposeAggregator", _aggregator)
+}
+
+// ProposeAggregator is a paid mutator transaction binding the contract method 0xf8a2abd3.
+//
+// Solidity: function proposeAggregator(address _aggregator) returns()
+func (_Feed *FeedSession) ProposeAggregator(_aggregator common.Address) (*types.Transaction, error) {
+	return _Feed.Contract.ProposeAggregator(&_Feed.TransactOpts, _aggregator)
+}
+
+// ProposeAggregator is a paid mutator transaction binding the contract method 0xf8a2abd3.
+//
+// Solidity: function proposeAggregator(address _aggregator) returns()
+func (_Feed *FeedTransactorSession) ProposeAggregator(_aggregator common.Address) (*types.Transaction, error) {
+	return _Feed.Contract.ProposeAggregator(&_Feed.TransactOpts, _aggregator)
+}
+
+// SetController is a paid mutator transaction binding the contract method 0x92eefe9b.
+//
+// Solidity: function setController(address _accessController) returns()
+func (_Feed *FeedTransactor) SetController(opts *bind.TransactOpts, _accessController common.Address) (*types.Transaction, error) {
+	return _Feed.contract.Transact(opts, "setController", _accessController)
+}
+
+// SetController is a paid mutator transaction binding the contract method 0x92eefe9b.
+//
+// Solidity: function setController(address _accessController) returns()
+func (_Feed *FeedSession) SetController(_accessController common.Address) (*types.Transaction, error) {
+	return _Feed.Contract.SetController(&_Feed.TransactOpts, _accessController)
+}
+
+// SetController is a paid mutator transaction binding the contract method 0x92eefe9b.
+//
+// Solidity: function setController(address _accessController) returns()
+func (_Feed *FeedTransactorSession) SetController(_accessController common.Address) (*types.Transaction, error) {
+	return _Feed.Contract.SetController(&_Feed.TransactOpts, _accessController)
+}
+
+// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
+//
+// Solidity: function transferOwnership(address _to) returns()
+func (_Feed *FeedTransactor) TransferOwnership(opts *bind.TransactOpts, _to common.Address) (*types.Transaction, error) {
+	return _Feed.contract.Transact(opts, "transferOwnership", _to)
+}
+
+// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
+//
+// Solidity: function transferOwnership(address _to) returns()
+func (_Feed *FeedSession) TransferOwnership(_to common.Address) (*types.Transaction, error) {
+	return _Feed.Contract.TransferOwnership(&_Feed.TransactOpts, _to)
+}
+
+// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
+//
+// Solidity: function transferOwnership(address _to) returns()
+func (_Feed *FeedTransactorSession) TransferOwnership(_to common.Address) (*types.Transaction, error) {
+	return _Feed.Contract.TransferOwnership(&_Feed.TransactOpts, _to)
+}
+
+// FeedAnswerUpdatedIterator is returned from FilterAnswerUpdated and is used to iterate over the raw logs and unpacked data for AnswerUpdated events raised by the Feed contract.
+type FeedAnswerUpdatedIterator struct {
+	Event *FeedAnswerUpdated // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *FeedAnswerUpdatedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(FeedAnswerUpdated)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(FeedAnswerUpdated)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *FeedAnswerUpdatedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *FeedAnswerUpdatedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// FeedAnswerUpdated represents a AnswerUpdated event raised by the Feed contract.
+type FeedAnswerUpdated struct {
+	Current   *big.Int
+	RoundId   *big.Int
+	UpdatedAt *big.Int
+	Raw       types.Log // Blockchain specific contextual infos
+}
+
+// FilterAnswerUpdated is a free log retrieval operation binding the contract event 0x0559884fd3a460db3073b7fc896cc77986f16e378210ded43186175bf646fc5f.
+//
+// Solidity: event AnswerUpdated(int256 indexed current, uint256 indexed roundId, uint256 updatedAt)
+func (_Feed *FeedFilterer) FilterAnswerUpdated(opts *bind.FilterOpts, current []*big.Int, roundId []*big.Int) (*FeedAnswerUpdatedIterator, error) {
+
+	var currentRule []interface{}
+	for _, currentItem := range current {
+		currentRule = append(currentRule, currentItem)
+	}
+	var roundIdRule []interface{}
+	for _, roundIdItem := range roundId {
+		roundIdRule = append(roundIdRule, roundIdItem)
+	}
+
+	logs, sub, err := _Feed.contract.FilterLogs(opts, "AnswerUpdated", currentRule, roundIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return &FeedAnswerUpdatedIterator{contract: _Feed.contract, event: "AnswerUpdated", logs: logs, sub: sub}, nil
+}
+
+// WatchAnswerUpdated is a free log subscription operation binding the contract event 0x0559884fd3a460db3073b7fc896cc77986f16e378210ded43186175bf646fc5f.
+//
+// Solidity: event AnswerUpdated(int256 indexed current, uint256 indexed roundId, uint256 updatedAt)
+func (_Feed *FeedFilterer) WatchAnswerUpdated(opts *bind.WatchOpts, sink chan<- *FeedAnswerUpdated, current []*big.Int, roundId []*big.Int) (event.Subscription, error) {
+
+	var currentRule []interface{}
+	for _, currentItem := range current {
+		currentRule = append(currentRule, currentItem)
+	}
+	var roundIdRule []interface{}
+	for _, roundIdItem := range roundId {
+		roundIdRule = append(roundIdRule, roundIdItem)
+	}
+
+	logs, sub, err := _Feed.contract.WatchLogs(opts, "AnswerUpdated", currentRule, roundIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(FeedAnswerUpdated)
+				if err := _Feed.contract.UnpackLog(event, "AnswerUpdated", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseAnswerUpdated is a log parse operation binding the contract event 0x0559884fd3a460db3073b7fc896cc77986f16e378210ded43186175bf646fc5f.
+//
+// Solidity: event AnswerUpdated(int256 indexed current, uint256 indexed roundId, uint256 updatedAt)
+func (_Feed *FeedFilterer) ParseAnswerUpdated(log types.Log) (*FeedAnswerUpdated, error) {
+	event := new(FeedAnswerUpdated)
+	if err := _Feed.contract.UnpackLog(event, "AnswerUpdated", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// FeedNewRoundIterator is returned from FilterNewRound and is used to iterate over the raw logs and unpacked data for NewRound events raised by the Feed contract.
+type FeedNewRoundIterator struct {
+	Event *FeedNewRound // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *FeedNewRoundIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(FeedNewRound)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(FeedNewRound)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *FeedNewRoundIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *FeedNewRoundIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// FeedNewRound represents a NewRound event raised by the Feed contract.
+type FeedNewRound struct {
+	RoundId   *big.Int
+	StartedBy common.Address
+	StartedAt *big.Int
+	Raw       types.Log // Blockchain specific contextual infos
+}
+
+// FilterNewRound is a free log retrieval operation binding the contract event 0x0109fc6f55cf40689f02fbaad7af7fe7bbac8a3d2186600afc7d3e10cac60271.
+//
+// Solidity: event NewRound(uint256 indexed roundId, address indexed startedBy, uint256 startedAt)
+func (_Feed *FeedFilterer) FilterNewRound(opts *bind.FilterOpts, roundId []*big.Int, startedBy []common.Address) (*FeedNewRoundIterator, error) {
+
+	var roundIdRule []interface{}
+	for _, roundIdItem := range roundId {
+		roundIdRule = append(roundIdRule, roundIdItem)
+	}
+	var startedByRule []interface{}
+	for _, startedByItem := range startedBy {
+		startedByRule = append(startedByRule, startedByItem)
+	}
+
+	logs, sub, err := _Feed.contract.FilterLogs(opts, "NewRound", roundIdRule, startedByRule)
+	if err != nil {
+		return nil, err
+	}
+	return &FeedNewRoundIterator{contract: _Feed.contract, event: "NewRound", logs: logs, sub: sub}, nil
+}
+
+// WatchNewRound is a free log subscription operation binding the contract event 0x0109fc6f55cf40689f02fbaad7af7fe7bbac8a3d2186600afc7d3e10cac60271.
+//
+// Solidity: event NewRound(uint256 indexed roundId, address indexed startedBy, uint256 startedAt)
+func (_Feed *FeedFilterer) WatchNewRound(opts *bind.WatchOpts, sink chan<- *FeedNewRound, roundId []*big.Int, startedBy []common.Address) (event.Subscription, error) {
+
+	var roundIdRule []interface{}
+	for _, roundIdItem := range roundId {
+		roundIdRule = append(roundIdRule, roundIdItem)
+	}
+	var startedByRule []interface{}
+	for _, startedByItem := range startedBy {
+		startedByRule = append(startedByRule, startedByItem)
+	}
+
+	logs, sub, err := _Feed.contract.WatchLogs(opts, "NewRound", roundIdRule, startedByRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(FeedNewRound)
+				if err := _Feed.contract.UnpackLog(event, "NewRound", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseNewRound is a log parse operation binding the contract event 0x0109fc6f55cf40689f02fbaad7af7fe7bbac8a3d2186600afc7d3e10cac60271.
+//
+// Solidity: event NewRound(uint256 indexed roundId, address indexed startedBy, uint256 startedAt)
+func (_Feed *FeedFilterer) ParseNewRound(log types.Log) (*FeedNewRound, error) {
+	event := new(FeedNewRound)
+	if err := _Feed.contract.UnpackLog(event, "NewRound", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// FeedOwnershipTransferRequestedIterator is returned from FilterOwnershipTransferRequested and is used to iterate over the raw logs and unpacked data for OwnershipTransferRequested events raised by the Feed contract.
+type FeedOwnershipTransferRequestedIterator struct {
+	Event *FeedOwnershipTransferRequested // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *FeedOwnershipTransferRequestedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(FeedOwnershipTransferRequested)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(FeedOwnershipTransferRequested)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *FeedOwnershipTransferRequestedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *FeedOwnershipTransferRequestedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// FeedOwnershipTransferRequested represents a OwnershipTransferRequested event raised by the Feed contract.
+type FeedOwnershipTransferRequested struct {
+	From common.Address
+	To   common.Address
+	Raw  types.Log // Blockchain specific contextual infos
+}
+
+// FilterOwnershipTransferRequested is a free log retrieval operation binding the contract event 0xed8889f560326eb138920d842192f0eb3dd22b4f139c87a2c57538e05bae1278.
+//
+// Solidity: event OwnershipTransferRequested(address indexed from, address indexed to)
+func (_Feed *FeedFilterer) FilterOwnershipTransferRequested(opts *bind.FilterOpts, from []common.Address, to []common.Address) (*FeedOwnershipTransferRequestedIterator, error) {
+
+	var fromRule []interface{}
+	for _, fromItem := range from {
+		fromRule = append(fromRule, fromItem)
+	}
+	var toRule []interface{}
+	for _, toItem := range to {
+		toRule = append(toRule, toItem)
+	}
+
+	logs, sub, err := _Feed.contract.FilterLogs(opts, "OwnershipTransferRequested", fromRule, toRule)
+	if err != nil {
+		return nil, err
+	}
+	return &FeedOwnershipTransferRequestedIterator{contract: _Feed.contract, event: "OwnershipTransferRequested", logs: logs, sub: sub}, nil
+}
+
+// WatchOwnershipTransferRequested is a free log subscription operation binding the contract event 0xed8889f560326eb138920d842192f0eb3dd22b4f139c87a2c57538e05bae1278.
+//
+// Solidity: event OwnershipTransferRequested(address indexed from, address indexed to)
+func (_Feed *FeedFilterer) WatchOwnershipTransferRequested(opts *bind.WatchOpts, sink chan<- *FeedOwnershipTransferRequested, from []common.Address, to []common.Address) (event.Subscription, error) {
+
+	var fromRule []interface{}
+	for _, fromItem := range from {
+		fromRule = append(fromRule, fromItem)
+	}
+	var toRule []interface{}
+	for _, toItem := range to {
+		toRule = append(toRule, toItem)
+	}
+
+	logs, sub, err := _Feed.contract.WatchLogs(opts, "OwnershipTransferRequested", fromRule, toRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(FeedOwnershipTransferRequested)
+				if err := _Feed.contract.UnpackLog(event, "OwnershipTransferRequested", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseOwnershipTransferRequested is a log parse operation binding the contract event 0xed8889f560326eb138920d842192f0eb3dd22b4f139c87a2c57538e05bae1278.
+//
+// Solidity: event OwnershipTransferRequested(address indexed from, address indexed to)
+func (_Feed *FeedFilterer) ParseOwnershipTransferRequested(log types.Log) (*FeedOwnershipTransferRequested, error) {
+	event := new(FeedOwnershipTransferRequested)
+	if err := _Feed.contract.UnpackLog(event, "OwnershipTransferRequested", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// FeedOwnershipTransferredIterator is returned from FilterOwnershipTransferred and is used to iterate over the raw logs and unpacked data for OwnershipTransferred events raised by the Feed contract.
+type FeedOwnershipTransferredIterator struct {
+	Event *FeedOwnershipTransferred // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *FeedOwnershipTransferredIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(FeedOwnershipTransferred)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(FeedOwnershipTransferred)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *FeedOwnershipTransferredIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *FeedOwnershipTransferredIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// FeedOwnershipTransferred represents a OwnershipTransferred event raised by the Feed contract.
+type FeedOwnershipTransferred struct {
+	From common.Address
+	To   common.Address
+	Raw  types.Log // Blockchain specific contextual infos
+}
+
+// FilterOwnershipTransferred is a free log retrieval operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
+//
+// Solidity: event OwnershipTransferred(address indexed from, address indexed to)
+func (_Feed *FeedFilterer) FilterOwnershipTransferred(opts *bind.FilterOpts, from []common.Address, to []common.Address) (*FeedOwnershipTransferredIterator, error) {
+
+	var fromRule []interface{}
+	for _, fromItem := range from {
+		fromRule = append(fromRule, fromItem)
+	}
+	var toRule []interface{}
+	for _, toItem := range to {
+		toRule = append(toRule, toItem)
+	}
+
+	logs, sub, err := _Feed.contract.FilterLogs(opts, "OwnershipTransferred", fromRule, toRule)
+	if err != nil {
+		return nil, err
+	}
+	return &FeedOwnershipTransferredIterator{contract: _Feed.contract, event: "OwnershipTransferred", logs: logs, sub: sub}, nil
+}
+
+// WatchOwnershipTransferred is a free log subscription operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
+//
+// Solidity: event OwnershipTransferred(address indexed from, address indexed to)
+func (_Feed *FeedFilterer) WatchOwnershipTransferred(opts *bind.WatchOpts, sink chan<- *FeedOwnershipTransferred, from []common.Address, to []common.Address) (event.Subscription, error) {
+
+	var fromRule []interface{}
+	for _, fromItem := range from {
+		fromRule = append(fromRule, fromItem)
+	}
+	var toRule []interface{}
+	for _, toItem := range to {
+		toRule = append(toRule, toItem)
+	}
+
+	logs, sub, err := _Feed.contract.WatchLogs(opts, "OwnershipTransferred", fromRule, toRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(FeedOwnershipTransferred)
+				if err := _Feed.contract.UnpackLog(event, "OwnershipTransferred", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseOwnershipTransferred is a log parse operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
+//
+// Solidity: event OwnershipTransferred(address indexed from, address indexed to)
+func (_Feed *FeedFilterer) ParseOwnershipTransferred(log types.Log) (*FeedOwnershipTransferred, error) {
+	event := new(FeedOwnershipTransferred)
+	if err := _Feed.contract.UnpackLog(event, "OwnershipTransferred", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}


### PR DESCRIPTION
Switches from the coingecko API to chainlink oracle for fetching latest pricing data (ETH and fiat) on mainnet, removes RUB as supported currency as there is no available RUB / USD chainlink oracle.