### PR TITLE
(BIDS-2122) Add deposited count to dashboard summary text

### DIFF
--- a/static/js/dashboard.js
+++ b/static/js/dashboard.js
@@ -751,13 +751,13 @@ $(document).ready(function () {
     var el = document.getElementById("dashboard-info")
     var depositedText = ""
     if (state.validatorsCount.deposited > 0) {
-      depositedText = `${state.validatorsCount.deposited} deposited, `
+      depositedText = `, ${state.validatorsCount.deposited} deposited`
     }
     var slashedText = ""
     if (state.validatorsCount.slashed > 0) {
       slashedText = `, ${state.validatorsCount.slashed} slashed`
     }
-    el.innerText = `${state.validatorsCount.active_online + state.validatorsCount.active_offline} active (${state.validatorsCount.active_online} online, ${state.validatorsCount.active_offline} offline), ${depositedText}${state.validatorsCount.pending} pending, ${state.validatorsCount.exited + state.validatorsCount.slashed} exited validators (${state.validatorsCount.exited} voluntary${slashedText})`
+    el.innerText = `${state.validatorsCount.active_online + state.validatorsCount.active_offline} active (${state.validatorsCount.active_online} online, ${state.validatorsCount.active_offline} offline)${depositedText}, ${state.validatorsCount.pending} pending, ${state.validatorsCount.exited + state.validatorsCount.slashed} exited validators (${state.validatorsCount.exited} voluntary${slashedText})`
 
     if (state.validators.length > 0) {
       showSelectedValidator()

--- a/static/js/dashboard.js
+++ b/static/js/dashboard.js
@@ -749,11 +749,15 @@ $(document).ready(function () {
 
   function renderDashboardInfo() {
     var el = document.getElementById("dashboard-info")
+    var depositedText = ""
+    if (state.validatorsCount.deposited > 0) {
+      depositedText = `${state.validatorsCount.deposited} deposited, `
+    }
     var slashedText = ""
     if (state.validatorsCount.slashed > 0) {
       slashedText = `, ${state.validatorsCount.slashed} slashed`
     }
-    el.innerText = `${state.validatorsCount.active_online + state.validatorsCount.active_offline} active (${state.validatorsCount.active_online} online, ${state.validatorsCount.active_offline} offline), ${state.validatorsCount.pending} pending, ${state.validatorsCount.exited + state.validatorsCount.slashed} exited validators (${state.validatorsCount.exited} voluntary${slashedText})`
+    el.innerText = `${state.validatorsCount.active_online + state.validatorsCount.active_offline} active (${state.validatorsCount.active_online} online, ${state.validatorsCount.active_offline} offline), ${depositedText}${state.validatorsCount.pending} pending, ${state.validatorsCount.exited + state.validatorsCount.slashed} exited validators (${state.validatorsCount.exited} voluntary${slashedText})`
 
     if (state.validators.length > 0) {
       showSelectedValidator()
@@ -983,6 +987,7 @@ $(document).ready(function () {
           // 0:pubkey, 1:idx, 2:[currbal,effbal], 3:state, 4:[actepoch,acttime], 5:[exit,exittime], 6:[wd,wdt], 7:[lasta,lastat], 8:[exprop,misprop]
           // console.log(`latestEpoch: ${result.latestEpoch}`)
           // var latestEpoch = result.latestEpoch
+          state.validatorsCount.deposited = 0
           state.validatorsCount.pending = 0
           state.validatorsCount.active_online = 0
           state.validatorsCount.active_offline = 0


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f0cfccf</samp>

Added `deposited` validators count to dashboard. The `static/js/dashboard.js` file was updated to show the number of validators who have deposited but not yet activated.
