### PR TITLE
(BIDS-2016) search redirect to deposits with address

### DIFF
--- a/static/js/layout.js
+++ b/static/js/layout.js
@@ -410,7 +410,7 @@ $(document).ready(function () {
     } else if (sug.address !== undefined) {
       window.location = "/address/" + sug.address
     } else if (sug.eth1_address !== undefined) {
-      window.location = "/validators/initiated-deposits?q=" + sug.eth1_address
+      window.location = "/validators/deposits?q=" + sug.eth1_address
     } else if (sug.graffiti !== undefined) {
       // sug.graffiti is html-escaped to prevent xss, we need to unescape it
       var el = document.createElement("textarea")


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5c86fa4</samp>

Updated the frontend search URL for validators by eth1 address to use the new `/validators/deposits` endpoint. This fixes the search functionality that was broken by the API changes.
