### PR TITLE
(BIDS-1944) return the Signature in Deposits page as hex

### DIFF
--- a/handlers/api.go
+++ b/handlers/api.go
@@ -600,7 +600,7 @@ func ApiSlotDeposits(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	rows, err := db.ReaderDb.Query("SELECT amount, block_index, block_root, block_slot, proof, publickey, ENCODE(signature, 'hex') AS signature, withdrawalcredentials FROM blocks_deposits WHERE block_slot = $1 ORDER BY block_index DESC limit $2 offset $3", slot, limit, offset)
+	rows, err := db.ReaderDb.Query("SELECT amount, block_index, block_root, block_slot, proof, publickey, signature, withdrawalcredentials FROM blocks_deposits WHERE block_slot = $1 ORDER BY block_index DESC limit $2 offset $3", slot, limit, offset)
 	if err != nil {
 		logger.WithError(err).Error("could not retrieve db results")
 		sendErrorResponse(w, r.URL.String(), "could not retrieve db results")

--- a/handlers/api.go
+++ b/handlers/api.go
@@ -600,7 +600,7 @@ func ApiSlotDeposits(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	rows, err := db.ReaderDb.Query("SELECT amount, block_index, block_root, block_slot, proof, publickey, signature, withdrawalcredentials FROM blocks_deposits WHERE block_slot = $1 ORDER BY block_index DESC limit $2 offset $3", slot, limit, offset)
+	rows, err := db.ReaderDb.Query("SELECT amount, block_index, block_root, block_slot, proof, publickey, ENCODE(signature, 'hex') AS signature, withdrawalcredentials FROM blocks_deposits WHERE block_slot = $1 ORDER BY block_index DESC limit $2 offset $3", slot, limit, offset)
 	if err != nil {
 		logger.WithError(err).Error("could not retrieve db results")
 		sendErrorResponse(w, r.URL.String(), "could not retrieve db results")

--- a/handlers/slot.go
+++ b/handlers/slot.go
@@ -511,7 +511,7 @@ func SlotDepositData(w http.ResponseWriter, r *http.Request) {
 			utils.FormatPublicKey(deposit.PublicKey),
 			utils.FormatBalance(deposit.Amount, currency),
 			utils.FormatWithdawalCredentials(deposit.WithdrawalCredentials, true),
-			deposit.Signature,
+			fmt.Sprintf("0x%v", hex.EncodeToString(deposit.Signature)),
 		})
 	}
 

--- a/handlers/slot.go
+++ b/handlers/slot.go
@@ -512,6 +512,7 @@ func SlotDepositData(w http.ResponseWriter, r *http.Request) {
 			utils.FormatBalance(deposit.Amount, currency),
 			utils.FormatWithdawalCredentials(deposit.WithdrawalCredentials, true),
 			fmt.Sprintf("0x%v", hex.EncodeToString(deposit.Signature)),
+			utils.FormatHash(deposit.Signature, true),
 		})
 	}
 

--- a/templates/slot/slot.html
+++ b/templates/slot/slot.html
@@ -174,7 +174,7 @@
           {
             targets: 4,
             render: function (data, type, row) {
-              return `<div class="d-flex"><div data-toggle="tooltip" title="${data}" style="max-width: 130px;" class="text-truncate">${data}</div><i class="fa fa-copy text-muted p-1" role="button" data-toggle="tooltip" title="Copy to clipboard" data-clipboard-text="${data}"></i></div>`
+              return `<div class="d-flex"><div data-toggle="tooltip" title="${row[4]}" style="max-width: 130px;" class="text-truncate">${row[5]}</div><i class="fa fa-copy text-muted p-1" role="button" data-toggle="tooltip" title="Copy to clipboard" data-clipboard-text="${row[4]}"></i></div>`
             },
           },
         ],


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a6fdef4</samp>

Encode deposit signatures as hex in the API response. This improves the consistency and compatibility of the explorer's API with the Eth2.0 API standard.
