### PR TITLE
Add graffitiwall pixel history

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -912,11 +912,7 @@ func saveGraffitiwall(blocks map[uint64]map[string]*types.Block, tx *sqlx.Tx) er
 			validator
 		)
 		VALUES ($1, $2, $3, $4, $5)
-		ON CONFLICT (x, y) DO UPDATE SET
-										 color         = EXCLUDED.color,
-										 slot          = EXCLUDED.slot,
-										 validator     = EXCLUDED.validator
-		WHERE excluded.slot > graffitiwall.slot;
+		ON CONFLICT (x, y, slot) DO NOTHING;
 		`)
 	if err != nil {
 		return err

--- a/db/migrations/20230330131622_init_database.sql
+++ b/db/migrations/20230330131622_init_database.sql
@@ -470,13 +470,15 @@ CREATE TABLE IF NOT EXISTS
 
 CREATE TABLE IF NOT EXISTS
     graffitiwall (
+        slot INT NOT NULL,
         x INT NOT NULL,
         y INT NOT NULL,
         color TEXT NOT NULL,
-        slot INT NOT NULL,
         VALIDATOR INT NOT NULL,
-        PRIMARY KEY (x, y)
+        PRIMARY KEY (slot)
     );
+
+CREATE INDEX IF NOT EXISTS idx_graffitiwall_coordinates ON graffitiwall (x, y);
 
 CREATE TABLE IF NOT EXISTS
     eth1_deposits (

--- a/db/migrations/20230330131622_init_database.sql
+++ b/db/migrations/20230330131622_init_database.sql
@@ -470,15 +470,13 @@ CREATE TABLE IF NOT EXISTS
 
 CREATE TABLE IF NOT EXISTS
     graffitiwall (
-        slot INT NOT NULL,
         x INT NOT NULL,
         y INT NOT NULL,
         color TEXT NOT NULL,
+        slot INT NOT NULL,
         VALIDATOR INT NOT NULL,
-        PRIMARY KEY (slot)
+        PRIMARY KEY (x, y)
     );
-
-CREATE INDEX IF NOT EXISTS idx_graffitiwall_coordinates ON graffitiwall (x, y);
 
 CREATE TABLE IF NOT EXISTS
     eth1_deposits (

--- a/db/migrations/20230426113138_alter_graffitiwall_pk.sql
+++ b/db/migrations/20230426113138_alter_graffitiwall_pk.sql
@@ -1,0 +1,19 @@
+-- +goose Up
+-- +goose StatementBegin
+SELECT 'up SQL query';
+ALTER TABLE graffitiwall DROP CONSTRAINT graffitiwall_pkey, ADD PRIMARY KEY(slot);
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+SELECT 'down SQL query';
+-- remove overwritten pixels
+DELETE FROM graffitiwall AS todel
+    WHERE EXISTS (
+        SELECT 1
+        FROM graffitiwall AS newer
+        WHERE newer.x = todel.x AND newer.y = todel.y
+        AND newer.slot > todel.slot
+    );
+ALTER TABLE graffitiwall DROP CONSTRAINT graffitiwall_pkey, ADD PRIMARY KEY(x, y);
+-- +goose StatementEnd

--- a/handlers/api.go
+++ b/handlers/api.go
@@ -2522,7 +2522,7 @@ func ApiGraffitiwall(w http.ResponseWriter, r *http.Request) {
 		validator
 	FROM graffitiwall
 	WHERE slot BETWEEN $1 AND $2 AND x BETWEEN $3 AND $4 AND y BETWEEN $5 AND $6
-	ORDER BY x, y, slot desc`, startSlot, endSlot, startX, endX, startY, endY)
+	ORDER BY x, y, slot DESC`, startSlot, endSlot, startX, endX, startY, endY)
 	if err != nil {
 		logger.WithError(err).Error("could not retrieve db results")
 		sendErrorResponse(w, r.URL.String(), "could not retrieve db results")

--- a/handlers/api.go
+++ b/handlers/api.go
@@ -2447,7 +2447,7 @@ func ApiValidatorProposals(w http.ResponseWriter, r *http.Request) {
 // @Param endx query int false "End X limit" default(999)
 // @Param endy query int false "End Y limit" default(999)
 // @Param startSlot query string false "Start slot to query (end slot - 10000 if empty)"
-// @Param endSlot query string false "End slot to query"
+// @Param slot query string false "End slot to query"
 // @Param summarize query bool false "Only return end state of each pixel" default(true)
 // @Success 200 {object} types.ApiResponse
 // @Failure 400 {object} types.ApiResponse
@@ -2458,20 +2458,21 @@ func ApiGraffitiwall(w http.ResponseWriter, r *http.Request) {
 	q := r.URL.Query()
 	startSlot := uint64(0)
 	endSlot := uint64(0)
-	if q.Get("endSlot") == "" {
+	if q.Get("slot") == "" {
 		endSlot = services.LatestSlot()
 	} else {
 		var err error
-		endSlot, err = strconv.ParseUint(q.Get("endSlot"), 10, 64)
+		endSlot, err = strconv.ParseUint(q.Get("slot"), 10, 64)
 		if err != nil {
-			logger.WithError(err).Errorf("invalid endSlot provided: %v", err)
-			sendErrorResponse(w, r.URL.String(), "invalid endSlot provided")
+			logger.WithError(err).Errorf("invalid slot provided: %v", err)
+			sendErrorResponse(w, r.URL.String(), "invalid slot provided")
 			return
 		}
 	}
+	endSlot = utilMath.MaxU64(endSlot, 10000)
 
 	if q.Get("startSlot") == "" {
-		startSlot = utilMath.MaxU64(endSlot, 10000) - 10000
+		startSlot = endSlot - 10000
 	} else {
 		var err error
 		startSlot, err = strconv.ParseUint(q.Get("startSlot"), 10, 64)

--- a/handlers/api.go
+++ b/handlers/api.go
@@ -2446,7 +2446,9 @@ func ApiValidatorProposals(w http.ResponseWriter, r *http.Request) {
 // @Param starty query int false "Start Y offset" default(0)
 // @Param endx query int false "End X limit" default(999)
 // @Param endy query int false "End Y limit" default(999)
-// @Param slot query string false "Slot to query"
+// @Param startSlot query string false "Start slot to query (end slot - 10000 if empty)"
+// @Param endSlot query string false "End slot to query"
+// @Param summarize query bool false "Only return end state of each pixel" default(true)
 // @Success 200 {object} types.ApiResponse
 // @Failure 400 {object} types.ApiResponse
 // @Router /api/v1/graffitiwall [get]
@@ -2454,19 +2456,36 @@ func ApiGraffitiwall(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	q := r.URL.Query()
-	slotQuery := uint64(0)
-	if q.Get("slot") == "" {
-		slotQuery = services.LatestSlot()
+	startSlot := uint64(0)
+	endSlot := uint64(0)
+	if q.Get("endSlot") == "" {
+		endSlot = services.LatestSlot()
 	} else {
 		var err error
-		slotQuery, err = strconv.ParseUint(q.Get("slot"), 10, 64)
+		endSlot, err = strconv.ParseUint(q.Get("endSlot"), 10, 64)
 		if err != nil {
-			logger.WithError(err).Errorf("invalid slot provided: %v", err)
-			sendErrorResponse(w, r.URL.String(), "invalid slot provided")
+			logger.WithError(err).Errorf("invalid endSlot provided: %v", err)
+			sendErrorResponse(w, r.URL.String(), "invalid endSlot provided")
 			return
 		}
 	}
-	slotQuery = utilMath.MaxU64(slotQuery, 10000)
+
+	if q.Get("startSlot") == "" {
+		startSlot = utilMath.MaxU64(endSlot, 10000) - 10000
+	} else {
+		var err error
+		startSlot, err = strconv.ParseUint(q.Get("startSlot"), 10, 64)
+		if err != nil {
+			logger.WithError(err).Errorf("invalid startSlot provided: %v", err)
+			sendErrorResponse(w, r.URL.String(), "invalid startSlot provided")
+			return
+		}
+		if startSlot > endSlot {
+			logger.Errorf("start slot greater than end slot")
+			sendErrorResponse(w, r.URL.String(), "start slot greater than end slot")
+			return
+		}
+	}
 
 	defaultStartPxl := uint64(0)
 	defaultEndPxl := uint64(999)
@@ -2482,8 +2501,20 @@ func ApiGraffitiwall(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	summarize, err := strconv.ParseBool(q.Get("summarize"))
+	if err != nil {
+		logger.WithError(err).Errorf("invalid value for summarize provided: %v", err)
+		sendErrorResponse(w, r.URL.String(), "invalid value for summarize provided")
+		return
+	}
+	summarize_query := ""
+	if summarize {
+		// only pick latest pixel update
+		summarize_query = "DISTINCT ON (x, y) "
+	}
+
 	rows, err := db.ReaderDb.Query(`
