### PR TITLE
(BIDS-2066) write statistic for orphaned att and sync

### DIFF
--- a/cmd/misc/main.go
+++ b/cmd/misc/main.go
@@ -11,8 +11,10 @@ import (
 	"fmt"
 	"math/big"
 	"strconv"
+	"strings"
 
 	_ "github.com/jackc/pgx/v4/stdlib"
+	"github.com/jmoiron/sqlx"
 
 	"flag"
 
@@ -125,6 +127,8 @@ func main() {
 		}
 	case "debug-rewards":
 		CompareRewards(opts.StartDay, opts.EndDay, opts.Validator)
+	case "update-orphaned-statistics":
+		UpdateOrphanedStatistics(opts.StartDay, opts.EndDay, db.WriterDb)
 
 	default:
 		utils.LogFatal(nil, "unknown command", 0)
@@ -218,6 +222,127 @@ func CompareRewards(dayStart uint64, dayEnd uint64, validator uint64) {
 		if tot != *dbRewards {
 			logrus.Errorf("Rewards are not the same on day %v-> big: %v, db: %v", day, tot, *dbRewards)
 		}
+	}
+
+}
+
+// Update Orphaned statistics for Sync / Attestations
+func UpdateOrphanedStatistics(dayStart uint64, dayEnd uint64, WriterDb *sqlx.DB) {
+	bt, err := db.InitBigtable(utils.Config.Bigtable.Project, utils.Config.Bigtable.Instance, fmt.Sprintf("%d", utils.Config.Chain.Config.DepositChainID))
+	if err != nil {
+		logrus.Fatalf("error connecting to bigtable: %v", err)
+	}
+	defer bt.Close()
+
+	for day := dayStart; day <= dayEnd; day++ {
+		tx, err := WriterDb.Beginx()
+		if err != nil {
+			logrus.Errorf("error WriterDb.Beginx %v", err)
+			return
+		}
+		defer tx.Rollback()
+		startEpoch := day * utils.EpochsPerDay()
+		endEpoch := startEpoch + utils.EpochsPerDay() - 1
+
+		if err != nil {
+			logrus.Errorf("error getting validator Count %v", err)
+			return
+		}
+
+		logrus.Infof("exporting failed attestations statistics lastEpoch: %v firstEpoch: %v", startEpoch, endEpoch)
+		ma, err := bt.GetValidatorFailedAttestationsCount([]uint64{}, startEpoch, endEpoch)
+		if err != nil {
+			logrus.Errorf("error getting failed attestations %v", err)
+			return
+		}
+		maArr := make([]*types.ValidatorMissedAttestationsStatistic, 0, len(ma))
+		for _, stat := range ma {
+			maArr = append(maArr, stat)
+		}
+
+		batchSize := 16000 // max parameters: 65535
+		for b := 0; b < len(maArr); b += batchSize {
+			start := b
+			end := b + batchSize
+			if len(maArr) < end {
+				end = len(maArr)
+			}
+
+			numArgs := 4
+			valueStrings := make([]string, 0, batchSize)
+			valueArgs := make([]interface{}, 0, batchSize*numArgs)
+			for i, stat := range maArr[start:end] {
+				valueStrings = append(valueStrings, fmt.Sprintf("($%d, $%d, $%d, $%d)", i*numArgs+1, i*numArgs+2, i*numArgs+3, i*numArgs+4))
+				valueArgs = append(valueArgs, stat.Index)
+				valueArgs = append(valueArgs, day)
+				valueArgs = append(valueArgs, stat.MissedAttestations)
+				valueArgs = append(valueArgs, stat.OrphanedAttestations)
+			}
+			stmt := fmt.Sprintf(`
+			insert into validator_stats (validatorindex, day, missed_attestations, orphaned_attestations) VALUES
+			%s
+			on conflict (validatorindex, day) do update set missed_attestations = excluded.missed_attestations, orphaned_attestations = excluded.orphaned_attestations;`,
+				strings.Join(valueStrings, ","))
+			_, err := tx.Exec(stmt, valueArgs...)
+			if err != nil {
+				logrus.Errorf("Error inserting failed attestations %v", err)
+				return
+			}
+
+			logrus.Infof("saving failed attestations batch %v completed", b)
+		}
+
+		logrus.Infof("Update Orphaned for day [%v] epoch %v -> %v", day, startEpoch, endEpoch)
+		syncStats, err := bt.GetValidatorSyncDutiesStatistics([]uint64{}, startEpoch, endEpoch)
+		if err != nil {
+			logrus.Errorf("error getting GetValidatorSyncDutiesStatistics %v", err)
+			return
+		}
+
+		syncStatsArr := make([]*types.ValidatorSyncDutiesStatistic, 0, len(syncStats))
+		for _, stat := range syncStats {
+			syncStatsArr = append(syncStatsArr, stat)
+		}
+
+		batchSize = 13000 // max parameters: 65535
+		for b := 0; b < len(syncStatsArr); b += batchSize {
+			start := b
+			end := b + batchSize
+			if len(syncStatsArr) < end {
+				end = len(syncStatsArr)
+			}
+
+			numArgs := 5
+			valueStrings := make([]string, 0, batchSize)
+			valueArgs := make([]interface{}, 0, batchSize*numArgs)
+			for i, stat := range syncStatsArr[start:end] {
+				valueStrings = append(valueStrings, fmt.Sprintf("($%d, $%d, $%d, $%d, $%d)", i*numArgs+1, i*numArgs+2, i*numArgs+3, i*numArgs+4, i*numArgs+5))
+				valueArgs = append(valueArgs, stat.Index)
+				valueArgs = append(valueArgs, day)
+				valueArgs = append(valueArgs, stat.ParticipatedSync)
+				valueArgs = append(valueArgs, stat.MissedSync)
+				valueArgs = append(valueArgs, stat.OrphanedSync)
+			}
+			stmt := fmt.Sprintf(`
+				insert into validator_stats (validatorindex, day, participated_sync, missed_sync, orphaned_sync)  VALUES
+				%s
+				on conflict (validatorindex, day) do update set participated_sync = excluded.participated_sync, missed_sync = excluded.missed_sync, orphaned_sync = excluded.orphaned_sync;`,
+				strings.Join(valueStrings, ","))
+			_, err := tx.Exec(stmt, valueArgs...)
+			if err != nil {
+				logrus.Errorf("error inserting into validator_stats %v", err)
+				return
+			}
+
+			logrus.Infof("saving sync statistics batch %v completed", b)
+		}
+
+		err = tx.Commit()
+		if err != nil {
+			logrus.Errorf("error commiting tx for validator_stats %v", err)
+			return
+		}
+		logrus.Infof("Update Orphaned for day [%v] completed", day)
 	}
 
 }

