### PR TITLE
(BIDS-1967) Convert ETH values correctly from GWei to ETH

### DIFF
--- a/services/charts_updater.go
+++ b/services/charts_updater.go
@@ -697,7 +697,7 @@ func effectiveBalanceDistributionChartData() (*types.GenericChartData, error) {
 		if len(balance) == 0 {
 			continue
 		}
-		effectiveBalances = append(effectiveBalances, float64(balance[0].EffectiveBalance)/1e6)
+		effectiveBalances = append(effectiveBalances, float64(balance[0].EffectiveBalance)/1e9)
 	}
 
 	bins := int(math.Sqrt(float64(len(effectiveBalances)))) + 1

--- a/services/charts_updater.go
+++ b/services/charts_updater.go
@@ -647,7 +647,7 @@ func balanceDistributionChartData() (*types.GenericChartData, error) {
 		if len(balance) == 0 {
 			continue
 		}
-		currentBalances = append(currentBalances, float64(balance[0].Balance)/1e6)
+		currentBalances = append(currentBalances, float64(balance[0].Balance)/1e9)
 	}
 
 	bins := int(math.Sqrt(float64(len(currentBalances)))) + 1


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d22d732</samp>

Fixed balance distribution chart data and conversion factor in `charts_updater.go`. The chart now shows the correct distribution of balances and effective balances in ether instead of gwei.
