### PR TITLE
(BIDS-2099) exited validator history sync

### DIFF
--- a/handlers/common.go
+++ b/handlers/common.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
+	utilMath "github.com/protolambda/zrnt/eth2/util/math"
 	"github.com/rocket-pool/rocketpool-go/utils/eth"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
@@ -182,6 +183,7 @@ func GetValidatorEarnings(validators []uint64, currency string) (*types.Validato
 			b.Status,
 		}
 		if b.Status == 0 {
+			validatorProposalData.LastScheduledSlot = utilMath.MaxU64(validatorProposalData.LastScheduledSlot, b.Slot)
 			validatorProposalData.ScheduledBlocksCount++
 		} else if b.Status == 1 {
 			validatorProposalData.ProposedBlocksCount++

--- a/handlers/common.go
+++ b/handlers/common.go
@@ -43,7 +43,7 @@ func GetValidatorOnlineThresholdSlot() uint64 {
 	return validatorOnlineThresholdSlot
 }
 
-// GetValidatorEarnings will return the earnings (last day, week, month and total) of selected validators
+// GetValidatorEarnings will return the earnings (last day, week, month and total) of selected validators, including proposal and statisic information - infused with data from the current b. day
 func GetValidatorEarnings(validators []uint64, currency string) (*types.ValidatorEarnings, map[uint64]*types.Validator, error) {
 	if len(validators) == 0 {
 		return nil, nil, errors.New("no validators provided")

--- a/handlers/validator.go
+++ b/handlers/validator.go
@@ -1643,7 +1643,7 @@ func ValidatorHistory(w http.ResponseWriter, r *http.Request) {
 		})
 	}
 
-	totalCount = protomath.MaxU64(totalCount, uint64(pageLength*maxPages))
+	totalCount = protomath.MinU64(totalCount, uint64(pageLength*maxPages))
 
 	data := &types.DataTableResponse{
 		Draw:            draw,

--- a/handlers/validator.go
+++ b/handlers/validator.go
@@ -1576,7 +1576,7 @@ func ValidatorHistory(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	tableData := make([][]interface{}, 0, 0)
+	tableData := make([][]interface{}, 0)
 
 	if extraEpochs > 0 {
 		startEpoch := currentEpoch + 1

--- a/handlers/validator.go
+++ b/handlers/validator.go
@@ -23,7 +23,6 @@ import (
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/lib/pq"
-	"github.com/protolambda/zrnt/eth2/util/math"
 	protomath "github.com/protolambda/zrnt/eth2/util/math"
 	"golang.org/x/sync/errgroup"
 
@@ -1573,7 +1572,7 @@ func ValidatorHistory(w http.ResponseWriter, r *http.Request) {
 		}
 		lastActionEpoch := (lastActoinDay + 1) * utils.EpochsPerDay()
 		if lastActionEpoch > currentEpoch {
-			extraEpochs = math.MinU64(lastActionEpoch, services.LatestEpoch()-1) - currentEpoch
+			extraEpochs = protomath.MinU64(lastActionEpoch, services.LatestEpoch()-1) - currentEpoch
 		}
 	}
 

--- a/handlers/validator.go
+++ b/handlers/validator.go
@@ -25,7 +25,6 @@ import (
 	"github.com/lib/pq"
 	"github.com/protolambda/zrnt/eth2/util/math"
 	protomath "github.com/protolambda/zrnt/eth2/util/math"
-	utilMath "github.com/protolambda/zrnt/eth2/util/math"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/gorilla/csrf"
@@ -414,7 +413,7 @@ func Validator(w http.ResponseWriter, r *http.Request) {
 		validatorPageData.IncomeTotalFormatted = earnings.TotalFormatted
 		validatorPageData.IncomeToday = earnings.IncomeToday
 		validatorPageData.ValidatorProposalData = earnings.ProposalData
-		validatorPageData.FutureDutiesEpoch = utilMath.MaxU64(validatorPageData.FutureDutiesEpoch, earnings.ProposalData.LastScheduledSlot/data.ChainConfig.SlotsPerEpoch)
+		validatorPageData.FutureDutiesEpoch = protomath.MaxU64(validatorPageData.FutureDutiesEpoch, earnings.ProposalData.LastScheduledSlot/data.ChainConfig.SlotsPerEpoch)
 
 		if utils.Config.Frontend.Validator.ShowProposerRewards {
 			validatorPageData.IncomeProposerFormatted = &earnings.ProposerTotalFormatted
@@ -669,7 +668,7 @@ func Validator(w http.ResponseWriter, r *http.Request) {
 		}
 
 		if len(allSyncPeriods) > 0 && allSyncPeriods[0].LastEpoch > latestEpoch {
-			validatorPageData.FutureDutiesEpoch = utilMath.MaxU64(validatorPageData.FutureDutiesEpoch, allSyncPeriods[0].LastEpoch)
+			validatorPageData.FutureDutiesEpoch = protomath.MaxU64(validatorPageData.FutureDutiesEpoch, allSyncPeriods[0].LastEpoch)
 		}
 
 		// remove scheduled committees

--- a/templates/validator/overview.html
+++ b/templates/validator/overview.html
@@ -208,7 +208,12 @@
       <div class="col">
         <div class="px-2 mx-auto" style="max-width: 50rem;">
           <div class="p-2 text-justify">
-            This validator has exited the system during epoch <a href="/epoch/{{ .ExitEpoch }}">{{ .ExitEpoch }}</a> and is no longer validating. There is no need to keep the validator running anymore.
+            {{ if .FutureDutiesEpoch }}
+              This validator has exited the system during epoch <a href="/epoch/{{ .ExitEpoch }}">{{ .ExitEpoch }}</a> but has still future duties. <i class="fas fa-exclamation-circle"></i> Please keep the validator running until epoch <a href="/epoch/{{ .FutureDutiesEpoch }}">{{ .FutureDutiesEpoch }}</a>!
+            {{ else }}
+              This validator has exited the system during epoch <a href="/epoch/{{ .ExitEpoch }}">{{ .ExitEpoch }}</a> and is no longer validating. There is no need to keep the validator running anymore.
+            {{ end }}
+
             {{ if .CappellaHasHappened }}
               Funds will be withdrawable after epoch <span><a href="/epoch/{{ .WithdrawableEpoch }}">{{ .WithdrawableEpoch }}</a></span
               >.

--- a/types/templates.go
+++ b/types/templates.go
@@ -368,6 +368,7 @@ type ValidatorPageData struct {
 	PendingCount                             uint64
 	SyncCount                                uint64 // amount of sync committees the validator was (and is) part of
 	SlotsPerSyncCommittee                    uint64
+	FutureDutiesEpoch                        uint64
 	SlotsDoneInCurrentSyncCommittee          uint64
 	ScheduledSyncCountSlots                  uint64
 	ParticipatedSyncCountSlots               uint64
@@ -1011,6 +1012,7 @@ type ValidatorProposalData struct {
 	Proposals                [][]uint64
 	BlocksCount              uint64
 	ScheduledBlocksCount     uint64
+	LastScheduledSlot        uint64
 	MissedBlocksCount        uint64
 	OrphanedBlocksCount      uint64
 	ProposedBlocksCount      uint64


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at dbcedd2</samp>

This pull request enhances the eth2-beaconchain-explorer to better track and display the proposal duties of validators who have exited. It uses the zrnt library for uint64 math, adds new fields to the templates, and updates the validator overview page to show a warning message and icon for validators with future duties.
