### PR TITLE
(BIDS-2020) Fix graffitiwall on conflict save

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -905,14 +905,18 @@ func saveGraffitiwall(blocks map[uint64]map[string]*types.Block, tx *sqlx.Tx) er
 
 	stmtGraffitiwall, err := tx.Prepare(`
 		INSERT INTO graffitiwall (
-			x,
-			y,
-			color,
-			slot,
-			validator
-		)
-		VALUES ($1, $2, $3, $4, $5)
-		ON CONFLICT (x, y, slot) DO NOTHING;
+            x,
+            y,
+            color,
+            slot,
+            validator
+        )
+        VALUES ($1, $2, $3, $4, $5)
+        ON CONFLICT (slot) DO UPDATE SET
+            x = EXCLUDED.x,
+            y = EXCLUDED.y,
+            color = EXCLUDED.color,
+            validator = EXCLUDED.validator;
 		`)
 	if err != nil {
 		return err


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3e65ccb</samp>

Update SQL statement for graffitiwall insertion to allow editing. This file changes the `db/db.go` file to use the `ON CONFLICT DO UPDATE` clause when inserting a graffitiwall record, so that users can modify their previous submissions.
