### PR TITLE
(BIDS-1766) no attestation found

### DIFF
--- a/handlers/validators.go
+++ b/handlers/validators.go
@@ -320,7 +320,7 @@ func ValidatorsData(w http.ResponseWriter, r *http.Request) {
 			tableData[i] = append(tableData[i], nil)
 		}
 
-		if v.LastAttestationSlot != nil {
+		if v.LastAttestationSlot != nil && *v.LastAttestationSlot > 0 {
 			tableData[i] = append(tableData[i], []interface{}{
 				*v.LastAttestationSlot,
 				utils.SlotToTime(uint64(*v.LastAttestationSlot)).Unix(),


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e9ab83a</samp>

Fix negative slots and other issues in validators table. Check `last_attestation_slot` before adding it to `tableData` in `handlers/validators.go`.
