### PR TITLE
(BIDS-2094) index page: dont show fractional validators

### DIFF
--- a/handlers/index.go
+++ b/handlers/index.go
@@ -7,36 +7,32 @@ import (
 	"eth2-exporter/types"
 	"eth2-exporter/utils"
 	"fmt"
-	"html/template"
 	"net/http"
 )
 
-var indexTemplateFiles = append(layoutTemplateFiles,
-	"index/index.html",
-	"index/depositProgress.html",
-	"index/depositChart.html",
-	"index/genesis.html",
-	"index/hero.html",
-	"index/networkStats.html",
-	"index/postGenesis.html",
-	"index/preGenesis.html",
-	"index/recentBlocks.html",
-	"index/recentEpochs.html",
-	"index/genesisCountdown.html",
-	"index/depositDistribution.html",
-	"svg/bricks.html",
-	"svg/professor.html",
-	"svg/timeline.html",
-	"components/rocket.html",
-	"slotViz.html",
-)
-
-var indexTemplate = template.Must(template.New("index").Funcs(utils.GetTemplateFuncs()).ParseFS(templates.Files,
-	indexTemplateFiles...,
-))
-
 // Index will return the main "index" page using a go template
 func Index(w http.ResponseWriter, r *http.Request) {
+	var indexTemplateFiles = append(layoutTemplateFiles,
+		"index/index.html",
+		"index/depositProgress.html",
+		"index/depositChart.html",
+		"index/genesis.html",
+		"index/hero.html",
+		"index/networkStats.html",
+		"index/postGenesis.html",
+		"index/preGenesis.html",
+		"index/recentBlocks.html",
+		"index/recentEpochs.html",
+		"index/genesisCountdown.html",
+		"index/depositDistribution.html",
+		"svg/bricks.html",
+		"svg/professor.html",
+		"svg/timeline.html",
+		"components/rocket.html",
+		"slotViz.html",
+	)
+
+	var indexTemplate = templates.GetTemplate(indexTemplateFiles...)
 
 	w.Header().Set("Content-Type", "text/html")
 	data := InitPageData(w, r, "index", "", "", indexTemplateFiles)

--- a/templates/index/index.html
+++ b/templates/index/index.html
@@ -80,6 +80,7 @@
                         ],
                         legend: {enabled: true},
                         tooltip: {
+                            valueDecimals: 0,
                             formatter: function (tooltip) {
                                 var orig = tooltip.defaultFormatter.call(this, tooltip)
                                 var epoch = timeToEpoch(this.x)
@@ -108,14 +109,6 @@
                                             opposite: true
                                         }
                                     ],
-                                    tooltip: {
-                                        formatter: function (tooltip) {
-                                            var orig = tooltip.defaultFormatter.call(this, tooltip)
-                                            var epoch = timeToEpoch(this.x)
-                                            orig[0] = `${orig[0]}<span style="font-size:10px">Ep ${epoch}</span>`
-                                            return orig
-                                        }
-                                    },
                                 },
                             },
                         ],


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 97c2210</samp>

Improved the deposit chart UI in the index page and fixed a race condition when loading templates from the embedded filesystem. Moved the template variables and used `templates.GetTemplate` in `handlers/index.go`.
