### PR TITLE
(BIDS-2011) Add config parameter for API base url

### DIFF
--- a/handlers/calculator.go
+++ b/handlers/calculator.go
@@ -4,6 +4,7 @@ import (
 	"eth2-exporter/db"
 	"eth2-exporter/templates"
 	"eth2-exporter/types"
+	"eth2-exporter/utils"
 	"net/http"
 )
 
@@ -22,6 +23,18 @@ func StakingCalculator(w http.ResponseWriter, r *http.Request) {
 	}
 
 	calculatorPageData.TotalStaked = total
+
+	calculatorPageData.EtherscanApiBaseUrl = utils.Config.EtherscanAPIBaseURL
+	if len(calculatorPageData.EtherscanApiBaseUrl) < 1 {
+		switch dcid := utils.Config.Chain.Config.DepositChainID; dcid {
+		case 5: // goerli
+			calculatorPageData.EtherscanApiBaseUrl = "api-goerli.etherscan.io"
+		case 11155111: // sepolia
+			calculatorPageData.EtherscanApiBaseUrl = "api-sepolia.etherscan.io"
+		default:
+			calculatorPageData.EtherscanApiBaseUrl = "api.etherscan.io"
+		}
+	}
 
 	w.Header().Set("Content-Type", "text/html")
 

--- a/handlers/calculator.go
+++ b/handlers/calculator.go
@@ -23,18 +23,7 @@ func StakingCalculator(w http.ResponseWriter, r *http.Request) {
 	}
 
 	calculatorPageData.TotalStaked = total
-
-	calculatorPageData.EtherscanApiBaseUrl = utils.Config.EtherscanAPIBaseURL
-	if len(calculatorPageData.EtherscanApiBaseUrl) < 1 {
-		switch dcid := utils.Config.Chain.Config.DepositChainID; dcid {
-		case 5: // goerli
-			calculatorPageData.EtherscanApiBaseUrl = "api-goerli.etherscan.io"
-		case 11155111: // sepolia
-			calculatorPageData.EtherscanApiBaseUrl = "api-sepolia.etherscan.io"
-		default:
-			calculatorPageData.EtherscanApiBaseUrl = "api.etherscan.io"
-		}
-	}
+	calculatorPageData.EtherscanApiBaseUrl = utils.GetEtherscanAPIBaseUrl(true)
 
 	w.Header().Set("Content-Type", "text/html")
 

--- a/templates/calculator.html
+++ b/templates/calculator.html
@@ -382,7 +382,7 @@
       fetchStats() {
         return new Promise((resolve, reject) => {
           var count = 0
-          fetch("https://api.etherscan.io/api?module=stats&action=ethsupply&apikey=")
+          fetch("https://{{ .EtherscanApiBaseUrl }}/api?module=stats&action=ethsupply&apikey=")
             .then((res) => res.json())
             .then((data) => {
               console.log("success", data)

--- a/types/config.go
+++ b/types/config.go
@@ -38,6 +38,7 @@ type Config struct {
 	Eth1ErigonEndpoint  string `yaml:"eth1ErigonEndpoint" envconfig:"ETH1_ERIGON_ENDPOINT"`
 	Eth1GethEndpoint    string `yaml:"eth1GethEndpoint" envconfig:"ETH1_GETH_ENDPOINT"`
 	EtherscanAPIKey     string `yaml:"etherscanApiKey" envconfig:"ETHERSCAN_API_KEY"`
+	EtherscanAPIBaseURL string `yaml:"etherscanApiBaseUrl" envconfig:"ETHERSCAN_API_BASEURL"`
 	RedisCacheEndpoint  string `yaml:"redisCacheEndpoint" envconfig:"REDIS_CACHE_ENDPOINT"`
 	TieredCacheProvider string `yaml:"tieredCacheProvider" envconfig:"CACHE_PROVIDER"`
 	ReportServiceStatus bool   `yaml:"reportServiceStatus" envconfig:"REPORT_SERVICE_STATUS"`

--- a/types/templates.go
+++ b/types/templates.go
@@ -1081,6 +1081,7 @@ type StakingCalculatorPageData struct {
 	BestValidatorBalanceHistory *[]ValidatorBalanceHistory
 	WatchlistBalanceHistory     [][]interface{}
 	TotalStaked                 uint64
+	EtherscanApiBaseUrl         string
 }
 
 type DepositsPageData struct {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -877,19 +877,37 @@ func TryFetchContractMetadata(address []byte) (*types.ContractMetadata, error) {
 // 	}
 // }
 
+func GetEtherscanAPIBaseUrl(provideDefault bool) string {
+	const mainnetBaseUrl = "api.etherscan.io"
+	const goerliBaseUrl = "api-goerli.etherscan.io"
+	const sepoliaBaseUrl = "api-sepolia.etherscan.io"
+
+	// check config first
+	if len(Config.EtherscanAPIBaseURL) > 0 {
+		return Config.EtherscanAPIBaseURL
+	}
+
+	// check chain id
+	switch Config.Chain.Config.DepositChainID {
+	case 1: // mainnet
+		return mainnetBaseUrl
+	case 5: // goerli
+		return goerliBaseUrl
+	case 11155111: // sepolia
+		return sepoliaBaseUrl
+	}
+
+	// use default
+	if provideDefault {
+		return mainnetBaseUrl
+	}
+	return ""
+}
+
 func getABIFromEtherscan(address []byte) (*types.ContractMetadata, error) {
-	baseUrl := Config.EtherscanAPIBaseURL
+	baseUrl := GetEtherscanAPIBaseUrl(false)
 	if len(baseUrl) < 1 {
-		switch dcid := Config.Chain.Config.DepositChainID; dcid {
-		case 1: // mainnet
-			baseUrl = "api.etherscan.io"
-		case 5: // goerli
-			baseUrl = "api-goerli.etherscan.io"
-		case 11155111: // sepolia
-			baseUrl = "api-sepolia.etherscan.io"
-		default: // unsupported
-			return nil, nil
-		}
+		return nil, nil
 	}
 
 	httpClient := http.Client{Timeout: time.Second * 5}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -878,16 +878,18 @@ func TryFetchContractMetadata(address []byte) (*types.ContractMetadata, error) {
 // }
 
 func getABIFromEtherscan(address []byte) (*types.ContractMetadata, error) {
-	baseUrl := ""
-	switch dcid := Config.Chain.Config.DepositChainID; dcid {
-	case 1: // mainnet
-		baseUrl = "api.etherscan.io"
-	case 5: // goerli
-		baseUrl = "api-goerli.etherscan.io"
-	case 11155111: // sepolia
-		baseUrl = "api-sepolia.etherscan.io"
-	default: // unsupported
-		return nil, nil
+	baseUrl := Config.EtherscanAPIBaseURL
+	if len(baseUrl) < 1 {
+		switch dcid := Config.Chain.Config.DepositChainID; dcid {
+		case 1: // mainnet
+			baseUrl = "api.etherscan.io"
+		case 5: // goerli
+			baseUrl = "api-goerli.etherscan.io"
+		case 11155111: // sepolia
+			baseUrl = "api-sepolia.etherscan.io"
+		default: // unsupported
+			return nil, nil
+		}
 	}
 
 	httpClient := http.Client{Timeout: time.Second * 5}


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5d30c55</samp>

This pull request adds support for customizing the Etherscan API base URL for the staking calculator and the ABI fetching functions. It uses the `utils` package and the `Config` struct to set and access the base URL based on the configuration or the deposit chain ID.
