### PR TITLE
(BIDS-1694) truncate only tooltip for method names

### DIFF
--- a/handlers/slot.go
+++ b/handlers/slot.go
@@ -718,7 +718,7 @@ func BlockTransactionsData(w http.ResponseWriter, r *http.Request) {
 	for i, v := range transactions.Txs {
 		methodFormatted := `<span class="badge badge-light">Transfer</span>`
 		if len(v.Method) > 0 && v.Method != "Transfer" {
-			methodFormatted = fmt.Sprintf(`<span class="badge badge-light text-truncate mw-100" truncate-tooltip="%v"{>%v</span>`, v.Method, v.Method)
+			methodFormatted = fmt.Sprintf(`<span class="badge badge-light text-truncate mw-100" truncate-tooltip="%v">%v</span>`, v.Method, v.Method)
 		}
 		data[i] = &transactionsData{
 			HashFormatted: v.HashFormatted,

--- a/handlers/slot.go
+++ b/handlers/slot.go
@@ -718,7 +718,7 @@ func BlockTransactionsData(w http.ResponseWriter, r *http.Request) {
 	for i, v := range transactions.Txs {
 		methodFormatted := `<span class="badge badge-light">Transfer</span>`
 		if len(v.Method) > 0 && v.Method != "Transfer" {
-			methodFormatted = fmt.Sprintf(`<span class="badge badge-light text-truncate mw-100" data-toggle="tooltip" title="%v"{>%v</span>`, v.Method, v.Method)
+			methodFormatted = fmt.Sprintf(`<span class="badge badge-light text-truncate mw-100" truncate-tooltip="%v"{>%v</span>`, v.Method, v.Method)
 		}
 		data[i] = &transactionsData{
 			HashFormatted: v.HashFormatted,

--- a/static/js/layout.js
+++ b/static/js/layout.js
@@ -507,14 +507,13 @@ function formatAriaEthereumDate(elem) {
 function truncateTooltip() {
   let nodes = $("[truncate-tooltip]")
   nodes.each((_, node) => {
-    console.log(node)
     let title = ""
     if (node.scrollWidth > node.offsetWidth) {
       title = node.attributes["truncate-tooltip"].value
     }
-    if (node.attributes["title"]?.value != title) {
-      node.setAttribute("title", title)
-      if (title > 0) {
+    if (node.attributes["data-original-title"]?.value != title) {
+      node.setAttribute("data-original-title", title)
+      if (title !== "") {
         $(node).tooltip()
       }
     }

--- a/static/js/layout.js
+++ b/static/js/layout.js
@@ -14,6 +14,7 @@ function applyTTFix() {
   $("button, a").on("mousedown", (evt) => {
     evt.preventDefault() // prevent setting the browser focus on all mouse buttons, which prevents tooltips from disapearing
   })
+  truncateTooltip()
 }
 
 // FAB toggle
@@ -501,6 +502,23 @@ function formatAriaEthereumDate(elem) {
   } else {
     $(elem).text(local.toFormat(format))
   }
+}
+
+function truncateTooltip() {
+  let nodes = $("[truncate-tooltip]")
+  nodes.each((_, node) => {
+    console.log(node)
+    let title = ""
+    if (node.scrollWidth > node.offsetWidth) {
+      title = node.attributes["truncate-tooltip"].value
+    }
+    if (node.attributes["title"]?.value != title) {
+      node.setAttribute("title", title)
+      if (title > 0) {
+        $(node).tooltip()
+      }
+    }
+  })
 }
 
 function formatTimestamps(selStr) {

--- a/templates/slot/execTransactions.html
+++ b/templates/slot/execTransactions.html
@@ -22,7 +22,7 @@
         {{ range .Txs }}
           <tr class="border-bottom">
             <td class="border-0">{{ .HashFormatted }}</td>
-            <td class="border-0" {{ if gt (len .Method ) 0 }}data-toggle="tooltip" title="{{ .Method }}"{{ end }}><span class="badge badge-light text-truncate mw-100">{{ if gt (len .Method ) 0 }}{{ .Method }}{{ else }}Transfer{{ end }}</span></td>
+            <td class="border-0"><span truncate-tooltip="{{ .Method }}" class="badge badge-light text-truncate mw-100">{{ if gt (len .Method ) 0 }}{{ .Method }}{{ else }}Transfer{{ end }}</span></td>
             <td class="border-0">{{ .FromFormatted }}</td>
             <td class="border-0">{{ .ToFormatted }}</td>
             <td class="border-0">{{ formatAmountFormatted .Value "Ether" 5 0 true true false }}</td>

--- a/utils/eth1.go
+++ b/utils/eth1.go
@@ -382,7 +382,7 @@ func trimAmount(amount *big.Int, unitDigits int, maxPreCommaDigitsBeforeTrim int
 }
 
 func FormatMethod(method string) template.HTML {
-	return template.HTML(fmt.Sprintf(`<span class="badge badge-light text-truncate mw-100" data-toggle="tooltip" title="%s">%s</span>`, method, method))
+	return template.HTML(fmt.Sprintf(`<span class="badge badge-light text-truncate mw-100" truncate-tooltip="%s">%s</span>`, method, method))
 }
 
 func FormatBlockUsage(gasUsage uint64, gasLimit uint64) template.HTML {


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 18e315d</samp>

Fixed a bug that prevented tooltips from showing up for truncated method names in the UI. Added a custom `truncate-tooltip` attribute and a function in `layout.js` to handle the tooltip logic, and replaced the `data-toggle` attribute in various HTML and Go files.
