### PR TITLE
(BIDS-1896) drop proposer reward columns on downgrade

### DIFF
--- a/db/migrations/20230406123551_add_proposer_statistic_columns.sql
+++ b/db/migrations/20230406123551_add_proposer_statistic_columns.sql
@@ -9,4 +9,7 @@ ALTER TABLE validator_performance ADD COLUMN IF NOT EXISTS cl_proposer_performan
 -- +goose Down
 -- +goose StatementBegin
 SELECT 'down SQL query';
+ALTER TABLE validator_stats DROP COLUMN IF EXISTS cl_proposer_rewards_gwei;
+ALTER TABLE validator_stats DROP COLUMN IF EXISTS cl_proposer_rewards_gwei_total;
+ALTER TABLE validator_performance DROP COLUMN IF EXISTS cl_proposer_performance_total;
 -- +goose StatementEnd


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6920427</samp>

Remove unused columns related to client loyalty feature from validator stats tables. This is part of a database migration to simplify the schema and reduce storage.
