### PR TITLE
(NOBIDS) fix crashbug in on demand epoch exporter

### DIFF
--- a/cmd/misc/main.go
+++ b/cmd/misc/main.go
@@ -4,6 +4,7 @@ import (
 	"eth2-exporter/db"
 	"eth2-exporter/exporter"
 	"eth2-exporter/rpc"
+	"eth2-exporter/services"
 	"eth2-exporter/types"
 	"eth2-exporter/utils"
 	"eth2-exporter/version"
@@ -102,6 +103,11 @@ func main() {
 		logrus.Infof("db schema applied successfully")
 	case "epoch-export":
 		logrus.Infof("exporting epochs %v - %v", opts.StartEpoch, opts.EndEpoch)
+
+		err = services.InitLastAttestationCache(utils.Config.LastAttestationCachePath)
+		if err != nil {
+			logrus.Fatalf("error initializing last attesation cache: %v", err)
+		}
 
 		for epoch := opts.StartEpoch; epoch <= opts.EndEpoch; epoch++ {
 			err = exporter.ExportEpoch(epoch, rpcClient)


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 63391a2</samp>

Added a caching feature for validator attestation data using the `services` package. Modified `cmd/misc/main.go` to initialize the cache file.
