### PR TITLE
Bids 1961/time column tooltip consistency

### DIFF
--- a/db/bigtable_eth1.go
+++ b/db/bigtable_eth1.go
@@ -1840,7 +1840,7 @@ func (bigtable *Bigtable) GetAddressTransactionsTableData(address []byte, search
 			utils.FormatTransactionHash(t.Hash),
 			utils.FormatMethod(method),
 			utils.FormatBlockNumber(t.BlockNumber),
-			utils.FormatTimeFromNow(t.Time.AsTime()),
+			utils.FormatTimestamp(t.Time.AsTime().Unix()),
 			from,
 			utils.FormatInOutSelf(address, t.From, t.To),
 			to,
@@ -1932,7 +1932,7 @@ func (bigtable *Bigtable) GetAddressBlocksMinedTableData(address string, search 
 
 		tableData[i] = []interface{}{
 			utils.FormatBlockNumber(b.Number),
-			utils.FormatTimeFromNow(b.Time.AsTime()),
+			utils.FormatTimestamp(b.Time.AsTime().Unix()),
 			utils.FormatBlockUsage(b.GasUsed, b.GasLimit),
 			utils.FormatAmount(reward, "Ether", 6),
 		}
@@ -2019,7 +2019,7 @@ func (bigtable *Bigtable) GetAddressUnclesMinedTableData(address string, search 
 
 		tableData[i] = []interface{}{
 			utils.FormatBlockNumber(u.Number),
-			utils.FormatTimeFromNow(u.Time.AsTime()),
+			utils.FormatTimestamp(u.Time.AsTime().Unix()),
 			utils.FormatDifficulty(new(big.Int).SetBytes(u.Difficulty)),
 			utils.FormatAmount(new(big.Int).SetBytes(u.Reward), "Ether", 6),
 		}
@@ -2121,7 +2121,7 @@ func (bigtable *Bigtable) GetAddressInternalTableData(address []byte, search str
 
 		tableData[i] = []interface{}{
 			utils.FormatTransactionHash(t.ParentHash),
-			utils.FormatTimeFromNow(t.Time.AsTime()),
+			utils.FormatTimestamp(t.Time.AsTime().Unix()),
 			from,
 			utils.FormatInOutSelf(address, t.From, t.To),
 			to,
@@ -2412,7 +2412,7 @@ func (bigtable *Bigtable) GetAddressErc20TableData(address []byte, search string
 
 		tableData[i] = []interface{}{
 			utils.FormatTransactionHash(t.ParentHash),
-			utils.FormatTimeFromNow(t.Time.AsTime()),
+			utils.FormatTimestamp(t.Time.AsTime().Unix()),
 			from,
 			utils.FormatInOutSelf(address, t.From, t.To),
 			to,
@@ -2504,7 +2504,7 @@ func (bigtable *Bigtable) GetAddressErc721TableData(address string, search strin
 		}
 		tableData[i] = []interface{}{
 			utils.FormatTransactionHash(t.ParentHash),
-			utils.FormatTimeFromNow(t.Time.AsTime()),
+			utils.FormatTimestamp(t.Time.AsTime().Unix()),
 			from,
 			to,
 			utils.FormatAddressAsLink(t.TokenAddress, "", false, true),
@@ -2588,7 +2588,7 @@ func (bigtable *Bigtable) GetAddressErc1155TableData(address string, search stri
 		}
 		tableData[i] = []interface{}{
 			utils.FormatTransactionHash(t.ParentHash),
-			utils.FormatTimeFromNow(t.Time.AsTime()),
+			utils.FormatTimestamp(t.Time.AsTime().Unix()),
 			from,
 			to,
 			utils.FormatAddressAsLink(t.TokenAddress, "", false, true),
@@ -3319,7 +3319,7 @@ func (bigtable *Bigtable) GetTokenTransactionsTableData(token []byte, address []
 
 		tableData[i] = []interface{}{
 			utils.FormatTransactionHash(t.ParentHash),
-			utils.FormatTimeFromNow(t.Time.AsTime()),
+			utils.FormatTimestamp(t.Time.AsTime().Unix()),
 			from,
 			utils.FormatInOutSelf(address, t.From, t.To),
 			to,

--- a/eth1data/eth1data.go
+++ b/eth1data/eth1data.go
@@ -87,7 +87,7 @@ func GetEth1Transaction(hash common.Hash) (*types.Eth1TxData, error) {
 		return nil, fmt.Errorf("error retrieving block header data for tx %v: %v", hash, err)
 	}
 	txPageData.BlockNumber = header.Number.Int64()
-	txPageData.Timestamp = header.Time
+	txPageData.Timestamp = time.Unix(int64(header.Time), 0)
 
 	msg, err := tx.AsMessage(geth_types.NewLondonSigner(tx.ChainId()), header.BaseFee)
 	if err != nil {

--- a/handlers/dashboard.go
+++ b/handlers/dashboard.go
@@ -308,7 +308,7 @@ func getNextWithdrawalRow(queryValidators []uint64) ([][]interface{}, error) {
 		template.HTML(fmt.Sprintf("%v", utils.FormatValidator(nextValidator.Index))),
 		template.HTML(fmt.Sprintf(`<span class="text-muted">~ %s</span>`, utils.FormatEpoch(uint64(utils.TimeToEpoch(timeToWithdrawal))))),
 		template.HTML(fmt.Sprintf(`<span class="text-muted">~ %s</span>`, utils.FormatBlockSlot(utils.TimeToSlot(uint64(timeToWithdrawal.Unix()))))),
-		template.HTML(fmt.Sprintf(`<span class="">~ %s</span>`, utils.FormatTimeFromNow(timeToWithdrawal))),
+		template.HTML(fmt.Sprintf(`<span class="">~ %s</span>`, utils.FormatTimestamp(timeToWithdrawal.Unix()))),
 		withdrawalCredentialsTemplate,
 		template.HTML(fmt.Sprintf(`<span class="text-muted"><span data-toggle="tooltip" title="If the withdrawal were to be processed at this very moment, this amount would be withdrawn"><i class="far ml-1 fa-question-circle" style="margin-left: 0px !important;"></i></span> %s</span>`, utils.FormatAmount(new(big.Int).Mul(new(big.Int).SetUint64(withdrawalAmount), big.NewInt(1e9)), "Ether", 6))),
 	})
@@ -561,7 +561,7 @@ func DashboardDataWithdrawals(w http.ResponseWriter, r *http.Request) {
 			template.HTML(fmt.Sprintf("%v", utils.FormatValidator(w.ValidatorIndex))),
 			template.HTML(fmt.Sprintf("%v", utils.FormatEpoch(utils.EpochOfSlot(w.Slot)))),
 			template.HTML(fmt.Sprintf("%v", utils.FormatBlockSlot(w.Slot))),
-			template.HTML(fmt.Sprintf("%v", utils.FormatTimeFromNow(utils.SlotToTime(w.Slot)))),
+			template.HTML(fmt.Sprintf("%v", utils.FormatTimestamp(utils.SlotToTime(w.Slot).Unix()))),
 			template.HTML(fmt.Sprintf("%v", utils.FormatAddress(w.Address, nil, "", false, false, true))),
 			template.HTML(fmt.Sprintf("%v", utils.FormatAmount(new(big.Int).Mul(new(big.Int).SetUint64(w.Amount), big.NewInt(1e9)), "Ether", 6))),
 		})
@@ -686,7 +686,8 @@ func DashboardDataValidators(w http.ResponseWriter, r *http.Request) {
 		if v.LastAttestationSlot != nil && *v.LastAttestationSlot != 0 {
 			tableData[i] = append(tableData[i], []interface{}{
 				*v.LastAttestationSlot,
-				utils.SlotToTime(uint64(*v.LastAttestationSlot)).Unix(),
+				utils.FormatTimestamp(utils.SlotToTime(uint64(*v.LastAttestationSlot)).Unix()),
+				//utils.SlotToTime(uint64(*v.LastAttestationSlot)).Unix(),
 			})
 		} else {
 			tableData[i] = append(tableData[i], nil)

--- a/handlers/eth1Account.go
+++ b/handlers/eth1Account.go
@@ -145,7 +145,7 @@ func Eth1Address(w http.ResponseWriter, r *http.Request) {
 			withdrawalsData = append(withdrawalsData, []interface{}{
 				template.HTML(fmt.Sprintf("%v", utils.FormatEpoch(utils.EpochOfSlot(w.Slot)))),
 				template.HTML(fmt.Sprintf("%v", utils.FormatBlockSlot(w.Slot))),
-				template.HTML(fmt.Sprintf("%v", utils.FormatTimeFromNow(utils.SlotToTime(w.Slot)))),
+				template.HTML(fmt.Sprintf("%v", utils.FormatTimestamp(utils.SlotToTime(w.Slot).Unix()))),
 				template.HTML(fmt.Sprintf("%v", utils.FormatValidator(w.ValidatorIndex))),
 				template.HTML(fmt.Sprintf("%v", utils.FormatAmount(new(big.Int).Mul(new(big.Int).SetUint64(w.Amount), big.NewInt(1e9)), "Ether", 6))),
 			})
@@ -378,7 +378,7 @@ func Eth1AddressWithdrawals(w http.ResponseWriter, r *http.Request) {
 		tableData[i] = []interface{}{
 			template.HTML(fmt.Sprintf("%v", utils.FormatEpoch(utils.EpochOfSlot(w.Slot)))),
 			template.HTML(fmt.Sprintf("%v", utils.FormatBlockSlot(w.Slot))),
-			template.HTML(fmt.Sprintf("%v", utils.FormatTimeFromNow(utils.SlotToTime(w.Slot)))),
+			template.HTML(fmt.Sprintf("%v", utils.FormatTimestamp(utils.SlotToTime(w.Slot).Unix()))),
 			template.HTML(fmt.Sprintf("%v", utils.FormatValidator(w.ValidatorIndex))),
 			template.HTML(fmt.Sprintf("%v", utils.FormatAmount(new(big.Int).Mul(new(big.Int).SetUint64(w.Amount), big.NewInt(1e9)), "Ether", 6))),
 		}

--- a/handlers/eth1tx.go
+++ b/handlers/eth1tx.go
@@ -82,7 +82,7 @@ func Eth1TransactionTx(w http.ResponseWriter, r *http.Request) {
 			cPrice, _ := currentEthPrice.Float64()
 			txData.CurrentEtherPrice = template.HTML(p.Sprintf(`<span>%s %.2f</span>`, symbol, cPrice))
 
-			txDay := utils.TimeToDay(txData.Timestamp)
+			txDay := utils.TimeToDay(uint64(txData.Timestamp.Unix()))
 			latestEpoch, err := db.GetLatestEpoch()
 			if err != nil {
 				logrus.Error(err)

--- a/handlers/user.go
+++ b/handlers/user.go
@@ -2513,7 +2513,7 @@ func NotificationWebhookPage(w http.ResponseWriter, r *http.Request) {
 		ls := template.HTML(`N/A`)
 
 		if wh.LastSent.Valid {
-			ls = utils.FormatTimestampTs(wh.LastSent.Time)
+			ls = utils.FormatTimestamp(wh.LastSent.Time.Unix())
 		}
 
 		whErr := types.UserWebhookRowError{}

--- a/handlers/validator.go
+++ b/handlers/validator.go
@@ -502,7 +502,7 @@ func Validator(w http.ResponseWriter, r *http.Request) {
 					tableData = append(tableData, []interface{}{
 						template.HTML(fmt.Sprintf(`<span class="text-muted">~ %s</span>`, utils.FormatEpoch(uint64(utils.TimeToEpoch(timeToWithdrawal))))),
 						template.HTML(fmt.Sprintf(`<span class="text-muted">~ %s</span>`, utils.FormatBlockSlot(utils.TimeToSlot(uint64(timeToWithdrawal.Unix()))))),
-						template.HTML(fmt.Sprintf(`<span class="">~ %s</span>`, utils.FormatTimeFromNow(timeToWithdrawal))),
+						template.HTML(fmt.Sprintf(`<span class="">~ %s</span>`, utils.FormatTimestamp(timeToWithdrawal.Unix()))),
 						withdrawalCredentialsTemplate,
 						template.HTML(fmt.Sprintf(`<span class="text-muted"><span data-toggle="tooltip" title="If the withdrawal were to be processed at this very moment, this amount would be withdrawn"><i class="far ml-1 fa-question-circle" style="margin-left: 0px !important;"></i></span> %s</span>`, utils.FormatAmount(new(big.Int).Mul(new(big.Int).SetUint64(withdrawalAmont), big.NewInt(1e9)), "Ether", 6))),
 					})
@@ -1299,7 +1299,7 @@ func ValidatorWithdrawals(w http.ResponseWriter, r *http.Request) {
 		tableData = append(tableData, []interface{}{
 			template.HTML(fmt.Sprintf("%v", utils.FormatEpoch(utils.EpochOfSlot(w.Slot)))),
 			template.HTML(fmt.Sprintf("%v", utils.FormatBlockSlot(w.Slot))),
-			template.HTML(fmt.Sprintf("%v", utils.FormatTimeFromNow(utils.SlotToTime(w.Slot)))),
+			template.HTML(fmt.Sprintf("%v", utils.FormatTimestamp(utils.SlotToTime(w.Slot).Unix()))),
 			template.HTML(fmt.Sprintf("%v", utils.FormatAddress(w.Address, nil, "", false, false, true))),
 			template.HTML(fmt.Sprintf("%v", utils.FormatAmount(new(big.Int).Mul(new(big.Int).SetUint64(w.Amount), big.NewInt(1e9)), "Ether", 6))),
 		})

--- a/handlers/withdrawals.go
+++ b/handlers/withdrawals.go
@@ -175,7 +175,7 @@ func WithdrawalsTableData(draw uint64, search string, length, start uint64, orde
 			template.HTML(fmt.Sprintf("%v", utils.FormatBlockSlot(w.Slot))),
 			template.HTML(fmt.Sprintf("%v", w.Index)),
 			template.HTML(fmt.Sprintf("%v", utils.FormatValidator(w.ValidatorIndex))),
-			template.HTML(fmt.Sprintf("%v", utils.FormatTimeFromNow(utils.SlotToTime(w.Slot)))),
+			template.HTML(fmt.Sprintf("%v", utils.FormatTimestamp(utils.SlotToTime(w.Slot).Unix()))),
 			template.HTML(fmt.Sprintf("%v", utils.FormatAddress(w.Address, nil, "", false, false, true))),
 			template.HTML(fmt.Sprintf("%v", utils.FormatAmount(new(big.Int).Mul(new(big.Int).SetUint64(w.Amount), big.NewInt(1e9)), formatCurrency, 6))),
 		}

--- a/static/js/dashboard.js
+++ b/static/js/dashboard.js
@@ -529,7 +529,7 @@ $(document).ready(function () {
         render: function (data, type, row, meta) {
           if (type == "sort" || type == "type") return data ? data[0] : null
           if (data === null) return "No Attestation found"
-          return `<span>${getRelativeTime(luxon.DateTime.fromMillis(data[1] * 1000))}</span>`
+          return `${data[1]}`
         },
       },
       {

--- a/static/js/layout.js
+++ b/static/js/layout.js
@@ -490,13 +490,15 @@ function formatAriaEthereumDate(elem) {
   }
 
   var local = luxon.DateTime.fromMillis(dt * 1000)
+  var toolTipFormat = "yyyy-MM-dd HH:mm:ss"
+
   if (format === "FROMNOW") {
     $(elem).text(getRelativeTime(local))
-    $(elem).attr("data-original-title", local.toFormat("yyyy-MM-dd HH:mm:ss"))
+    $(elem).attr("data-original-title", local.toFormat(toolTipFormat))
     $(elem).attr("data-toggle", "tooltip")
   } else if (format === "LOCAL") {
     $(elem).text(local.toFormat("MMM-dd-yyyy HH:mm:ss") + " UTC" + local.toFormat("Z"))
-    $(elem).attr("data-original-title", local.toFormat("yyyy-MM-dd HH:mm:ss"))
+    $(elem).attr("data-original-title", local.toFormat(toolTipFormat))
     $(elem).attr("data-toggle", "tooltip")
   } else {
     $(elem).text(local.toFormat(format))
@@ -510,10 +512,11 @@ function formatTimestamps(selStr) {
   }
   sel.find(".timestamp").each(function () {
     var ts = $(this).data("timestamp")
-    var tsLuxon = luxon.DateTime.fromMillis(ts * 1000)
+    var local = luxon.DateTime.fromMillis(ts * 1000)
+    var toolTipFormat = "yyyy-MM-dd HH:mm:ss"
 
-    $(this).text(getRelativeTime(tsLuxon))
-    $(this).attr("data-original-title", tsLuxon.toFormat("yyyy-MM-dd HH:mm:ss"))
+    $(this).text(getRelativeTime(local))
+    $(this).attr("data-original-title", local.toFormat(toolTipFormat))
   })
 
   if (sel.find('[data-toggle="tooltip"]').tooltip) {

--- a/static/js/layout.js
+++ b/static/js/layout.js
@@ -489,17 +489,17 @@ function formatAriaEthereumDate(elem) {
     format = "ff"
   }
 
+  var local = luxon.DateTime.fromMillis(dt * 1000)
   if (format === "FROMNOW") {
-    $(elem).text(getRelativeTime(luxon.DateTime.fromMillis(dt * 1000)))
-    $(elem).attr("title", luxon.DateTime.fromMillis(dt * 1000).toFormat("ff"))
+    $(elem).text(getRelativeTime(local))
+    $(elem).attr("data-original-title", local.toFormat("yyyy-MM-dd HH:mm:ss"))
     $(elem).attr("data-toggle", "tooltip")
   } else if (format === "LOCAL") {
-    var local = luxon.DateTime.fromMillis(dt * 1000)
     $(elem).text(local.toFormat("MMM-dd-yyyy HH:mm:ss") + " UTC" + local.toFormat("Z"))
-    $(elem).attr("title", luxon.DateTime.fromMillis(dt * 1000).toFormat("ff"))
+    $(elem).attr("data-original-title", local.toFormat("yyyy-MM-dd HH:mm:ss"))
     $(elem).attr("data-toggle", "tooltip")
   } else {
-    $(elem).text(luxon.DateTime.fromMillis(dt * 1000).toFormat(format))
+    $(elem).text(local.toFormat(format))
   }
 }
 
@@ -511,9 +511,9 @@ function formatTimestamps(selStr) {
   sel.find(".timestamp").each(function () {
     var ts = $(this).data("timestamp")
     var tsLuxon = luxon.DateTime.fromMillis(ts * 1000)
-    $(this).attr("data-original-title", tsLuxon.toFormat("ff"))
 
     $(this).text(getRelativeTime(tsLuxon))
+    $(this).attr("data-original-title", tsLuxon.toFormat("yyyy-MM-dd HH:mm:ss"))
   })
 
   if (sel.find('[data-toggle="tooltip"]').tooltip) {
@@ -526,7 +526,7 @@ function getLuxonDateFromTimestamp(ts) {
     return
   }
 
-  // Parse Date depanding on the format we get it
+  // Parse Date depending on the format we get it
   if (`${ts}`.includes("T")) {
     if (ts === "0001-01-01T00:00:00Z") {
       return

--- a/static/js/layout.js
+++ b/static/js/layout.js
@@ -490,15 +490,13 @@ function formatAriaEthereumDate(elem) {
   }
 
   var local = luxon.DateTime.fromMillis(dt * 1000)
-  var toolTipFormat = "yyyy-MM-dd HH:mm:ss"
-
   if (format === "FROMNOW") {
     $(elem).text(getRelativeTime(local))
-    $(elem).attr("data-original-title", local.toFormat(toolTipFormat))
+    $(elem).attr("data-original-title", formatTimestampsTooltip(local))
     $(elem).attr("data-toggle", "tooltip")
   } else if (format === "LOCAL") {
     $(elem).text(local.toFormat("MMM-dd-yyyy HH:mm:ss") + " UTC" + local.toFormat("Z"))
-    $(elem).attr("data-original-title", local.toFormat(toolTipFormat))
+    $(elem).attr("data-original-title", formatTimestampsTooltip(local))
     $(elem).attr("data-toggle", "tooltip")
   } else {
     $(elem).text(local.toFormat(format))
@@ -513,15 +511,21 @@ function formatTimestamps(selStr) {
   sel.find(".timestamp").each(function () {
     var ts = $(this).data("timestamp")
     var local = luxon.DateTime.fromMillis(ts * 1000)
-    var toolTipFormat = "yyyy-MM-dd HH:mm:ss"
 
     $(this).text(getRelativeTime(local))
-    $(this).attr("data-original-title", local.toFormat(toolTipFormat))
+    $(this).attr("data-original-title", formatTimestampsTooltip(local))
   })
 
   if (sel.find('[data-toggle="tooltip"]').tooltip) {
     sel.find('[data-toggle="tooltip"]').tooltip()
   }
+}
+
+function formatTimestampsTooltip(local) {
+  var toolTipFormat = "yyyy-MM-dd HH:mm:ss"
+  var tooltip = local.toFormat(toolTipFormat)
+
+  return tooltip
 }
 
 function getLuxonDateFromTimestamp(ts) {

--- a/static/js/notificationsCenter.js
+++ b/static/js/notificationsCenter.js
@@ -489,6 +489,7 @@ function loadValidatorsData(data) {
     fixedHeader: true,
     data: data,
     drawCallback: function (settings) {
+      formatTimestamps()
       $('[data-toggle="tooltip"]').tooltip()
 
       // click event to validators table edit button
@@ -651,7 +652,7 @@ function loadValidatorsData(data) {
                   .replace("validator", "")
                   .replaceAll("_", " ")
               : "N/A"
-          }</span><span class="heading-l4 d-block d-sm-inline-block mt-2 mt-sm-0">${getRelativeTime(luxon.DateTime.fromMillis(row.Notification[0].Timestamp * 1000)) || "N/A"}</span>`
+          }</span><span class="heading-l4 d-block d-sm-inline-block mt-2 mt-sm-0 timestamp" data-toggle="tooltip" data-placement="top" data-timestamp="${row.Notification[0].Timestamp}"></span>`
         },
       },
       {

--- a/templates/broadcaststatus.html
+++ b/templates/broadcaststatus.html
@@ -45,12 +45,12 @@
                     </div>
                     <div class="row flex-nowrap border-bottom p-3 mx-0">
                       <div class="col-md-4">Created time:</div>
-                      <div class="col-md-8">{{ .Job.CreatedTime | formatTime }}</div>
+                      <div class="col-md-8"><span aria-ethereum-date="{{ .Job.CreatedTime.Unix }}">{{ .Job.CreatedTime }}</span></div>
                     </div>
                     {{ if .Job.SubmittedToNodeTime.Valid }}
                       <div class="row flex-nowrap border-bottom p-3 mx-0">
                         <div class="col-md-4">Submitted to node time:</div>
-                        <div class="col-md-8">{{ .Job.SubmittedToNodeTime.Time | formatTime }}</div>
+                        <div class="col-md-8"><span aria-ethereum-date="{{ .Job.SubmittedToNodeTime.Time.Unix }}">{{ .Job.SubmittedToNodeTime.Time }}</span></div>
                       </div>
                     {{ end }}
                     <h4 class="h4 mt-2 pl-3 pt-3">Affected Validators:</h4>

--- a/templates/burn.html
+++ b/templates/burn.html
@@ -220,9 +220,6 @@
                 this.page = {{.}}
         },
         filters: {
-            fromNow(date) {
-                return getRelativeTime(luxon.DateTime.fromISO(date));
-            },
             toFixed(number, digits) {
                 return number.toFixed(digits)
             },
@@ -811,7 +808,7 @@
                   <td>${ block.gas_used }</td>
                   <td><span class="badge badge-pill text-white badge-success">${ block.mining_reward | formatETH(5)} ETH</span></td>
                   <td>${ block.tx_count }</td>
-                  <td>${ block.time | fromNow }</td>
+                  <td><span class="timestamp" data-toggle="tooltip" data-placement="top" data-timestamp="${block.time.Unix}"></span></td>
                   <td><span class="badge badge-pill text-white badge-info">${ block.base_fee_per_gas | formatGWei(2)} GWei</span></td>
                   <td><span class="badge badge-pill text-white badge-warning">${ block.burned_fees | formatETH(5)} ETH</span></td>
                 </tr>

--- a/templates/burn.html
+++ b/templates/burn.html
@@ -220,6 +220,12 @@
                 this.page = {{.}}
         },
         filters: {
+            fromNow(date) {
+                return getRelativeTime(luxon.DateTime.fromISO(date));
+            },
+            toTimestamp(date){
+                return new Date(date).getTime() / 1000
+            },
             toFixed(number, digits) {
                 return number.toFixed(digits)
             },
@@ -808,7 +814,7 @@
                   <td>${ block.gas_used }</td>
                   <td><span class="badge badge-pill text-white badge-success">${ block.mining_reward | formatETH(5)} ETH</span></td>
                   <td>${ block.tx_count }</td>
-                  <td><span class="timestamp" data-toggle="tooltip" data-placement="top" data-timestamp="${block.time.Unix}"></span></td>
+                  <td><span class="timestamp" data-toggle="tooltip" data-placement="top" v-bind:data-timestamp="block.time | toTimestamp"></span></td>
                   <td><span class="badge badge-pill text-white badge-info">${ block.base_fee_per_gas | formatGWei(2)} GWei</span></td>
                   <td><span class="badge badge-pill text-white badge-warning">${ block.burned_fees | formatETH(5)} ETH</span></td>
                 </tr>

--- a/templates/burn.html
+++ b/templates/burn.html
@@ -223,8 +223,8 @@
             fromNow(date) {
                 return getRelativeTime(luxon.DateTime.fromISO(date));
             },
-            toTimestamp(date){
-                return new Date(date).getTime() / 1000
+            timestampTooltip(date){
+                return formatTimestampsTooltip(luxon.DateTime.fromISO(date))
             },
             toFixed(number, digits) {
                 return number.toFixed(digits)
@@ -814,7 +814,7 @@
                   <td>${ block.gas_used }</td>
                   <td><span class="badge badge-pill text-white badge-success">${ block.mining_reward | formatETH(5)} ETH</span></td>
                   <td>${ block.tx_count }</td>
-                  <td><span class="timestamp" data-toggle="tooltip" data-placement="top" v-bind:data-timestamp="block.time | toTimestamp"></span></td>
+                  <td><span data-toggle="tooltip" data-placement="top" v-bind:data-original-title="block.time | timestampTooltip">${ block.time | fromNow }</span></td>
                   <td><span class="badge badge-pill text-white badge-info">${ block.base_fee_per_gas | formatGWei(2)} GWei</span></td>
                   <td><span class="badge badge-pill text-white badge-warning">${ block.burned_fees | formatETH(5)} ETH</span></td>
                 </tr>

--- a/templates/dashboard/tables.html
+++ b/templates/dashboard/tables.html
@@ -82,6 +82,9 @@
                 next: '<i class="fas fa-chevron-right"></i>',
               },
             },
+            drawCallback: function (settings) {
+              formatTimestamps()
+            },
           })
           initializedWithdrawalTable = true
         } else {

--- a/templates/eth1tx.html
+++ b/templates/eth1tx.html
@@ -119,7 +119,7 @@
               </div>
               <div class="row border-bottom p-3 mx-0" style="border-width:4px !important;">
                 <div class="col-md-3">Timestamp:</div>
-                <div class="col-md-9">{{ formatTimestampUInt64 .Timestamp }}</div>
+                <div class="col-md-9"><span aria-ethereum-date="{{ .Timestamp.Unix }}" aria-ethereum-date-format="FROMNOW">{{ .Timestamp }}</span></div>
               </div>
               <div class="row border-bottom p-3 mx-0">
                 <div class="col-md-3">From:</div>

--- a/templates/index/index.html
+++ b/templates/index/index.html
@@ -142,6 +142,9 @@
             filters: {
                 fromNow(date) {
                     return getRelativeTime(luxon.DateTime.fromISO(date));
+                },
+                toTimestamp(date){
+                    return new Date(date).getTime() / 1000
                 }
             },
             created: function () {

--- a/templates/index/index.html
+++ b/templates/index/index.html
@@ -143,8 +143,8 @@
                 fromNow(date) {
                     return getRelativeTime(luxon.DateTime.fromISO(date));
                 },
-                toTimestamp(date){
-                    return new Date(date).getTime() / 1000
+                timestampTooltip(date){
+                    return formatTimestampsTooltip(luxon.DateTime.fromISO(date))
                 }
             },
             created: function () {

--- a/templates/index/recentBlocks.html
+++ b/templates/index/recentBlocks.html
@@ -36,7 +36,7 @@
                 <span style="background: #e7e1d7" class="badge text-dark">Genesis</span>
               </td>
               <td v-else v-html="block.status_formatted"></td>
-              <td>${ block.ts | fromNow }</td>
+              <td>{ block.ts | formatTimestamp }</td>
               <td v-if="block.slot !== 0" v-html="block.proposer_formatted"></td>
               <td v-else>N/A</td>
               <!-- <td class="text-monospace">

--- a/templates/index/recentBlocks.html
+++ b/templates/index/recentBlocks.html
@@ -36,7 +36,7 @@
                 <span style="background: #e7e1d7" class="badge text-dark">Genesis</span>
               </td>
               <td v-else v-html="block.status_formatted"></td>
-              <td><span class="timestamp" data-toggle="tooltip" data-placement="top" v-bind:data-timestamp="block.ts | toTimestamp"></span></td>
+              <td><span data-toggle="tooltip" data-placement="top" v-bind:data-original-title="block.ts | timestampTooltip">${block.ts | fromNow}</span></td>
               <td v-if="block.slot !== 0" v-html="block.proposer_formatted"></td>
               <td v-else>N/A</td>
               <!-- <td class="text-monospace">

--- a/templates/index/recentBlocks.html
+++ b/templates/index/recentBlocks.html
@@ -36,7 +36,7 @@
                 <span style="background: #e7e1d7" class="badge text-dark">Genesis</span>
               </td>
               <td v-else v-html="block.status_formatted"></td>
-              <td>{ block.ts | formatTimestamp }</td>
+              <td><span class="timestamp" data-toggle="tooltip" data-placement="top" v-bind:data-timestamp="block.ts | toTimestamp"></span></td>
               <td v-if="block.slot !== 0" v-html="block.proposer_formatted"></td>
               <td v-else>N/A</td>
               <!-- <td class="text-monospace">

--- a/templates/index/recentEpochs.html
+++ b/templates/index/recentEpochs.html
@@ -21,7 +21,7 @@
           <tbody v-if="page && page.epochs && page.epochs.length">
             <tr v-for="epoch in page.epochs">
               <td><a v-bind:href="'/epoch/' + epoch.epoch" v-html="addCommas(epoch.epoch)"></a></td>
-              <td>${ epoch.ts | fromNow }</td>
+              <td><span class="timestamp" data-toggle="tooltip" data-placement="top" data-timestamp="${epoch.ts.Unix}"></span></td>
               <td v-html="epoch.finalized_formatted"></td>
               <td v-html="epoch.eligibleether_formatted"></td>
               <td v-html="epoch.globalparticipationrate_formatted"></td>

--- a/templates/index/recentEpochs.html
+++ b/templates/index/recentEpochs.html
@@ -21,7 +21,7 @@
           <tbody v-if="page && page.epochs && page.epochs.length">
             <tr v-for="epoch in page.epochs">
               <td><a v-bind:href="'/epoch/' + epoch.epoch" v-html="addCommas(epoch.epoch)"></a></td>
-              <td><span class="timestamp" data-toggle="tooltip" data-placement="top" data-timestamp="${epoch.ts.Unix}"></span></td>
+              <td><span class="timestamp" data-toggle="tooltip" data-placement="top" v-bind:data-timestamp="epoch.ts | toTimestamp"></span></td>
               <td v-html="epoch.finalized_formatted"></td>
               <td v-html="epoch.eligibleether_formatted"></td>
               <td v-html="epoch.globalparticipationrate_formatted"></td>

--- a/templates/index/recentEpochs.html
+++ b/templates/index/recentEpochs.html
@@ -21,7 +21,7 @@
           <tbody v-if="page && page.epochs && page.epochs.length">
             <tr v-for="epoch in page.epochs">
               <td><a v-bind:href="'/epoch/' + epoch.epoch" v-html="addCommas(epoch.epoch)"></a></td>
-              <td><span class="timestamp" data-toggle="tooltip" data-placement="top" v-bind:data-timestamp="epoch.ts | toTimestamp"></span></td>
+              <td><span data-toggle="tooltip" data-placement="top" v-bind:data-original-title="epoch.ts | timestampTooltip">${epoch.ts | fromNow}</span></td>
               <td v-html="epoch.finalized_formatted"></td>
               <td v-html="epoch.eligibleether_formatted"></td>
               <td v-html="epoch.globalparticipationrate_formatted"></td>

--- a/templates/pools_rocketpool.html
+++ b/templates/pools_rocketpool.html
@@ -236,13 +236,13 @@
         {
           targets: 3,
           render: function (data, type, row, meta) {
-            return `<span style="font-size: .9rem; font-weight: 400;">${getRelativeTime(luxon.DateTime.fromMillis(parseInt($(data).attr("data-timestamp")) * 1000))}</span>`
+            return `${data}`
           },
         },
         {
           targets: 4,
           render: function (data, type, row, meta) {
-            return `<span style="font-size: .9rem; font-weight: 400;">${getRelativeTime(luxon.DateTime.fromMillis(parseInt($(data).attr("data-timestamp")) * 1000))}</span>`
+            return `${data}`
           },
         },
         {

--- a/templates/relays.html
+++ b/templates/relays.html
@@ -204,7 +204,7 @@
           </div>
         </div>
       </div>
-      <div>Last updated: {{ formatTime .Data.LastUpdated }}</div>
+      <div>Last updated: <span aria-ethereum-date="{{ .Data.LastUpdated.Unix }}">{{ .Data.LastUpdated }}</span></div>
     </div>
   </section>
   <div id="tempcont" class=""></div>

--- a/templates/user/settings.html
+++ b/templates/user/settings.html
@@ -750,8 +750,7 @@
                               Grant account access (required)
                             </span>
                             <br /><br />
-                            <span>Paired:</span><i> {{ formatTimestamp $value.CreatedAt }}</i>
-
+                            <span>Paired:</span><i> {{ formatTimestamp $value.CreatedAt.Unix }}</i>
                             {{ if lt $key $lastPairedElement }}
                               <hr style="width: 98%; margin-top:28px;margin-bottom:28px;" />
                             {{ end }}

--- a/templates/user/settings.html
+++ b/templates/user/settings.html
@@ -750,7 +750,7 @@
                               Grant account access (required)
                             </span>
                             <br /><br />
-                            <span>Paired:</span><i> {{ formatTimestampTs $value.CreatedAt }}</i>
+                            <span>Paired:</span><i> {{ formatTimestamp $value.CreatedAt }}</i>
 
                             {{ if lt $key $lastPairedElement }}
                               <hr style="width: 98%; margin-top:28px;margin-bottom:28px;" />

--- a/templates/validator/tables.html
+++ b/templates/validator/tables.html
@@ -201,7 +201,7 @@
                     columnDefs: [
                     ],
                     drawCallback: function(settings) {
-                        // formatTimestamps()
+                         formatTimestamps()
                     },
                 })
             }

--- a/templates/validators.html
+++ b/templates/validators.html
@@ -188,7 +188,7 @@
                             // 9223372036854775808 gets rounded up as it is above the Number.MAX_SAFE_INTEGER value
                             if (data === null || data[0] === 9223372036854776000)
                                 return '-';
-                            return `<span data-toggle="tooltip" data-placement="top" title="${luxon.DateTime.fromMillis(data[1] * 1000).toFormat('ff')}">${getRelativeTime(luxon.DateTime.fromMillis(data[1] * 1000))} (<a href="/epoch/${data[0]}">Epoch ${addCommas(data[0])}</a>)</span>`
+                            return `<span data-toggle="tooltip" data-placement="top" title="${luxon.DateTime.fromMillis(data[1] * 1000).toFormat('yyyy-MM-dd HH:mm:ss')}">${getRelativeTime(luxon.DateTime.fromMillis(data[1] * 1000))} (<a href="/epoch/${data[0]}">Epoch ${addCommas(data[0])}</a>)</span>`
                         }
                     },
                     {
@@ -197,7 +197,7 @@
                         render: function(data, type, row, meta) {
                             if (data === null)
                                 return '-';
-                            return `<span data-toggle="tooltip" data-placement="top" title="${luxon.DateTime.fromMillis(data[1] * 1000).toFormat('ff')}">${getRelativeTime(luxon.DateTime.fromMillis(data[1] * 1000))} (<a href="/epoch/${data[0]}">Epoch ${addCommas(data[0])}</a>)</span>`
+                            return `<span data-toggle="tooltip" data-placement="top" title="${luxon.DateTime.fromMillis(data[1] * 1000).toFormat('yyyy-MM-dd HH:mm:ss')}">${getRelativeTime(luxon.DateTime.fromMillis(data[1] * 1000))} (<a href="/epoch/${data[0]}">Epoch ${addCommas(data[0])}</a>)</span>`
                         }
                     },
                     {
@@ -206,7 +206,7 @@
                         render: function(data, type, row, meta) {
                             if (data === null)
                                 return '-';
-                            return `<span data-toggle="tooltip" data-placement="top" title="${luxon.DateTime.fromMillis(data[1] * 1000).toFormat('ff')}">${getRelativeTime(luxon.DateTime.fromMillis(data[1] * 1000))} (<a href="/epoch/${data[0]}">Epoch ${addCommas(data[0])}</a>)</span>`
+                            return `<span data-toggle="tooltip" data-placement="top" title="${luxon.DateTime.fromMillis(data[1] * 1000).toFormat('yyyy-MM-dd HH:mm:ss')}">${getRelativeTime(luxon.DateTime.fromMillis(data[1] * 1000))} (<a href="/epoch/${data[0]}">Epoch ${addCommas(data[0])}</a>)</span>`
                         }
                     },
                     {
@@ -215,7 +215,7 @@
                         render: function(data, type, row, meta) {
                             if (data === null)
                                 return 'No Attestation found';
-                            return `<span data-toggle="tooltip" data-placement="top" title="${luxon.DateTime.fromMillis(data[1] * 1000).toFormat('ff')}">${getRelativeTime(luxon.DateTime.fromMillis(data[1] * 1000))} (<a href="/slot/${data[0]}">Block ${addCommas(data[0])}</a>)</span>`
+                            return `<span data-toggle="tooltip" data-placement="top" title="${luxon.DateTime.fromMillis(data[1] * 1000).toFormat('yyyy-MM-dd HH:mm:ss')}">${getRelativeTime(luxon.DateTime.fromMillis(data[1] * 1000))} (<a href="/slot/${data[0]}">Block ${addCommas(data[0])}</a>)</span>`
                         }
                     },
                     {

--- a/templates/validators.html
+++ b/templates/validators.html
@@ -132,6 +132,7 @@
                     }
                 },
                 drawCallback: function() {
+                    formatTimestamps()
                     $('#validators').find('[data-toggle="tooltip"]').tooltip();
                     validatorsDataTable.columns.adjust().responsive.recalc()
                 },
@@ -188,7 +189,7 @@
                             // 9223372036854775808 gets rounded up as it is above the Number.MAX_SAFE_INTEGER value
                             if (data === null || data[0] === 9223372036854776000)
                                 return '-';
-                            return `<span data-toggle="tooltip" data-placement="top" title="${luxon.DateTime.fromMillis(data[1] * 1000).toFormat('yyyy-MM-dd HH:mm:ss')}">${getRelativeTime(luxon.DateTime.fromMillis(data[1] * 1000))} (<a href="/epoch/${data[0]}">Epoch ${addCommas(data[0])}</a>)</span>`
+                            return `<span><span class="timestamp" data-toggle="tooltip" data-placement="top" data-timestamp="${data[1]}"></span> (<a href="/epoch/${data[0]}">Epoch ${addCommas(data[0])}</a>)</span>`
                         }
                     },
                     {
@@ -197,7 +198,7 @@
                         render: function(data, type, row, meta) {
                             if (data === null)
                                 return '-';
-                            return `<span data-toggle="tooltip" data-placement="top" title="${luxon.DateTime.fromMillis(data[1] * 1000).toFormat('yyyy-MM-dd HH:mm:ss')}">${getRelativeTime(luxon.DateTime.fromMillis(data[1] * 1000))} (<a href="/epoch/${data[0]}">Epoch ${addCommas(data[0])}</a>)</span>`
+                            return `<span><span class="timestamp" data-toggle="tooltip" data-placement="top" data-timestamp="${data[1]}"></span> (<a href="/epoch/${data[0]}">Epoch ${addCommas(data[0])}</a>)</span>`
                         }
                     },
                     {
@@ -206,7 +207,7 @@
                         render: function(data, type, row, meta) {
                             if (data === null)
                                 return '-';
-                            return `<span data-toggle="tooltip" data-placement="top" title="${luxon.DateTime.fromMillis(data[1] * 1000).toFormat('yyyy-MM-dd HH:mm:ss')}">${getRelativeTime(luxon.DateTime.fromMillis(data[1] * 1000))} (<a href="/epoch/${data[0]}">Epoch ${addCommas(data[0])}</a>)</span>`
+                            return `<span><span class="timestamp" data-toggle="tooltip" data-placement="top" data-timestamp="${data[1]}"></span> (<a href="/epoch/${data[0]}">Epoch ${addCommas(data[0])}</a>)</span>`
                         }
                     },
                     {
@@ -215,7 +216,7 @@
                         render: function(data, type, row, meta) {
                             if (data === null)
                                 return 'No Attestation found';
-                            return `<span data-toggle="tooltip" data-placement="top" title="${luxon.DateTime.fromMillis(data[1] * 1000).toFormat('yyyy-MM-dd HH:mm:ss')}">${getRelativeTime(luxon.DateTime.fromMillis(data[1] * 1000))} (<a href="/slot/${data[0]}">Block ${addCommas(data[0])}</a>)</span>`
+                            return `<span><span class="timestamp" data-toggle="tooltip" data-placement="top" data-timestamp="${data[1]}"></span> (<a href="/slot/${data[0]}">Block ${addCommas(data[0])}</a>)</span>`
                         }
                     },
                     {

--- a/types/templates.go
+++ b/types/templates.go
@@ -1680,7 +1680,7 @@ type Eth1TxData struct {
 	Receipt                     *geth_types.Receipt
 	ErrorMsg                    string
 	BlockNumber                 int64
-	Timestamp                   uint64
+	Timestamp                   time.Time
 	IsPending                   bool
 	TargetIsContract            bool
 	IsContractCreation          bool

--- a/utils/eth1.go
+++ b/utils/eth1.go
@@ -9,7 +9,6 @@ import (
 	"html/template"
 	"math/big"
 	"strings"
-	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -406,14 +405,6 @@ func FormatDifficulty(number *big.Int) string {
 	f.Quo(f, big.NewFloat(1e12))
 	r, _ := f.Float64()
 	return fmt.Sprintf("%.1f T", r)
-}
-
-func FormatTime(t time.Time) template.HTML {
-	return template.HTML(fmt.Sprintf("<span aria-ethereum-date=\"%v\">%v</span>", t.Unix(), t))
-}
-
-func FormatTimeFromNow(t time.Time) template.HTML {
-	return template.HTML(HumanizeTime(t))
 }
 
 func FormatHashrate(h float64) template.HTML {

--- a/utils/format.go
+++ b/utils/format.go
@@ -803,17 +803,12 @@ func FormatMachineName(machineName string) template.HTML {
 
 // FormatTimestamp will return a timestamp formated as html. This is supposed to be used together with client-side js
 func FormatTimestamp(ts int64) template.HTML {
-	return template.HTML(fmt.Sprintf("<span class=\"timestamp\" title=\"%v\" data-toggle=\"tooltip\" data-placement=\"top\" data-timestamp=\"%d\"></span>", time.Unix(ts, 0), ts))
+	return template.HTML(fmt.Sprintf("<span class=\"timestamp\" title=\"%v\" data-toggle=\"tooltip\" data-placement=\"top\" data-timestamp=\"%d\"></span>", time.Unix(ts, 0).Format("2006-01-02 15:04:05"), ts))
 }
 
-// FormatTs will return a timestamp formated as html. This is supposed to be used together with client-side js
+// FormatTsWithoutTooltip will return a timestamp formated as html. This is supposed to be used together with client-side js
 func FormatTsWithoutTooltip(ts int64) template.HTML {
 	return template.HTML(fmt.Sprintf("<span class=\"timestamp\" data-timestamp=\"%d\"></span>", ts))
-}
-
-// FormatTimestamp will return a timestamp formated as html. This is supposed to be used together with client-side js
-func FormatTimestampTs(ts time.Time) template.HTML {
-	return template.HTML(fmt.Sprintf("<span class=\"timestamp\" title=\"%v\" data-timestamp=\"%d\"></span>", ts, ts.Unix()))
 }
 
 // FormatValidatorStatus will return the validator-status formated as html
@@ -1228,11 +1223,6 @@ func FormatEth1TxStatus(status uint64) template.HTML {
 	} else {
 		return template.HTML("<h5 class=\"m-0\"><span class=\"badge badge-danger badge-pill align-middle text-white\"><i class=\"fas fa-times-circle\"></i> Failed</span></h5>")
 	}
-}
-
-// FormatTimestamp will return a timestamp formated as html. This is supposed to be used together with client-side js
-func FormatTimestampUInt64(ts uint64) template.HTML {
-	return template.HTML(fmt.Sprintf("<span class=\"timestamp\" title=\"%v\" data-toggle=\"tooltip\" data-placement=\"top\" data-timestamp=\"%d\"></span>", time.Unix(int64(ts), 0), ts))
 }
 
 // FormatEth1AddressFull will return the eth1-address formated as html

--- a/utils/format.go
+++ b/utils/format.go
@@ -15,7 +15,6 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/prysmaticlabs/go-bitfield"
 	"github.com/shopspring/decimal"
@@ -803,7 +802,7 @@ func FormatMachineName(machineName string) template.HTML {
 
 // FormatTimestamp will return a timestamp formated as html. This is supposed to be used together with client-side js
 func FormatTimestamp(ts int64) template.HTML {
-	return template.HTML(fmt.Sprintf("<span class=\"timestamp\" title=\"%v\" data-toggle=\"tooltip\" data-placement=\"top\" data-timestamp=\"%d\"></span>", time.Unix(ts, 0).Format("2006-01-02 15:04:05"), ts))
+	return template.HTML(fmt.Sprintf("<span class=\"timestamp\" data-toggle=\"tooltip\" data-placement=\"top\" data-timestamp=\"%d\"></span>", ts))
 }
 
 // FormatTsWithoutTooltip will return a timestamp formated as html. This is supposed to be used together with client-side js

--- a/utils/humanize.go
+++ b/utils/humanize.go
@@ -1,7 +1,6 @@
 package utils
 
 import (
-	"fmt"
 	"time"
 )
 
@@ -13,78 +12,3 @@ const (
 	Year     = 12 * Month
 	LongTime = 37 * Year
 )
-
-// Time formats a time into a relative string.
-//
-// Time(someT) -> "3 weeks ago"
-func HumanizeTime(then time.Time) string {
-
-	duration := time.Since(then).Milliseconds()
-	var prefix string
-	var suffix string
-
-	if duration < 0 {
-		duration = duration * -1
-		prefix = "in "
-	} else {
-		suffix = " ago"
-	}
-
-	secondsPart := int64(0)
-	minutesPart := int64(0)
-	hoursPart := int64(0)
-	daysPart := int64(0)
-
-	parts := make([]string, 0, 4)
-	daysPart = duration / 1000 / 60 / 60 / 24
-	if daysPart > 0 {
-		sDays := "s"
-		if daysPart == 1 {
-			sDays = ""
-		}
-		parts = append(parts, fmt.Sprintf("%d day%s", daysPart, sDays))
-	}
-
-	duration = duration - daysPart*1000*60*60*24
-
-	hoursPart = duration / 1000 / 60 / 60
-	if hoursPart > 0 {
-		sHours := "s"
-		if hoursPart == 1 {
-			sHours = ""
-		}
-		parts = append(parts, fmt.Sprintf("%d hr%s", hoursPart, sHours))
-	}
-
-	duration = duration - hoursPart*1000*60*60
-
-	minutesPart = duration / 1000 / 60
-	if minutesPart > 0 {
-		sMinutes := "s"
-		if minutesPart == 1 {
-			sMinutes = ""
-		}
-		parts = append(parts, fmt.Sprintf("%d min%s", minutesPart, sMinutes))
-	}
-
-	duration = duration - minutesPart*1000*60
-
-	secondsPart = duration / 1000
-	if secondsPart > 0 && len(parts) == 0 {
-		sSeconds := "s"
-		if secondsPart == 1 {
-			sSeconds = ""
-		}
-		parts = append(parts, fmt.Sprintf("%d sec%s", secondsPart, sSeconds))
-	}
-
-	if len(parts) == 1 {
-		return fmt.Sprintf("%s%s%s", prefix, parts[0], suffix)
-	} else if len(parts) > 1 {
-		return fmt.Sprintf("%s%s %s%s", prefix, parts[0], parts[1], suffix)
-	}
-
-	logger.Errorf("error formatting time %v", time.Since(then))
-	return fmt.Sprintf("%s%s%s", prefix, time.Since(then), suffix)
-
-}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -121,7 +121,6 @@ func GetTemplateFuncs() template.FuncMap {
 		"formatSlashedValidatorInt64":             FormatSlashedValidatorInt64,
 		"formatTimestamp":                         FormatTimestamp,
 		"formatTsWithoutTooltip":                  FormatTsWithoutTooltip,
-		"formatTime":                              FormatTime,
 		"formatValidatorName":                     FormatValidatorName,
 		"formatAttestationInclusionEffectiveness": FormatAttestationInclusionEffectiveness,
 		"formatValidatorTags":                     FormatValidatorTags,

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -121,7 +121,6 @@ func GetTemplateFuncs() template.FuncMap {
 		"formatSlashedValidatorInt64":             FormatSlashedValidatorInt64,
 		"formatTimestamp":                         FormatTimestamp,
 		"formatTsWithoutTooltip":                  FormatTsWithoutTooltip,
-		"formatTimestampTs":                       FormatTimestampTs,
 		"formatTime":                              FormatTime,
 		"formatValidatorName":                     FormatValidatorName,
 		"formatAttestationInclusionEffectiveness": FormatAttestationInclusionEffectiveness,
@@ -215,7 +214,6 @@ func GetTemplateFuncs() template.FuncMap {
 		},
 		// ETH1 related formatting
 		"formatEth1TxStatus":    FormatEth1TxStatus,
-		"formatTimestampUInt64": FormatTimestampUInt64,
 		"formatEth1AddressFull": FormatEth1AddressFull,
 		"byteToString": func(num []byte) string {
 			return string(num)


### PR DESCRIPTION
Please see the comments of the BIDS for a summary of all the relevant pages.

It is of course possible that I missed some page or specific view, maybe you can think of others that view a time.
I could not find any other than the index and ethClients pages that automatically update their time every second but it should be checked that that part also still works for everything.

I could not test the /user/settings#app page which requires paired devices.