### PR TITLE
(NOBIDS) Fix panic when topics array is empty

### DIFF
--- a/eth1data/eth1data.go
+++ b/eth1data/eth1data.go
@@ -184,7 +184,7 @@ func GetEth1Transaction(hash common.Hash) (*types.Eth1TxData, error) {
 				boundContract := bind.NewBoundContract(*txPageData.To, *cmEntry.meta.ABI, nil, nil, nil)
 
 				for name, event := range cmEntry.meta.ABI.Events {
-					if bytes.Equal(event.ID.Bytes(), log.Topics[0].Bytes()) {
+					if log != nil && len(log.Topics) > 0 && bytes.Equal(event.ID.Bytes(), log.Topics[0].Bytes()) {
 						logData := make(map[string]interface{})
 						err := boundContract.UnpackLogIntoMap(logData, name, *log)
 


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0b3b258</samp>

Added safety checks to `GetEth1Transaction` in `eth1data/eth1data.go` to prevent panics from malformed log data. This improves the robustness and reliability of the eth1 data processing and display.
