### PR TITLE
(NOBIDS) check if all epochs are finalized for stats

### DIFF
--- a/cmd/statistics/main.go
+++ b/cmd/statistics/main.go
@@ -132,6 +132,7 @@ func main() {
 				err = db.WriteValidatorStatisticsForDay(uint64(d))
 				if err != nil {
 					logrus.Errorf("error exporting stats for day %v: %v", d, err)
+					break
 				}
 			}
 		}
@@ -147,6 +148,7 @@ func main() {
 				err = db.WriteChartSeriesForDay(int64(d))
 				if err != nil {
 					logrus.Errorf("error exporting chart series from day %v: %v", d, err)
+					break
 				}
 			}
 		}
@@ -225,6 +227,7 @@ func statisticsLoop() {
 					err := db.WriteValidatorStatisticsForDay(day)
 					if err != nil {
 						logrus.Errorf("error exporting stats for day %v: %v", day, err)
+						break
 					}
 				}
 			}
@@ -247,6 +250,7 @@ func statisticsLoop() {
 						err = db.WriteChartSeriesForDay(int64(day))
 						if err != nil {
 							logrus.Errorf("error exporting chart series from day %v: %v", day, err)
+							break
 						}
 					}
 				}

--- a/db/db.go
+++ b/db/db.go
@@ -479,6 +479,18 @@ func GetAllEpochs() ([]uint64, error) {
 	return epochs, nil
 }
 
+// Count finalized epochs in range
+func CountFinalizedEpochs(startEpoch uint64, endEpoch uint64) (uint64, error) {
+	var count uint64
+	err := WriterDb.Get(&count, "SELECT COUNT(*) FROM epochs WHERE epoch >= $1 AND epoch <= $2 AND finalized", startEpoch, endEpoch)
+
+	if err != nil {
+		return 0, fmt.Errorf("error counting finalized epochs [%v -> %v] from DB: %w", startEpoch, endEpoch, err)
+	}
+
+	return count, nil
+}
+
 // GetLastPendingAndProposedBlocks will return all proposed and pending blocks (ignores missed slots) from the database
 func GetLastPendingAndProposedBlocks(startEpoch, endEpoch uint64) ([]*types.MinimalBlock, error) {
 	var blocks []*types.MinimalBlock

--- a/db/db.go
+++ b/db/db.go
@@ -479,7 +479,7 @@ func GetAllEpochs() ([]uint64, error) {
 	return epochs, nil
 }
 
-// Count finalized epochs in range
+// Count finalized epochs in range (including start and end epoch)
 func CountFinalizedEpochs(startEpoch uint64, endEpoch uint64) (uint64, error) {
 	var count uint64
 	err := WriterDb.Get(&count, "SELECT COUNT(*) FROM epochs WHERE epoch >= $1 AND epoch <= $2 AND finalized", startEpoch, endEpoch)

--- a/db/statistics.go
+++ b/db/statistics.go
@@ -34,7 +34,7 @@ func WriteValidatorStatisticsForDay(day uint64) error {
 	}
 
 	if finalizedCount < epochsPerDay {
-		return fmt.Errorf("delaying statistics export as not all epochs for this day are finalized. LatestDB: %v", day)
+		return fmt.Errorf("delaying chart series export as not all epochs for day %v finalized. %v of %v", day, finalizedCount, epochsPerDay)
 	}
 
 	start := time.Now()
@@ -705,7 +705,7 @@ func WriteChartSeriesForDay(day int64) error {
 	}
 
 	if finalizedCount < epochsPerDay {
-		return fmt.Errorf("delaying chart series export as not all epochs for this day are finalized. LatestDB: %v", day)
+		return fmt.Errorf("delaying chart series export as not all epochs for day %v finalized. %v of %v", day, finalizedCount, epochsPerDay)
 	}
 
 	firstBlock, err := GetBlockNumber(uint64(firstSlot))

--- a/db/statistics.go
+++ b/db/statistics.go
@@ -28,13 +28,13 @@ func WriteValidatorStatisticsForDay(day uint64) error {
 
 	logger.Infof("exporting statistics for day %v (epoch %v to %v)", day, firstEpoch, lastEpoch)
 
-	latestDbEpoch, err := GetLatestEpoch()
+	finalizedCount, err := CountFinalizedEpochs(firstEpoch, lastEpoch)
 	if err != nil {
 		return err
 	}
 
-	if lastEpoch > latestDbEpoch {
-		return fmt.Errorf("delaying statistics export as epoch %v has not yet been indexed. LatestDB: %v", lastEpoch, latestDbEpoch)
+	if finalizedCount < epochsPerDay {
+		return fmt.Errorf("delaying statistics export as not all epochs for this day are finalized. LatestDB: %v", day)
 	}
 
 	start := time.Now()
@@ -699,13 +699,13 @@ func WriteChartSeriesForDay(day int64) error {
 	lastSlot := int64(firstSlot) + int64(epochsPerDay*utils.Config.Chain.Config.SlotsPerEpoch)
 	lastEpoch := lastSlot / int64(utils.Config.Chain.Config.SlotsPerEpoch)
 
-	latestDbEpoch, err := GetLatestEpoch()
+	finalizedCount, err := CountFinalizedEpochs(firstEpoch, uint64(lastEpoch))
 	if err != nil {
 		return err
 	}
 
-	if (uint64(lastSlot) / utils.Config.Chain.Config.SlotsPerEpoch) > latestDbEpoch {
-		return fmt.Errorf("delaying statistics export as epoch %v has not yet been indexed. LatestDB: %v", (uint64(lastSlot) / utils.Config.Chain.Config.SlotsPerEpoch), latestDbEpoch)
+	if finalizedCount < epochsPerDay {
+		return fmt.Errorf("delaying chart series export as not all epochs for this day are finalized. LatestDB: %v", day)
 	}
 
 	firstBlock, err := GetBlockNumber(uint64(firstSlot))


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6202936</samp>

This pull request improves the statistics export logic for the eth2-beaconchain-explorer by using finality status instead of indexing status, adding `break` statements to optimize the switch cases, and adding a new function to count finalized epochs.
