### PR TITLE
(NOBIDS) set proper caching headers for frequently called endpoints

### DIFF
--- a/handlers/common.go
+++ b/handlers/common.go
@@ -327,6 +327,7 @@ func getAvgSyncCommitteeInterval(validatorsCount int) float64 {
 // LatestState will return common information that about the current state of the eth2 chain
 func LatestState(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", fmt.Sprintf("public, max-age=%d", utils.Config.Chain.Config.SecondsPerSlot)) // set local cache to the seconds per slot interval
 	currency := GetCurrency(r)
 	data := services.LatestState()
 	// data.Currency = currency

--- a/handlers/index.go
+++ b/handlers/index.go
@@ -6,6 +6,7 @@ import (
 	"eth2-exporter/templates"
 	"eth2-exporter/types"
 	"eth2-exporter/utils"
+	"fmt"
 	"html/template"
 	"net/http"
 )
@@ -56,6 +57,7 @@ func Index(w http.ResponseWriter, r *http.Request) {
 // IndexPageData will show the main "index" page in json format
 func IndexPageData(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", fmt.Sprintf("public, max-age=%d", utils.Config.Chain.Config.SecondsPerSlot)) // set local cache to the seconds per slot interval
 
 	err := json.NewEncoder(w).Encode(services.LatestIndexPageData())
 

--- a/handlers/launch_metrics.go
+++ b/handlers/launch_metrics.go
@@ -3,6 +3,8 @@ package handlers
 import (
 	"encoding/json"
 	"eth2-exporter/services"
+	"eth2-exporter/utils"
+	"fmt"
 	"net/http"
 )
 
@@ -12,6 +14,7 @@ import (
 // SlotVizMetrics returns the metrics for the earliest epochs
 func SlotVizMetrics(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", fmt.Sprintf("public, max-age=%d", utils.Config.Chain.Config.SecondsPerSlot)) // set local cache to the seconds per slot interval
 
 	// res, err := db.GetSlotVizData(latestEpoch)
 	// if err != nil {


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d725650</samp>

This pull request enhances the caching behavior of the explorer's API endpoints by adding `Cache-Control` headers based on the chain configuration. It also adds some imports and formatting to the `handlers` package.
