### PR TITLE
(NOBIDS) add sync committee db index

### DIFF
--- a/db/migrations/20230411051948_add_sync_committee_index.sql
+++ b/db/migrations/20230411051948_add_sync_committee_index.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+-- +goose StatementBegin
+CREATE INDEX IF NOT EXISTS idx_sync_committees_period ON sync_committees (validatorindex, period DESC);
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP INDEX IF EXISTS idx_sync_committees_period;
+-- +goose StatementEnd


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3994623</samp>

This change adds a new database index to support the sync committee feature for the Altair fork. The index helps to query sync committee assignments faster by `validator_index` and `period`.
