### PR TITLE
(NOBIDS) Added Docker Info link

### DIFF
--- a/templates/user/settings.html
+++ b/templates/user/settings.html
@@ -531,6 +531,9 @@
 
                               <div style="clear: both;"></div>
                               <br />
+                              Docker is also available, for more information click <a href="https://github.com/gobitfly/eth2-client-metrics-exporter#example-with-docker"> here</a>!
+                              <br />
+                              <br />
 
                               <h4>2. Run Metrics Exporter</h4>
                               <div style="margin-left: 5px; margin-right: 5px;">
@@ -588,6 +591,9 @@
                               </div>
 
                               <div style="clear: both;"></div>
+                              <br />
+                              Docker is also available, for more information click <a href="https://github.com/gobitfly/eth2-client-metrics-exporter#example-with-docker"> here</a>!
+                              <br />
                               <br />
 
                               <h4>3. Run Metrics Exporter</h4>


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 07fa903</samp>

Add Docker links for client metrics in user settings. This change helps users who can use `eth2-client-metrics-exporter` to collect and export metrics from their Eth2 clients to the dashboard.
