### PR TITLE
(NOBIDS) Added more info to "searchAhead" error

### DIFF
--- a/handlers/search.go
+++ b/handlers/search.go
@@ -404,7 +404,7 @@ func SearchAhead(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err != nil {
-		logger.WithError(err).Error("error doing query for searchAhead")
+		logger.WithError(err).WithField("searchType", searchType).Error("error doing query for searchAhead")
 		http.Error(w, "Internal server error", http.StatusServiceUnavailable)
 		return
 	}


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ddcb1a3</samp>

Added `searchType` field to error logging in `SearchAhead` function. This improves the visibility of search errors in `handlers/search.go`.
