### PR TITLE
(NOBIDS) use redis for rate limiting metrics inserts

### DIFF
--- a/cmd/eth1indexer/main.go
+++ b/cmd/eth1indexer/main.go
@@ -129,7 +129,7 @@ func main() {
 		logrus.Fatalf("node chain id mismatch, wanted %v got %v", chainId, nodeChainId.String())
 	}
 
-	bt, err := db.InitBigtable(*bigtableProject, *bigtableInstance, chainId)
+	bt, err := db.InitBigtable(*bigtableProject, *bigtableInstance, chainId, utils.Config.RedisCacheEndpoint)
 	if err != nil {
 		logrus.Fatalf("error connecting to bigtable: %v", err)
 	}

--- a/cmd/explorer/main.go
+++ b/cmd/explorer/main.go
@@ -159,7 +159,7 @@ func main() {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		bt, err := db.InitBigtable(utils.Config.Bigtable.Project, utils.Config.Bigtable.Instance, fmt.Sprintf("%d", utils.Config.Chain.Config.DepositChainID), utils.Config.RedisCacheEndpoint) //
+		bt, err := db.InitBigtable(utils.Config.Bigtable.Project, utils.Config.Bigtable.Instance, fmt.Sprintf("%d", utils.Config.Chain.Config.DepositChainID), utils.Config.RedisCacheEndpoint)
 		if err != nil {
 			logrus.Fatalf("error connecting to bigtable: %v", err)
 		}

--- a/cmd/explorer/main.go
+++ b/cmd/explorer/main.go
@@ -159,7 +159,7 @@ func main() {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		bt, err := db.InitBigtable(utils.Config.Bigtable.Project, utils.Config.Bigtable.Instance, fmt.Sprintf("%d", utils.Config.Chain.Config.DepositChainID)) //
+		bt, err := db.InitBigtable(utils.Config.Bigtable.Project, utils.Config.Bigtable.Instance, fmt.Sprintf("%d", utils.Config.Chain.Config.DepositChainID), utils.Config.RedisCacheEndpoint) //
 		if err != nil {
 			logrus.Fatalf("error connecting to bigtable: %v", err)
 		}

--- a/cmd/frontend-data-updater/main.go
+++ b/cmd/frontend-data-updater/main.go
@@ -37,7 +37,7 @@ func main() {
 		}()
 	}
 
-	_, err = db.InitBigtable(cfg.Bigtable.Project, cfg.Bigtable.Instance, fmt.Sprintf("%d", utils.Config.Chain.Config.DepositChainID))
+	_, err = db.InitBigtable(cfg.Bigtable.Project, cfg.Bigtable.Instance, fmt.Sprintf("%d", utils.Config.Chain.Config.DepositChainID), utils.Config.RedisCacheEndpoint)
 	if err != nil {
 		logrus.Fatalf("error initializing bigtable %v", err)
 	}

--- a/cmd/migrations/bigtable/main.go
+++ b/cmd/migrations/bigtable/main.go
@@ -35,7 +35,7 @@ func main() {
 	}
 	utils.Config = cfg
 
-	bt, err := db.InitBigtable(utils.Config.Bigtable.Project, utils.Config.Bigtable.Instance, fmt.Sprintf("%d", utils.Config.Chain.Config.DepositChainID))
+	bt, err := db.InitBigtable(utils.Config.Bigtable.Project, utils.Config.Bigtable.Instance, fmt.Sprintf("%d", utils.Config.Chain.Config.DepositChainID), utils.Config.RedisCacheEndpoint)
 	if err != nil {
 		logrus.Fatalf("error connecting to bigtable: %v", err)
 	}
@@ -133,7 +133,7 @@ func monitor(configPath string) {
 	}
 	utils.Config = cfg
 
-	bt, err := db.InitBigtable(utils.Config.Bigtable.Project, utils.Config.Bigtable.Instance, fmt.Sprintf("%d", utils.Config.Chain.Config.DepositChainID))
+	bt, err := db.InitBigtable(utils.Config.Bigtable.Project, utils.Config.Bigtable.Instance, fmt.Sprintf("%d", utils.Config.Chain.Config.DepositChainID), utils.Config.RedisCacheEndpoint)
 	if err != nil {
 		logrus.Fatalf("error connecting to bigtable: %v", err)
 	}

--- a/cmd/misc/main.go
+++ b/cmd/misc/main.go
@@ -52,7 +52,7 @@ func main() {
 
 	chainIdString := strconv.FormatUint(utils.Config.Chain.Config.DepositChainID, 10)
 
-	_, err = db.InitBigtable(utils.Config.Bigtable.Project, utils.Config.Bigtable.Project, chainIdString)
+	_, err = db.InitBigtable(utils.Config.Bigtable.Project, utils.Config.Bigtable.Project, chainIdString, utils.Config.RedisCacheEndpoint)
 	if err != nil {
 		utils.LogFatal(err, "error initializing bigtable", 0)
 	}
@@ -188,7 +188,7 @@ func UpdateAPIKey(user uint64) error {
 // Debugging function to compare Rewards from the Statistic Table with the onces from the Big Table
 func CompareRewards(dayStart uint64, dayEnd uint64, validator uint64) {
 
-	bt, err := db.InitBigtable(utils.Config.Bigtable.Project, utils.Config.Bigtable.Instance, fmt.Sprintf("%d", utils.Config.Chain.Config.DepositChainID))
+	bt, err := db.InitBigtable(utils.Config.Bigtable.Project, utils.Config.Bigtable.Instance, fmt.Sprintf("%d", utils.Config.Chain.Config.DepositChainID), utils.Config.RedisCacheEndpoint)
 	if err != nil {
 		logrus.Fatalf("error connecting to bigtable: %v", err)
 	}

--- a/cmd/rewards-exporter/main.go
+++ b/cmd/rewards-exporter/main.go
@@ -57,7 +57,7 @@ func main() {
 
 	client := beacon.NewClient(*bnAddress, time.Minute*5)
 
-	bt, err := db.InitBigtable(utils.Config.Bigtable.Project, utils.Config.Bigtable.Instance, fmt.Sprintf("%d", utils.Config.Chain.Config.DepositChainID))
+	bt, err := db.InitBigtable(utils.Config.Bigtable.Project, utils.Config.Bigtable.Instance, fmt.Sprintf("%d", utils.Config.Chain.Config.DepositChainID), utils.Config.RedisCacheEndpoint)
 	if err != nil {
 		logrus.Fatalf("error connecting to bigtable: %v", err)
 	}

--- a/cmd/signatures/main.go
+++ b/cmd/signatures/main.go
@@ -65,7 +65,7 @@ func main() {
 		}()
 	}
 
-	bt, err := db.InitBigtable(*bigtableProject, *bigtableInstance, "1")
+	bt, err := db.InitBigtable(*bigtableProject, *bigtableInstance, "1", utils.Config.RedisCacheEndpoint)
 	if err != nil {
 		logrus.Errorf("error initializing bigtable: %v", err)
 		return

--- a/cmd/statistics/main.go
+++ b/cmd/statistics/main.go
@@ -90,7 +90,7 @@ func main() {
 	defer db.FrontendReaderDB.Close()
 	defer db.FrontendWriterDB.Close()
 
-	_, err = db.InitBigtable(cfg.Bigtable.Project, cfg.Bigtable.Instance, fmt.Sprintf("%d", utils.Config.Chain.Config.DepositChainID))
+	_, err = db.InitBigtable(cfg.Bigtable.Project, cfg.Bigtable.Instance, fmt.Sprintf("%d", utils.Config.Chain.Config.DepositChainID), utils.Config.RedisCacheEndpoint)
 	if err != nil {
 		logrus.Fatalf("error connecting to bigtable: %v", err)
 	}

--- a/db/bigtable.go
+++ b/db/bigtable.go
@@ -139,6 +139,7 @@ func (bigtable Bigtable) getMachineMetricNamesMap(userID uint64, searchDepth int
 		gcp_bigtable.FamilyFilter(MACHINE_METRICS_COLUMN_FAMILY),
 		gcp_bigtable.LatestNFilter(searchDepth),
 		gcp_bigtable.TimestampRangeFilter(time.Now().Add(time.Duration(searchDepth*-1)*time.Minute), time.Now()),
+		gcp_bigtable.StripValueFilter(),
 	)
 
 	machineNames := make(map[string]bool)


### PR DESCRIPTION
Switched to redis for rate limiting metric inserts. Uses the SETNX function with the metrics key + the current minute as rate limit key. Redis keys expire after 1 minute

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2969628</samp>

Added Redis caching to the `db` package and updated all commands that use the `InitBigtable` function to pass the Redis address as a parameter. This improves the performance and scalability of the machine metrics feature by reducing the load on Bigtable.
