### PR TITLE
(NOBIDS) slot template: remove pipeline from js literal

### DIFF
--- a/templates/slot/slot.html
+++ b/templates/slot/slot.html
@@ -138,7 +138,8 @@
       const infLoading = document.getElementById('attestations');
       if(infLoading) {
         try {
-          const res = await fetch(`/slot/${encodeURI({{.Slot}})}/attestations`);
+          const slot = {{ .Slot }} || 0;
+          const res = await fetch(`/slot/${encodeURI(slot)}/attestations`);
           const data = await res.json();
 
           for (let i = 1; i < data.length; ++i) {


### PR DESCRIPTION
Since [CL482079](https://go-review.googlesource.com/c/go/+/482079) template pipelines are not allowed inside JS literals anymore. This PR removes such a case from the slot template (didn't find any others in the project after a quick search).