### PR TITLE
(BIDS-1978) fix attestations + reward hist. for exiting vali.

### DIFF
--- a/handlers/validator.go
+++ b/handlers/validator.go
@@ -1628,7 +1628,7 @@ func ValidatorHistory(w http.ResponseWriter, r *http.Request) {
 	// Every validator is scheduled to issue an attestation once per epoch
 	// Hence we can calculate the number of attestations using the current epoch and the activation epoch
 	// Special care needs to be take for exited and pending validators
-	if activationAndExitEpoch.ExitEpoch != 9223372036854775807 && activationAndExitEpoch.ExitEpoch < services.LatestFinalizedEpoch() {
+	if activationAndExitEpoch.ExitEpoch != 9223372036854775807 && activationAndExitEpoch.ExitEpoch <= services.LatestFinalizedEpoch() {
 		totalCount += activationAndExitEpoch.ExitEpoch - activationAndExitEpoch.ActivationEpoch
 	} else {
 		totalCount += services.LatestFinalizedEpoch() - activationAndExitEpoch.ActivationEpoch + 1

--- a/handlers/validator.go
+++ b/handlers/validator.go
@@ -366,7 +366,7 @@ func Validator(w http.ResponseWriter, r *http.Request) {
 		validatorPageData.AttestationsCount = 0
 	}
 
-	if validatorPageData.ExitEpoch != 9223372036854775807 {
+	if validatorPageData.ExitEpoch != 9223372036854775807 && validatorPageData.ExitEpoch < validatorPageData.Epoch {
 		validatorPageData.AttestationsCount = validatorPageData.ExitEpoch - validatorPageData.ActivationEpoch
 	}
 
@@ -1177,7 +1177,7 @@ func ValidatorAttestations(w http.ResponseWriter, r *http.Request) {
 		totalCount = 0
 	}
 	lastAttestationEpoch := epoch
-	if ae.ExitEpoch != 9223372036854775807 {
+	if ae.ExitEpoch != 9223372036854775807 && ae.ExitEpoch < epoch {
 		lastAttestationEpoch = ae.ExitEpoch
 		totalCount = ae.ExitEpoch - ae.ActivationEpoch
 	}
@@ -1628,7 +1628,7 @@ func ValidatorHistory(w http.ResponseWriter, r *http.Request) {
 	// Every validator is scheduled to issue an attestation once per epoch
 	// Hence we can calculate the number of attestations using the current epoch and the activation epoch
 	// Special care needs to be take for exited and pending validators
-	if activationAndExitEpoch.ExitEpoch != 9223372036854775807 {
+	if activationAndExitEpoch.ExitEpoch != 9223372036854775807 && activationAndExitEpoch.ExitEpoch < services.LatestFinalizedEpoch() {
 		totalCount += activationAndExitEpoch.ExitEpoch - activationAndExitEpoch.ActivationEpoch
 	} else {
 		totalCount += services.LatestFinalizedEpoch() - activationAndExitEpoch.ActivationEpoch + 1
@@ -1644,7 +1644,7 @@ func ValidatorHistory(w http.ResponseWriter, r *http.Request) {
 
 	currentEpoch := services.LatestEpoch() - 1
 	// for an exited validator we show the history until his exit
-	if activationAndExitEpoch.ExitEpoch != 9223372036854775807 {
+	if activationAndExitEpoch.ExitEpoch != 9223372036854775807 && currentEpoch > (activationAndExitEpoch.ExitEpoch-1) {
 		currentEpoch = activationAndExitEpoch.ExitEpoch - 1
 	}
 

--- a/handlers/validator.go
+++ b/handlers/validator.go
@@ -366,7 +366,7 @@ func Validator(w http.ResponseWriter, r *http.Request) {
 		validatorPageData.AttestationsCount = 0
 	}
 
-	if validatorPageData.ExitEpoch != 9223372036854775807 && validatorPageData.ExitEpoch < validatorPageData.Epoch {
+	if validatorPageData.ExitEpoch != 9223372036854775807 && validatorPageData.ExitEpoch <= validatorPageData.Epoch {
 		validatorPageData.AttestationsCount = validatorPageData.ExitEpoch - validatorPageData.ActivationEpoch
 	}
 

--- a/handlers/validator.go
+++ b/handlers/validator.go
@@ -1177,7 +1177,7 @@ func ValidatorAttestations(w http.ResponseWriter, r *http.Request) {
 		totalCount = 0
 	}
 	lastAttestationEpoch := epoch
-	if ae.ExitEpoch != 9223372036854775807 && ae.ExitEpoch < epoch {
+	if ae.ExitEpoch != 9223372036854775807 && ae.ExitEpoch <= epoch {
 		lastAttestationEpoch = ae.ExitEpoch - 1
 		totalCount = ae.ExitEpoch - ae.ActivationEpoch
 	}

--- a/handlers/validator.go
+++ b/handlers/validator.go
@@ -1178,7 +1178,7 @@ func ValidatorAttestations(w http.ResponseWriter, r *http.Request) {
 	}
 	lastAttestationEpoch := epoch
 	if ae.ExitEpoch != 9223372036854775807 && ae.ExitEpoch < epoch {
-		lastAttestationEpoch = ae.ExitEpoch
+		lastAttestationEpoch = ae.ExitEpoch - 1
 		totalCount = ae.ExitEpoch - ae.ActivationEpoch
 	}
 


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at dfe889f</samp>

Fix validator history bugs for exited validators. Update `handlers/validator.go` to handle edge cases where the validator's `exit_epoch` is before the current or finalized epoch.