--- a/cmd/misc/main.go
+++ b/cmd/misc/main.go
@@ -228,6 +228,7 @@ func CompareRewards(dayStart uint64, dayEnd uint64, validator uint64) {
 
 // Update Orphaned statistics for Sync / Attestations
 func UpdateOrphanedStatistics(dayStart uint64, dayEnd uint64, WriterDb *sqlx.DB) {
+
 	bt, err := db.InitBigtable(utils.Config.Bigtable.Project, utils.Config.Bigtable.Instance, fmt.Sprintf("%d", utils.Config.Chain.Config.DepositChainID))
 	if err != nil {
 		logrus.Fatalf("error connecting to bigtable: %v", err)

--- a/cmd/misc/main.go
+++ b/cmd/misc/main.go
@@ -191,8 +191,8 @@ func UpdateAPIKey(user uint64) error {
 
 // Debugging function to compare Rewards from the Statistic Table with the onces from the Big Table
 func CompareRewards(dayStart uint64, dayEnd uint64, validator uint64) {
-
-	bt, err := db.InitBigtable(utils.Config.Bigtable.Project, utils.Config.Bigtable.Instance, fmt.Sprintf("%d", utils.Config.Chain.Config.DepositChainID))
+	chainId := fmt.Sprintf("%d", utils.Config.Chain.Config.DepositChainID)
+	bt, err := db.InitBigtable(utils.Config.Bigtable.Project, utils.Config.Bigtable.Instance, chainId)
 	if err != nil {
 		logrus.Fatalf("error connecting to bigtable: %v", err)
 	}

--- a/cmd/misc/main.go
+++ b/cmd/misc/main.go
@@ -191,8 +191,7 @@ func UpdateAPIKey(user uint64) error {
 
 // Debugging function to compare Rewards from the Statistic Table with the onces from the Big Table
 func CompareRewards(dayStart uint64, dayEnd uint64, validator uint64) {
-	chainId := fmt.Sprintf("%d", utils.Config.Chain.Config.DepositChainID)
-	bt, err := db.InitBigtable(utils.Config.Bigtable.Project, utils.Config.Bigtable.Instance, chainId)
+	bt, err := db.InitBigtable(utils.Config.Bigtable.Project, utils.Config.Bigtable.Instance, fmt.Sprintf("%d", utils.Config.Chain.Config.DepositChainID), utils.Config.RedisCacheEndpoint)
 
 	if err != nil {
 		logrus.Fatalf("error connecting to bigtable: %v", err)
@@ -229,8 +228,7 @@ func CompareRewards(dayStart uint64, dayEnd uint64, validator uint64) {
 
 // Update Orphaned statistics for Sync / Attestations
 func UpdateOrphanedStatistics(dayStart uint64, dayEnd uint64, WriterDb *sqlx.DB) {
-
-	bt, err := db.InitBigtable(utils.Config.Bigtable.Project, utils.Config.Bigtable.Instance, fmt.Sprintf("%d", utils.Config.Chain.Config.DepositChainID))
+	bt, err := db.InitBigtable(utils.Config.Bigtable.Project, utils.Config.Bigtable.Instance, fmt.Sprintf("%d", utils.Config.Chain.Config.DepositChainID), utils.Config.RedisCacheEndpoint)
 	if err != nil {
 		logrus.Fatalf("error connecting to bigtable: %v", err)
 	}

--- a/cmd/misc/main.go
+++ b/cmd/misc/main.go
@@ -255,7 +255,7 @@ func UpdateOrphanedStatistics(dayStart uint64, dayEnd uint64, WriterDb *sqlx.DB)
 			logrus.Errorf("error getting failed attestations %v", err)
 			return
 		}
-		maArr := make([]*types.ValidatorMissedAttestationsStatistic, 0, len(ma))
+		maArr := make([]*types.ValidatorFailedAttestationsStatistic, 0, len(ma))
 		for _, stat := range ma {
 			maArr = append(maArr, stat)
 		}

--- a/db/bigtable.go
+++ b/db/bigtable.go
@@ -1016,12 +1016,12 @@ func (bigtable *Bigtable) GetValidatorSyncDutiesHistory(validators []uint64, sta
 	return res, nil
 }
 
-func (bigtable *Bigtable) GetValidatorFailedAttestationsCount(validators []uint64, firstEpoch uint64, lastEpoch uint64) (map[uint64]*types.ValidatorMissedAttestationsStatistic, error) {
+func (bigtable *Bigtable) GetValidatorFailedAttestationsCount(validators []uint64, firstEpoch uint64, lastEpoch uint64) (map[uint64]*types.ValidatorFailedAttestationsStatistic, error) {
 	if firstEpoch > lastEpoch {
 		return nil, fmt.Errorf("GetValidatorMissedAttestationsCount received an invalid firstEpoch (%d) and lastEpoch (%d) combination", firstEpoch, lastEpoch)
 	}
 
-	res := make(map[uint64]*types.ValidatorMissedAttestationsStatistic)
+	res := make(map[uint64]*types.ValidatorFailedAttestationsStatistic)
 
 	data, err := bigtable.GetValidatorFailedAttestationHistory(validators, firstEpoch, lastEpoch)
 
@@ -1032,22 +1032,22 @@ func (bigtable *Bigtable) GetValidatorFailedAttestationsCount(validators []uint6
 	logger.Infof("retrieved missed attestation history for epochs %v - %v", firstEpoch, lastEpoch)
 
 	for validator, attestations := range data {
-		missed := len(attestations)
-		if missed > 0 {
-			missed := uint64(0)
-			orphaned := uint64(0)
-			for _, state := range attestations {
-				if state == 3 {
-					orphaned++
-				} else {
-					missed++
-				}
+		if len(attestations) == 0 {
+			continue
+		}
+		missed := uint64(0)
+		orphaned := uint64(0)
+		for _, state := range attestations {
+			if state == 3 {
+				orphaned++
+			} else {
+				missed++
 			}
-			res[validator] = &types.ValidatorMissedAttestationsStatistic{
-				Index:                validator,
-				MissedAttestations:   missed,
-				OrphanedAttestations: orphaned,
-			}
+		}
+		res[validator] = &types.ValidatorFailedAttestationsStatistic{
+			Index:                validator,
+			MissedAttestations:   missed,
+			OrphanedAttestations: orphaned,
 		}
 	}
 

--- a/db/db.go
+++ b/db/db.go
@@ -3141,3 +3141,17 @@ func GetValidatorPropsosals(validators []uint64, proposals *[]types.ValidatorPro
 		ORDER BY slot ASC
 		`, validatorsPQArray)
 }
+
+func GetOrphanedSlots(slots []uint64) ([]uint64, error) {
+	slotsPQArray := pq.Array(slots)
+	orphaned := []uint64{}
+
+	err := ReaderDb.Select(&orphaned, `
+		SELECT
+			slot
+		FROM blocks
+		WHERE slot = ANY($1) AND status = '3'
+		`, slotsPQArray)
+
+	return orphaned, err
+}

--- a/db/statistics.go
+++ b/db/statistics.go
@@ -44,8 +44,8 @@ func WriteValidatorStatisticsForDay(day uint64) error {
 		return err
 	}
 	defer tx.Rollback()
-	logger.Infof("exporting missed_attestations statistics lastEpoch: %v firstEpoch: %v", lastEpoch, firstEpoch)
-	ma, err := BigtableClient.GetValidatorMissedAttestationsCount([]uint64{}, firstEpoch, lastEpoch)
+	logger.Infof("exporting failed attestations statistics lastEpoch: %v firstEpoch: %v", lastEpoch, firstEpoch)
+	ma, err := BigtableClient.GetValidatorFailedAttestationsCount([]uint64{}, firstEpoch, lastEpoch)
 	if err != nil {
 		return err
 	}
@@ -70,7 +70,7 @@ func WriteValidatorStatisticsForDay(day uint64) error {
 			valueArgs = append(valueArgs, stat.Index)
 			valueArgs = append(valueArgs, day)
 			valueArgs = append(valueArgs, stat.MissedAttestations)
-			valueArgs = append(valueArgs, 0)
+			valueArgs = append(valueArgs, stat.OrphanedAttestations)
 		}
 		stmt := fmt.Sprintf(`
 		insert into validator_stats (validatorindex, day, missed_attestations, orphaned_attestations) VALUES
@@ -82,7 +82,7 @@ func WriteValidatorStatisticsForDay(day uint64) error {
 			return err
 		}
 
-		logger.Infof("saving missed attestations batch %v completed", b)
+		logger.Infof("saving failed attestations batch %v completed", b)
 	}
 
 	logger.Infof("export completed, took %v", time.Since(start))
@@ -533,7 +533,7 @@ func WriteValidatorStatisticsForDay(day uint64) error {
 			valueArgs = append(valueArgs, day)
 			valueArgs = append(valueArgs, stat.ParticipatedSync)
 			valueArgs = append(valueArgs, stat.MissedSync)
-			valueArgs = append(valueArgs, 0)
+			valueArgs = append(valueArgs, stat.OrphanedSync)
 		}
 		stmt := fmt.Sprintf(`
 		insert into validator_stats (validatorindex, day, participated_sync, missed_sync, orphaned_sync)  VALUES

--- a/db/statistics.go
+++ b/db/statistics.go
@@ -49,7 +49,7 @@ func WriteValidatorStatisticsForDay(day uint64) error {
 	if err != nil {
 		return err
 	}
-	maArr := make([]*types.ValidatorMissedAttestationsStatistic, 0, len(ma))
+	maArr := make([]*types.ValidatorFailedAttestationsStatistic, 0, len(ma))
 	for _, stat := range ma {
 		maArr = append(maArr, stat)
 	}

--- a/handlers/common.go
+++ b/handlers/common.go
@@ -200,7 +200,7 @@ func GetValidatorEarnings(validators []uint64, currency string) (*types.Validato
 
 	validatorProposalData.BlocksCount = uint64(len(proposals))
 	if validatorProposalData.BlocksCount > 0 {
-		validatorProposalData.UnmissedBlocksPercentage = float64(validatorProposalData.BlocksCount-validatorProposalData.MissedBlocksCount-validatorProposalData.OrphanedBlocksCount) / float64(len(proposals))
+		validatorProposalData.UnmissedBlocksPercentage = float64(validatorProposalData.BlocksCount-validatorProposalData.MissedBlocksCount-validatorProposalData.OrphanedBlocksCount) / float64(validatorProposalData.BlocksCount)
 	} else {
 		validatorProposalData.UnmissedBlocksPercentage = 1.0
 	}

--- a/handlers/validator.go
+++ b/handlers/validator.go
@@ -587,11 +587,21 @@ func Validator(w http.ResponseWriter, r *http.Request) {
 			lookback := int64(lastFinalizedEpoch - (lastStatsDay+1)*utils.EpochsPerDay())
 			if lookback > 0 {
 				// logger.Infof("retrieving attestations not yet in stats, lookback is %v", lookback)
-				missedAttestations, err := db.BigtableClient.GetValidatorMissedAttestationHistory([]uint64{index}, lastFinalizedEpoch-uint64(lookback), lastFinalizedEpoch)
+				attestations, err := db.BigtableClient.GetValidatorFailedAttestationHistory([]uint64{index}, lastFinalizedEpoch-uint64(lookback), lastFinalizedEpoch)
 				if err != nil {
 					return fmt.Errorf("error retrieving validator attestations not in stats from bigtable: %v", err)
 				}
-				attestationStats.MissedAttestations += uint64(len(missedAttestations[index]))
+				missed := uint64(0)
+				orphaned := uint64(0)
+				for _, state := range attestations[index] {
+					if state == 3 {
+						orphaned++
+					} else {
+						missed++
+					}
+				}
+				attestationStats.MissedAttestations += missed
+				attestationStats.OrphanedAttestations += orphaned
 
 			}
 

--- a/handlers/validator.go
+++ b/handlers/validator.go
@@ -608,7 +608,7 @@ func Validator(w http.ResponseWriter, r *http.Request) {
 			validatorPageData.MissedAttestationsCount = attestationStats.MissedAttestations
 			validatorPageData.OrphanedAttestationsCount = attestationStats.OrphanedAttestations
 			validatorPageData.ExecutedAttestationsCount = validatorPageData.AttestationsCount - validatorPageData.MissedAttestationsCount - validatorPageData.OrphanedAttestationsCount
-			validatorPageData.UnmissedAttestationsPercentage = float64(validatorPageData.AttestationsCount-validatorPageData.MissedAttestationsCount) / float64(validatorPageData.AttestationsCount)
+			validatorPageData.UnmissedAttestationsPercentage = float64(validatorPageData.ExecutedAttestationsCount) / float64(validatorPageData.AttestationsCount)
 		}
 		return nil
 	})
@@ -736,7 +736,7 @@ func Validator(w http.ResponseWriter, r *http.Request) {
 			validatorPageData.ScheduledSyncCountSlots = syncStats.ScheduledSlots
 			// actual sync duty count and percentage
 			validatorPageData.SyncCount = uint64(len(actualSyncPeriods))
-			validatorPageData.UnmissedSyncPercentage = float64(validatorPageData.ParticipatedSyncCountSlots) / float64(validatorPageData.ParticipatedSyncCountSlots+validatorPageData.MissedSyncCountSlots)
+			validatorPageData.UnmissedSyncPercentage = float64(validatorPageData.ParticipatedSyncCountSlots) / float64(validatorPageData.ParticipatedSyncCountSlots+validatorPageData.MissedSyncCountSlots+validatorPageData.OrphanedSyncCountSlots)
 		}
 		// sync luck
 		if len(allSyncPeriods) > 0 {

--- a/types/bigtable.go
+++ b/types/bigtable.go
@@ -17,7 +17,7 @@ type ValidatorBalanceStatistic struct {
 	EndBalance            uint64
 }
 
-type ValidatorMissedAttestationsStatistic struct {
+type ValidatorFailedAttestationsStatistic struct {
 	Index                uint64
 	MissedAttestations   uint64
 	OrphanedAttestations uint64

--- a/types/bigtable.go
+++ b/types/bigtable.go
@@ -18,14 +18,16 @@ type ValidatorBalanceStatistic struct {
 }
 
 type ValidatorMissedAttestationsStatistic struct {
-	Index              uint64
-	MissedAttestations uint64
+	Index                uint64
+	MissedAttestations   uint64
+	OrphanedAttestations uint64
 }
 
 type ValidatorSyncDutiesStatistic struct {
 	Index            uint64
 	ParticipatedSync uint64
 	MissedSync       uint64
+	OrphanedSync     uint64
 }
 
 type ValidatorWithdrawal struct {


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8e216d4</samp>

This pull request adds a new feature to update and display the orphaned statistics for sync and attestations in the eth2-beaconchain-explorer. It modifies the `db`, `types`, and `handlers` packages to query, store, and show the orphaned slots, blocks, and duties for validators. It also improves the accuracy of the failed attestations metric by distinguishing between missed and orphaned cases. It affects the files `cmd/misc/main.go`, `db/bigtable.go`, `db/statistics.go`, `types/bigtable.go`, `db/db.go`, and `handlers/validator.go`.
