### PR TITLE
(BIDS-2001) Show "Exited since" for exited validators

### DIFF
--- a/templates/validator/tables.html
+++ b/templates/validator/tables.html
@@ -791,7 +791,11 @@
         </tr>
         {{ if not (or (eq .ExitEpoch 9223372036854775807) (eq .ExitEpoch 0)) }}
           <tr>
-            <th scope="row">Exited since</th>
+            {{ if ge .Epoch .ExitEpoch }}
+              <th scope="row">Exited since</th>
+            {{ else }}
+              <th scope="row">Exiting on</th>
+            {{ end }}
             <td class="pl-0">
               <a href="/epoch/{{ .ExitEpoch }}">
                 <span title="Epoch: {{ .ExitEpoch }}" data-toggle="tooltip" aria-ethereum-date="{{ .ExitTs.Unix }}"></span>


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 58fd1d2</samp>

Improved validator status display in `templates/validator/tables.html` by adding a conditional statement to show the correct exit epoch label.
