### PR TITLE
BIDS-2157/Fix PoolInfos out of range

### DIFF
--- a/services/charts_updater.go
+++ b/services/charts_updater.go
@@ -969,7 +969,12 @@ func poolsDistributionChartData() (*types.GenericChartData, error) {
 		Drilldown string `json:"drilldown"`
 	}
 
-	poolData := LatestPoolsPageData().PoolInfos[1:]
+	poolData := []*types.PoolInfo{}
+	poolInfos := LatestPoolsPageData().PoolInfos
+
+	if len(poolInfos) > 1 {
+		poolData = poolInfos[1:]
+	}
 
 	seriesData := make([]seriesDataItem, 0, len(poolData))
 

--- a/services/charts_updater.go
+++ b/services/charts_updater.go
@@ -969,11 +969,9 @@ func poolsDistributionChartData() (*types.GenericChartData, error) {
 		Drilldown string `json:"drilldown"`
 	}
 
-	poolData := []*types.PoolInfo{}
-	poolInfos := LatestPoolsPageData().PoolInfos
-
-	if len(poolInfos) > 1 {
-		poolData = poolInfos[1:]
+	poolData := LatestPoolsPageData().PoolInfos
+	if len(poolData) > 1 {
+		poolData = poolData[1:]
 	}
 
 	seriesData := make([]seriesDataItem, 0, len(poolData))


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a456815</samp>

Fix index out of range error in `charts_updater.go`. Ensure `poolData` slice has a valid length for the charts updater service.
