### PR TITLE
(BIDS-1972) use correct balance for performance api

### DIFF
--- a/handlers/api.go
+++ b/handlers/api.go
@@ -2015,6 +2015,10 @@ func ApiValidatorPerformance(w http.ResponseWriter, r *http.Request) {
 
 	latestEpoch := int64(services.LatestFinalizedEpoch())
 	latestBalances, err := db.BigtableClient.GetValidatorBalanceHistory(queryIndices, uint64(latestEpoch), uint64(latestEpoch))
+	if err != nil {
+		sendErrorResponse(w, r.URL.String(), "error retrieving balances")
+		return
+	}
 
 	// create a map to easily check if a validator is part of data
 	validatorIndexMap := make(map[uint64]bool)


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a746c93</samp>

Improve validator performance API by using latest balances from Bigtable and removing redundant field. Refactor `handlers/api.go` to simplify code.
