### PR TITLE
Update Lodestar monitoring cmd

### DIFF
--- a/templates/user/settings.html
+++ b/templates/user/settings.html
@@ -32,7 +32,7 @@
         },
         {
             id: 'lodestar-graffiti',
-            config: "--monitoring.endpoint 'https://beaconcha.in/api/v1/client/metrics?apikey={apiKey}{machineName}' --metrics"
+            config: "--monitoring.endpoint 'https://beaconcha.in/api/v1/client/metrics?apikey={apiKey}{machineName}'"
         }
     ]
 
@@ -636,7 +636,7 @@
                           </h2>
                           <div id="collapseLodestar" class="collapse" aria-labelledby="headingLodestar" data-parent="#accordionExample" style="margin: 15px;">
                             <div class="accordion-body">
-                              Copy & Paste the following flags to your Lodestar validator <strong>and</strong> beaconnode:<br /><br />
+                              Copy & Paste the following flag to your Lodestar validator <strong>and</strong> beaconnode:<br /><br />
 
                               <div style="margin-left: 5px; margin-right: 5px;">
                                 <div style="float: left;  width: 90%;">


### PR DESCRIPTION
`--metrics` flag is no longer required as of v1.8.0, we now implicitly enable metrics

- https://github.com/ChainSafe/lodestar/pull/5328