### PR TITLE
(BIDS-1916) Sync event names

### DIFF
--- a/cmd/signatures/main.go
+++ b/cmd/signatures/main.go
@@ -72,7 +72,7 @@ func main() {
 	}
 
 	go ImportSignatures(bt, types.MethodSignature)
-	time.Sleep(time.Second * 2) // we need a little delay, as the api does not like to two requests at the same time
+	time.Sleep(time.Second * 2) // we need a little delay, as the api does not like two requests at the same time
 	go ImportSignatures(bt, types.EventSignature)
 
 	utils.WaitForCtrlC()

--- a/db/bigtable_eth1.go
+++ b/db/bigtable_eth1.go
@@ -3508,7 +3508,7 @@ func (bigtable *Bigtable) GetEventLabel(id []byte) string {
 		cacheKey := fmt.Sprintf("E:H2L:%s", event)
 		if _, err := cache.TieredCache.GetWithLocalTimeout(cacheKey, time.Hour, &label); err != nil {
 			sig, err := bigtable.GetSignature(event, types.EventSignature)
-			if err == nil && sig != nil {
+			if err == nil {
 				if sig != nil {
 					label = *sig
 				}

--- a/db/bigtable_eth1.go
+++ b/db/bigtable_eth1.go
@@ -3432,7 +3432,7 @@ func (bigtable *Bigtable) SaveSignatureImportStatus(status types.SignatureImport
 	return nil
 }
 
-// Save a list of method signatures
+// Save a list of signatures
 func (bigtable *Bigtable) SaveSignatures(signatures []types.Signature, st types.SignatureType) error {
 
 	mutsWrite := &types.BulkMutations{
@@ -3459,7 +3459,7 @@ func (bigtable *Bigtable) SaveSignatures(signatures []types.Signature, st types.
 	return nil
 }
 
-// get a method signature by it's hex representation
+// get a signature by it's hex representation
 func (bigtable *Bigtable) GetSignature(hex string, st types.SignatureType) (*string, error) {
 	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(time.Second*30))
 	defer cancel()
@@ -3483,7 +3483,7 @@ func (bigtable *Bigtable) GetMethodLabel(id []byte, invokesContract bool) string
 	if len(id) > 0 {
 		if invokesContract {
 			method = fmt.Sprintf("0x%x", id)
-			cacheKey := fmt.Sprintf("METHOD:HASH_TO_LABEL:%s", method)
+			cacheKey := fmt.Sprintf("M:H2L:%s", method)
 			if _, err := cache.TieredCache.GetWithLocalTimeout(cacheKey, time.Hour, &method); err != nil {
 				sig, err := bigtable.GetSignature(method, types.MethodSignature)
 				if err == nil && sig != nil {
@@ -3498,13 +3498,13 @@ func (bigtable *Bigtable) GetMethodLabel(id []byte, invokesContract bool) string
 	return method
 }
 
-// get a event label for its byte signature with defaults
+// get an event label for its byte signature with defaults
 func (bigtable *Bigtable) GetEventLabel(id []byte) string {
 	label := ""
 	if len(id) > 0 {
 		method := fmt.Sprintf("0x%x", id)
-		cacheKey := fmt.Sprintf("EVENT:HASH_TO_LABEL:%s", method)
-		if _, err := cache.TieredCache.GetWithLocalTimeout(cacheKey, time.Hour, &method); err != nil {
+		cacheKey := fmt.Sprintf("E:H2L:%s", fmt.Sprintf("0x%x", id))
+		if _, err := cache.TieredCache.GetWithLocalTimeout(cacheKey, time.Hour, &label); err != nil {
 			sig, err := bigtable.GetSignature(method, types.EventSignature)
 			if err == nil && sig != nil {
 				label = *sig

--- a/db/bigtable_eth1.go
+++ b/db/bigtable_eth1.go
@@ -3486,10 +3486,10 @@ func (bigtable *Bigtable) GetMethodLabel(id []byte, invokesContract bool) string
 			cacheKey := fmt.Sprintf("M:H2L:%s", method)
 			if _, err := cache.TieredCache.GetWithLocalTimeout(cacheKey, time.Hour, &method); err != nil {
 				sig, err := bigtable.GetSignature(method, types.MethodSignature)
-				if err == nil && sig != nil {
-					method = *sig
-				}
 				if err == nil {
+					if sig != nil {
+						method = *sig
+					}
 					cache.TieredCache.Set(cacheKey, method, time.Hour)
 				}
 			}
@@ -3505,14 +3505,14 @@ func (bigtable *Bigtable) GetEventLabel(id []byte) string {
 	label := ""
 	if len(id) > 0 {
 		event := fmt.Sprintf("0x%x", id)
-		cacheKey := fmt.Sprintf("E:H2L:%s", fmt.Sprintf("0x%x", id))
+		cacheKey := fmt.Sprintf("E:H2L:%s", event)
 		if _, err := cache.TieredCache.GetWithLocalTimeout(cacheKey, time.Hour, &label); err != nil {
 			sig, err := bigtable.GetSignature(event, types.EventSignature)
 			if err == nil && sig != nil {
-				label = *sig
-			}
-			if err == nil {
-				cache.TieredCache.Set(cacheKey, event, time.Hour)
+				if sig == nil {
+					label = *sig
+				}
+				cache.TieredCache.Set(cacheKey, label, time.Hour)
 			}
 		}
 	}

--- a/db/bigtable_eth1.go
+++ b/db/bigtable_eth1.go
@@ -3509,7 +3509,7 @@ func (bigtable *Bigtable) GetEventLabel(id []byte) string {
 		if _, err := cache.TieredCache.GetWithLocalTimeout(cacheKey, time.Hour, &label); err != nil {
 			sig, err := bigtable.GetSignature(event, types.EventSignature)
 			if err == nil && sig != nil {
-				if sig == nil {
+				if sig != nil {
 					label = *sig
 				}
 				cache.TieredCache.Set(cacheKey, label, time.Hour)

--- a/db/bigtable_eth1.go
+++ b/db/bigtable_eth1.go
@@ -3489,7 +3489,9 @@ func (bigtable *Bigtable) GetMethodLabel(id []byte, invokesContract bool) string
 				if err == nil && sig != nil {
 					method = *sig
 				}
-				cache.TieredCache.Set(cacheKey, method, time.Hour)
+				if err == nil {
+					cache.TieredCache.Set(cacheKey, method, time.Hour)
+				}
 			}
 		} else {
 			method = "Transfer*"
@@ -3502,14 +3504,16 @@ func (bigtable *Bigtable) GetMethodLabel(id []byte, invokesContract bool) string
 func (bigtable *Bigtable) GetEventLabel(id []byte) string {
 	label := ""
 	if len(id) > 0 {
-		method := fmt.Sprintf("0x%x", id)
+		event := fmt.Sprintf("0x%x", id)
 		cacheKey := fmt.Sprintf("E:H2L:%s", fmt.Sprintf("0x%x", id))
 		if _, err := cache.TieredCache.GetWithLocalTimeout(cacheKey, time.Hour, &label); err != nil {
-			sig, err := bigtable.GetSignature(method, types.EventSignature)
+			sig, err := bigtable.GetSignature(event, types.EventSignature)
 			if err == nil && sig != nil {
 				label = *sig
 			}
-			cache.TieredCache.Set(cacheKey, method, time.Hour)
+			if err == nil {
+				cache.TieredCache.Set(cacheKey, event, time.Hour)
+			}
 		}
 	}
 	return label

--- a/eth1data/eth1data.go
+++ b/eth1data/eth1data.go
@@ -167,11 +167,14 @@ func GetEth1Transaction(hash common.Hash) (*types.Eth1TxData, error) {
 				cmEntry.meta, cmEntry.err = db.BigtableClient.GetContractMetadata(log.Address.Bytes())
 				contractMetadataCache[log.Address] = cmEntry
 			}
-
 			if cmEntry.err != nil || cmEntry.meta == nil || cmEntry.meta.ABI == nil {
+				name := ""
+				if len(log.Topics) > 0 {
+					name = db.BigtableClient.GetEventLabel(log.Topics[0][:])
+				}
 				eth1Event := &types.Eth1EventData{
 					Address: log.Address,
-					Name:    "",
+					Name:    name,
 					Topics:  log.Topics,
 					Data:    log.Data,
 				}

--- a/handlers/slot.go
+++ b/handlers/slot.go
@@ -713,12 +713,13 @@ func BlockTransactionsData(w http.ResponseWriter, r *http.Request) {
 
 	data := make([]*transactionsData, len(transactions.Txs))
 	for i, v := range transactions.Txs {
-		if len(v.Method) == 0 {
-			v.Method = "Transfer"
+		methodFormatted := `<span class="badge badge-light">Transfer</span>`
+		if len(v.Method) > 0 && v.Method != "Transfer" {
+			methodFormatted = fmt.Sprintf(`<span class="badge badge-light text-truncate mw-100" data-toggle="tooltip" title="%v"{>%v</span>`, v.Method, v.Method)
 		}
 		data[i] = &transactionsData{
 			HashFormatted: v.HashFormatted,
-			Method:        `<span class="badge badge-light">` + v.Method + `</span>`,
+			Method:        methodFormatted,
 			FromFormatted: v.FromFormatted,
 			ToFormatted:   v.ToFormatted,
 			Value:         utils.FormatAmountFormatted(v.Value, "Ether", 5, 0, true, true, false),

--- a/types/frontend.go
+++ b/types/frontend.go
@@ -561,13 +561,20 @@ type SyncCommitteesStats struct {
 	ScheduledSlots    uint64 `json:"scheduledSlots"`
 }
 
-type MethodSignatureImportStatus struct {
+type SignatureType string
+
+const (
+	MethodSignature SignatureType = "method"
+	EventSignature  SignatureType = "event"
+)
+
+type SignatureImportStatus struct {
 	LatestTimestamp *string `json:"latestTimestamp"`
 	NextPage        *string `json:"nextPage"`
 	HasFinished     bool    `json:"hasFinished"`
 }
 
-type MethodSignature struct {
+type Signature struct {
 	Id        int64  `json:"id"`
 	CreatedAt string `json:"created_at"`
 	Text      string `json:"text_signature"`


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e6d4aa7</samp>

This pull request adds support for importing and displaying event signatures from the 4byte API, in addition to method signatures. It modifies the `cmd/signatures/main.go` program, the `db/bigtable_eth1.go` database interface, the `types/frontend.go` signature types, and the `eth1data/eth1data.go` event name logic.
