### PR TITLE
(BIDS-1604) only finalized blocks for income chart

### DIFF
--- a/handlers/common.go
+++ b/handlers/common.go
@@ -198,7 +198,7 @@ func GetValidatorEarnings(validators []uint64, currency string) (*types.Validato
 
 	validatorProposalData.BlocksCount = uint64(len(proposals))
 	if validatorProposalData.BlocksCount > 0 {
-		validatorProposalData.UnmissedBlocksPercentage = float64(validatorProposalData.BlocksCount-validatorProposalData.MissedBlocksCount) / float64(len(proposals))
+		validatorProposalData.UnmissedBlocksPercentage = float64(validatorProposalData.BlocksCount-validatorProposalData.MissedBlocksCount-validatorProposalData.OrphanedBlocksCount) / float64(len(proposals))
 	} else {
 		validatorProposalData.UnmissedBlocksPercentage = 1.0
 	}

--- a/handlers/dashboard.go
+++ b/handlers/dashboard.go
@@ -373,7 +373,7 @@ func DashboardDataBalanceCombined(w http.ResponseWriter, r *http.Request) {
 
 func getExecutionChartData(indices []uint64, currency string) ([]*types.ChartDataPoint, error) {
 	var limit uint64 = 300
-	blockList, consMap, err := findExecBlockNumbersByProposerIndex(indices, 0, limit, false)
+	blockList, consMap, err := findExecBlockNumbersByProposerIndex(indices, 0, limit, false, true)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 66ec7d9</samp>

Added a feature to show execution layer data for finalized blocks only on the dashboard, and fixed a bug that inflated the unmissed blocks percentage for validators. Modified the `findExecBlockNumbersByProposerIndex` function and the `validatorProposalData` struct in `handlers/api_eth1.go`, `handlers/common.go`, and `handlers/dashboard.go`.
