### PR TITLE
(BIDS-1303) get validator history prices with timezone buff

### DIFF
--- a/services/rewards.go
+++ b/services/rewards.go
@@ -27,7 +27,7 @@ func GetValidatorHist(validatorArr []uint64, currency string, start uint64, end 
 	var err error
 
 	var pricesDb []types.Price
-	// we get prices with a 1day buffer to so we have no problems in for different time zones
+	// we get prices with a 1 day buffer to so we have no problems in different time zones
 	var oneDay = 24 * 60 * 60
 	err = db.WriterDb.Select(&pricesDb,
 		`select ts, eur, usd, gbp, cad, jpy, cny, rub, aud from price where ts >= TO_TIMESTAMP($1) and ts <= TO_TIMESTAMP($2) order by ts desc`, start-uint64(oneDay), end+uint64(oneDay))

--- a/services/rewards.go
+++ b/services/rewards.go
@@ -27,8 +27,10 @@ func GetValidatorHist(validatorArr []uint64, currency string, start uint64, end 
 	var err error
 
 	var pricesDb []types.Price
+	// we get prices with a 1day buffer to so we have no problems in for different time zones
+	var oneDay = 24 * 60 * 60
 	err = db.WriterDb.Select(&pricesDb,
-		`select ts, eur, usd, gbp, cad, jpy, cny, rub, aud from price where ts >= TO_TIMESTAMP($1) and ts <= TO_TIMESTAMP($2) order by ts desc`, start, end)
+		`select ts, eur, usd, gbp, cad, jpy, cny, rub, aud from price where ts >= TO_TIMESTAMP($1) and ts <= TO_TIMESTAMP($2) order by ts desc`, start-uint64(oneDay), end+uint64(oneDay))
 	if err != nil {
 		logger.Errorf("error getting prices: %v", err)
 	}


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a54973d</samp>

Adjusted the query for fetching prices in `services/rewards.go` to account for time zone differences. Added a one-day buffer to the start and end timestamps of the rewards period.
