### PR TITLE
(BIDS-1535) Catch out of range error

### DIFF
--- a/cmd/eth1indexer/main.go
+++ b/cmd/eth1indexer/main.go
@@ -281,11 +281,15 @@ func main() {
 
 			err = IndexFromNode(bt, client, int64(lastBlockFromBlocksTable)-*offsetBlocks, int64(lastBlockFromNode), *concurrencyBlocks)
 			if err != nil {
-				errMsg := fmt.Sprintf("error indexing from node, start: %v end: %v concurrency: %v", int64(lastBlockFromBlocksTable)-*offsetBlocks, int64(lastBlockFromNode), *concurrencyBlocks)
+				errMsg := "error indexing from node"
+				errFields := map[string]interface{}{
+					"start":       int64(lastBlockFromBlocksTable) - *offsetBlocks,
+					"end":         int64(lastBlockFromNode),
+					"concurrency": *concurrencyBlocks}
 				if time.Since(lastSuccessulBlockIndexingTs) > time.Minute*30 {
-					utils.LogFatal(err, errMsg, 0)
+					utils.LogFatal(err, errMsg, 0, errFields)
 				} else {
-					utils.LogError(err, errMsg, 0)
+					utils.LogError(err, errMsg, 0, errFields)
 				}
 				continue
 			} else {

--- a/cmd/eth1indexer/main.go
+++ b/cmd/eth1indexer/main.go
@@ -282,11 +282,10 @@ func main() {
 			err = IndexFromNode(bt, client, int64(lastBlockFromBlocksTable)-*offsetBlocks, int64(lastBlockFromNode), *concurrencyBlocks)
 			if err != nil {
 				errMsg := fmt.Sprintf("error indexing from node, start: %v end: %v concurrency: %v", int64(lastBlockFromBlocksTable)-*offsetBlocks, int64(lastBlockFromNode), *concurrencyBlocks)
-				errEntry := logrus.WithError(err)
 				if time.Since(lastSuccessulBlockIndexingTs) > time.Minute*30 {
-					errEntry.Fatal(errMsg)
+					utils.LogFatal(err, errMsg, 0)
 				} else {
-					errEntry.Error(errMsg)
+					utils.LogError(err, errMsg, 0)
 				}
 				continue
 			} else {

--- a/rpc/erigon.go
+++ b/rpc/erigon.go
@@ -205,7 +205,6 @@ func (client *ErigonClient) GetBlock(number int64) (*types.Eth1Block, *types.Get
 			logger.Infof("retrieved %v calls via geth", len(gethTraceData))
 
 			for _, trace := range gethTraceData {
-
 				if trace.Error == "" {
 					c.Transactions[trace.TransactionPosition].Status = 1
 				} else {
@@ -249,6 +248,10 @@ func (client *ErigonClient) GetBlock(number int64) (*types.Eth1Block, *types.Get
 
 			if trace.TransactionHash == "" {
 				continue
+			}
+
+			if len(c.Transactions) <= trace.TransactionPosition {
+				return fmt.Errorf("error transaction position %v out of range", trace.TransactionPosition)
 			}
 
 			if trace.Error == "" {
@@ -332,7 +335,7 @@ func (client *ErigonClient) GetBlock(number int64) (*types.Eth1Block, *types.Get
 	}
 
 	if err := g.Wait(); err != nil {
-		return nil, nil, fmt.Errorf("error retrieving traces for block %v: %v", block.Number(), err)
+		return nil, nil, fmt.Errorf("error retrieving traces for block %v: %w", block.Number(), err)
 	}
 
 	return c, timings, nil

--- a/rpc/erigon.go
+++ b/rpc/erigon.go
@@ -250,7 +250,7 @@ func (client *ErigonClient) GetBlock(number int64) (*types.Eth1Block, *types.Get
 				continue
 			}
 
-			if len(c.Transactions) <= trace.TransactionPosition {
+			if trace.TransactionPosition >= len(c.Transactions) {
 				return fmt.Errorf("error transaction position %v out of range", trace.TransactionPosition)
 			}
 


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 79e21c3</samp>

This pull request enhances the reliability and robustness of the eth1 indexer and the `GetBlock` function. It adds a timeout mechanism for the indexer, and improves the error handling and validation of the `rpc/erigon.go` file.
