### PR TITLE
(NOBIDS) Removed needless output

### DIFF
--- a/handlers/user.go
+++ b/handlers/user.go
@@ -1190,11 +1190,7 @@ func UserUpdateFlagsPost(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	shareStats := FormValueOrJSON(r, "shareStats")
-
-	logger.Errorf("shareStats: %v", shareStats)
-
-	err = db.SetUserMonitorSharingSetting(user.UserID, shareStats == "true")
+	err = db.SetUserMonitorSharingSetting(user.UserID, FormValueOrJSON(r, "shareStats") == "true")
 	if err != nil {
 		logger.Errorf("error setting user monitor sharing settings: %v", err)
 		http.Error(w, "Internal server error", http.StatusInternalServerError)


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a600c34</samp>

Simplified the code for setting user monitor sharing settings in `handlers/user.go` by removing a redundant variable and logging statement. This change is part of a pull request to optimize and fix the user settings handler.
