### PR TITLE
(BIDS-2163) fix deposit, withdrawal range for statistics

### DIFF
--- a/db/statistics.go
+++ b/db/statistics.go
@@ -26,6 +26,13 @@ func WriteValidatorStatisticsForDay(day uint64) error {
 	firstEpoch := day * epochsPerDay
 	lastEpoch := firstEpoch + epochsPerDay - 1
 
+	// for getting the withrawals / deposits for the current day we have to go 1 epoch in the past as they effect the balance one epoch after they have happend
+	firstWithrawDepositEpoch := uint64(0)
+	if firstEpoch > 0 {
+		firstWithrawDepositEpoch = firstEpoch - 1
+	}
+	lastWithdrawDepositEpoch := lastEpoch - 1
+
 	logger.Infof("exporting statistics for day %v (epoch %v to %v)", day, firstEpoch, lastEpoch)
 
 	finalizedCount, err := CountFinalizedEpochs(firstEpoch, lastEpoch)
@@ -38,7 +45,6 @@ func WriteValidatorStatisticsForDay(day uint64) error {
 	}
 
 	start := time.Now()
-
 	tx, err := WriterDb.Beginx()
 	if err != nil {
 		return err
@@ -73,9 +79,9 @@ func WriteValidatorStatisticsForDay(day uint64) error {
 			valueArgs = append(valueArgs, stat.OrphanedAttestations)
 		}
 		stmt := fmt.Sprintf(`
-		insert into validator_stats (validatorindex, day, missed_attestations, orphaned_attestations) VALUES
-		%s
-		on conflict (validatorindex, day) do update set missed_attestations = excluded.missed_attestations, orphaned_attestations = excluded.orphaned_attestations;`,
+			insert into validator_stats (validatorindex, day, missed_attestations, orphaned_attestations) VALUES
+			%s
+			on conflict (validatorindex, day) do update set missed_attestations = excluded.missed_attestations, orphaned_attestations = excluded.orphaned_attestations;`,
 			strings.Join(valueStrings, ","))
 		_, err := tx.Exec(stmt, valueArgs...)
 		if err != nil {
@@ -125,7 +131,7 @@ func WriteValidatorStatisticsForDay(day uint64) error {
 		}
 	}
 
-	_, err = tx.Exec(depositsQry, firstEpoch, lastEpoch, day)
+	_, err = tx.Exec(depositsQry, firstWithrawDepositEpoch, lastWithdrawDepositEpoch, day)
 	if err != nil {
 		return err
 	}
@@ -145,7 +151,7 @@ func WriteValidatorStatisticsForDay(day uint64) error {
 		on conflict (validatorindex, day) do
 			update set withdrawals = excluded.withdrawals, 
 			withdrawals_amount = excluded.withdrawals_amount;`
-	_, err = tx.Exec(withdrawalsQuery, firstEpoch*utils.Config.Chain.Config.SlotsPerEpoch, (lastEpoch+1)*utils.Config.Chain.Config.SlotsPerEpoch, day)
+	_, err = tx.Exec(withdrawalsQuery, firstWithrawDepositEpoch*utils.Config.Chain.Config.SlotsPerEpoch, (lastWithdrawDepositEpoch+1)*utils.Config.Chain.Config.SlotsPerEpoch, day)
 	if err != nil {
 		return err
 	}

--- a/db/statistics.go
+++ b/db/statistics.go
@@ -26,7 +26,7 @@ func WriteValidatorStatisticsForDay(day uint64) error {
 	firstEpoch := day * epochsPerDay
 	lastEpoch := firstEpoch + epochsPerDay - 1
 
-	// for getting the withrawals / deposits for the current day we have to go 1 epoch in the past as they effect the balance one epoch after they have happend
+	// for getting the withrawals / deposits for the current day we have to go 1 epoch in the past as they affect the balance one epoch after they have happend
 	firstWithrawDepositEpoch := uint64(0)
 	if firstEpoch > 0 {
 		firstWithrawDepositEpoch = firstEpoch - 1


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5bf38e1</samp>

Fix validator statistics bug and improve code formatting in `db/statistics.go`. The bug caused incorrect values for deposits and withdrawals for the current day. The formatting changes make the code more readable and consistent.
