### PR TITLE
(NOBIDS) Switch deprecated Eth1DepositContractAddress to DepositContr…

### DIFF
--- a/config-example.yml
+++ b/config-example.yml
@@ -55,5 +55,4 @@ indexer:
     type: "prysm" # can be either prysm or lighthouse
     pageSize: 500 # the amount of entries to fetch per paged rpc call
   eth1Endpoint: "https://goerli.infura.io/v3/<api-token>"
-  eth1DepositContractAddress: "0x5cA1e00004366Ac85f492887AAab12d0e6418876"
   eth1DepositContractFirstBlock: 2523557

--- a/config.yaml
+++ b/config.yaml
@@ -42,6 +42,5 @@ indexer:
     type: "lighthouse" # can be either prysm or lighthouse
     pageSize: 100 # the amount of entries to fetch per paged rpc call, TODO set to 500
   eth1Endpoint: 'http://localhost:8545'
-  eth1DepositContractAddress: '0x4242424242424242424242424242424242424242'
   # Note: 0 is correct, but due to an underflow bug (being fixed), doesn't work.
   eth1DepositContractFirstBlock: 1

--- a/config/default.config.yml
+++ b/config/default.config.yml
@@ -61,5 +61,4 @@ indexer:
     type: "prysm" # can be either prysm or lighthouse
     pageSize: 500 # the amount of entries to fetch per paged rpc call
   eth1Endpoint: 'https://goerli.infura.io/v3/<api-token>'
-  eth1DepositContractAddress: '0x5cA1e00004366Ac85f492887AAab12d0e6418876'
   eth1DepositContractFirstBlock: 2523557

--- a/handlers/eth1Deposits.go
+++ b/handlers/eth1Deposits.go
@@ -152,7 +152,7 @@ func Eth1DepositsLeaderboard(w http.ResponseWriter, r *http.Request) {
 	data := InitPageData(w, r, "eth1Deposits", "/deposits/eth1", "Initiated Deposits", templateFiles)
 
 	data.Data = types.EthOneDepositLeaderBoardPageData{
-		DepositContract: utils.Config.Indexer.Eth1DepositContractAddress,
+		DepositContract: utils.Config.Chain.Config.DepositContractAddress,
 	}
 
 	if handleTemplateError(w, r, "eth1Deposits.go", "Eth1DepositsLeaderboard", "", eth1DepositsLeaderboardTemplate.ExecuteTemplate(w, "layout", data)) != nil {

--- a/handlers/pageData.go
+++ b/handlers/pageData.go
@@ -78,7 +78,7 @@ func InitPageData(w http.ResponseWriter, r *http.Request, active, path, title st
 			CurrentSymbol:          GetCurrencySymbol(r),
 		},
 		Mainnet:             utils.Config.Chain.Config.ConfigName == "mainnet",
-		DepositContract:     utils.Config.Indexer.Eth1DepositContractAddress,
+		DepositContract:     utils.Config.Chain.Config.DepositContractAddress,
 		ClientsUpdated:      ethclients.ClientsUpdated(),
 		ChainConfig:         utils.Config.Chain.Config,
 		Lang:                "en-US",

--- a/services/services.go
+++ b/services/services.go
@@ -626,7 +626,7 @@ func getIndexPageData() (*types.IndexPageData, error) {
 	data := &types.IndexPageData{}
 	data.Mainnet = utils.Config.Chain.Config.ConfigName == "mainnet"
 	data.NetworkName = utils.Config.Chain.Config.ConfigName
-	data.DepositContract = utils.Config.Indexer.Eth1DepositContractAddress
+	data.DepositContract = utils.Config.Chain.Config.DepositContractAddress
 
 	var epoch uint64
 	err := db.ReaderDb.Get(&epoch, "SELECT COALESCE(MAX(epoch), 0) FROM epochs")

--- a/types/config.go
+++ b/types/config.go
@@ -55,8 +55,6 @@ type Config struct {
 			Type     string `yaml:"type" envconfig:"INDEXER_NODE_TYPE"`
 			PageSize int32  `yaml:"pageSize" envconfig:"INDEXER_NODE_PAGE_SIZE"`
 		} `yaml:"node"`
-		// Deprecated Please use Phase0 config DEPOSIT_CONTRACT_ADDRESS
-		Eth1DepositContractAddress    string `yaml:"eth1DepositContractAddress" envconfig:"INDEXER_ETH1_DEPOSIT_CONTRACT_ADDRESS"`
 		Eth1DepositContractFirstBlock uint64 `yaml:"eth1DepositContractFirstBlock" envconfig:"INDEXER_ETH1_DEPOSIT_CONTRACT_FIRST_BLOCK"`
 		OneTimeExport                 struct {
 			Enabled    bool     `yaml:"enabled" envconfig:"INDEXER_ONETIMEEXPORT_ENABLED"`


### PR DESCRIPTION
…actAddress in Chain config

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 772a333</samp>

Removed the `Indexer.DepositContractAddress` field from the indexer config files and the `Config` type, and replaced its usage with the `ChainConfig.DepositContractAddress` field from the chain config. This avoids using a deprecated and potentially incorrect value for the deposit contract address across the application.