-	SELECT 
+	SELECT ` + summarize_query + `
 		x,
 		y,
 		color,
@@ -2491,7 +2522,7 @@ func ApiGraffitiwall(w http.ResponseWriter, r *http.Request) {
 		validator
 	FROM graffitiwall
 	WHERE slot BETWEEN $1 AND $2 AND x BETWEEN $3 AND $4 AND y BETWEEN $5 AND $6
-	ORDER BY slot desc, x, y`, slotQuery-10000, slotQuery, startX, endX, startY, endY)
+	ORDER BY x, y, slot desc`, startSlot, endSlot, startX, endX, startY, endY)
 	if err != nil {
 		logger.WithError(err).Error("could not retrieve db results")
 		sendErrorResponse(w, r.URL.String(), "could not retrieve db results")

--- a/handlers/graffitiwall.go
+++ b/handlers/graffitiwall.go
@@ -17,7 +17,8 @@ func Graffitiwall(w http.ResponseWriter, r *http.Request) {
 
 	var graffitiwallData []*types.GraffitiwallData
 
-	err = db.ReaderDb.Select(&graffitiwallData, "select x, y, color, slot, validator from graffitiwall")
+	// only fetch latest entry for each pixel
+	err = db.ReaderDb.Select(&graffitiwallData, "SELECT DISTINCT ON (x, y) x, y, color, slot, validator from graffitiwall ORDER BY x, y, slot DESC")
 
 	if err != nil {
 		logger.Errorf("error retrieving block tree data: %v", err)


### PR DESCRIPTION
This PR is meant to improve api requests related to the graffitiwall, mainly by implementing #1524.

I think you moved to google's BigTable which I've no access to. So I'm not sure how to properly apply the table definition changes, but you'll find them in the migrations file.

Also I dislike the 10,000 slot limit which has been introduced while implementing #1523. To recall, after this change only the graffiti pixels which have been drawn during the specified 10,000 slot window (and which also have not been overwritten at *any* later slot) are returned. So in order to reproduce the current graffitiwall status from the api, you'd need to query the entire time span of all slots. At the moment that translates to roughly 629 api calls. I understand the slot limit is a way to minimize load, but I think it was better like before (where you could accomplish the same task with just one api call).

Now to fix this I suggest letting the user define a custom slot window (start - end). If you want to keep the window, at least offer a dedicated way to just pull the latest state of the wall as that reduces bandwidth (since overwritten pixels are not sent any more, only the latest ones) and I assume that's what most people like to use anyways.

I've done a combination of both which I liked the most: I added the start field `startSlot`, but also defined a new boolean field called `summarize`. When set to `true` it only returns the end state of all pixels drawn in the specified time window, when set to `false` it returns all pixel updates (=pixel/turf wars).

I could only do some basic mock testing because it takes quite some effort to set everything up properly, hope that's okay.