### PR TITLE
(BIDS-1981) Add quotation marks around monitoring URL

### DIFF
--- a/templates/user/settings.html
+++ b/templates/user/settings.html
@@ -20,7 +20,7 @@
         },
         {
             id: 'lighthouse-graffiti',
-            config: "--monitoring-endpoint https://beaconcha.in/api/v1/client/metrics?apikey={apiKey}{machineName}"
+            config: "--monitoring-endpoint 'https://beaconcha.in/api/v1/client/metrics?apikey={apiKey}{machineName}'"
         },
         {
             id: 'nimbus-graffiti',
@@ -28,7 +28,7 @@
         },
         {
             id: 'teku-graffiti',
-            config: "--metrics-publish-endpoint https://beaconcha.in/api/v1/client/metrics?apikey={apiKey}{machineName}"
+            config: "--metrics-publish-endpoint 'https://beaconcha.in/api/v1/client/metrics?apikey={apiKey}{machineName}'"
         },
         {
             id: 'lodestar-graffiti',


### PR DESCRIPTION
The monitoring endpoint URL should be in quotation marks because some terminals might cut off after the special characters "&" or "?".