### PR TITLE
(BIDS-1819) Return CL and EL APR for API

### DIFF
--- a/handlers/api.go
+++ b/handlers/api.go
@@ -223,10 +223,16 @@ func ApiEthStoreDay(w http.ResponseWriter, r *http.Request) {
 			consensus_rewards_sum_wei,
 			total_rewards_wei,
 			apr,
+			CAST (ROUND((365 * consensus_rewards_sum_wei) / effective_balances_sum_wei, 16) AS double precision) as cl_apr,
+			CAST (ROUND((365 * tx_fees_sum_wei) / effective_balances_sum_wei, 16) AS double precision) as el_apr,
 			(select avg(apr) from eth_store_stats as e1 where e1.validator = -1 AND e1.day > e.day - 7 AND e1.day <= e.day) as avgapr7d,
+			(select avg(CAST (ROUND((365 * consensus_rewards_sum_wei) / effective_balances_sum_wei, 16) AS double precision)) from eth_store_stats as e1 where e1.validator = -1 AND e1.day > e.day - 7 AND e1.day <= e.day) as cl_avgapr7d,
+			(select avg(CAST (ROUND((365 * tx_fees_sum_wei) / effective_balances_sum_wei, 16) AS double precision)) from eth_store_stats as e1 where e1.validator = -1 AND e1.day > e.day - 7 AND e1.day <= e.day) as el_avgapr7d,
 			(select avg(consensus_rewards_sum_wei) from eth_store_stats as e1 where e1.validator = -1 AND e1.day > e.day - 7 AND e1.day <= e.day) as avgconsensus_rewards7d_wei,
 			(select avg(tx_fees_sum_wei) from eth_store_stats as e1 where e1.validator = -1 AND e1.day > e.day - 7 AND e1.day <= e.day) as avgtx_fees7d_wei,
 			(select avg(apr) from eth_store_stats as e2 where e2.validator = -1 AND e2.day > e.day - 31 AND e2.day <= e.day) as avgapr31d,
+			(select avg(CAST (ROUND((365 * consensus_rewards_sum_wei) / effective_balances_sum_wei, 16) AS double precision)) from eth_store_stats as e2 where e2.validator = -1 AND e2.day > e.day - 31 AND e2.day <= e.day) as cl_avgapr31d,
+			(select avg(CAST (ROUND((365 * tx_fees_sum_wei) / effective_balances_sum_wei, 16) AS double precision)) from eth_store_stats as e2 where e2.validator = -1 AND e2.day > e.day - 31 AND e2.day <= e.day) as el_avgapr31d,
 			(select avg(consensus_rewards_sum_wei) from eth_store_stats as e2 where e2.validator = -1 AND e2.day > e.day - 31 AND e2.day <= e.day) as avgconsensus_rewards31d_wei,
 			(select avg(tx_fees_sum_wei) from eth_store_stats as e2 where e2.validator = -1 AND e2.day > e.day - 31 AND e2.day <= e.day) as avgtx_fees31d_wei
 		FROM eth_store_stats e


### PR DESCRIPTION
We round to 16 decimals because the normal APR also gets saved with that precision due to decimals package division.