### PR TITLE
(NOBIDS) Adding docker build for new frontend

### DIFF
--- a/.github/workflows/publish-newfrontend-images.yml
+++ b/.github/workflows/publish-newfrontend-images.yml
@@ -1,0 +1,21 @@
+name: Publish Docker newfrontend images
+
+on:
+  # Trigger the workflow on push or pull request,
+  # but only for the newfrontend branch
+  push:
+    branches:
+      - newfrontend
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Publish to Dockerhub Registry
+        uses: elgohr/Publish-Docker-Github-Action@master
+        with:
+          name: gobitfly/eth2-beaconchain-explorer
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          tags: "newfrontend"


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d920540</samp>

Added a new workflow file to build and publish a Docker image of the new frontend version of the eth2-beaconchain-explorer application to the Dockerhub Registry. This change enables automated deployment of the redesigned user interface.
