### PR TITLE
Update stakingServices.html

### DIFF
--- a/templates/stakingServices.html
+++ b/templates/stakingServices.html
@@ -371,6 +371,20 @@
                     </td>
                   </tr>
                   <tr>
+                    <td data-column="Service"><a href="https://www.chainlabo.com/">ChainLabo</a></td>
+                    <td data-column="No Supermajority client" style="text-align: center;">❌</td>
+                    <td data-column="Validator key owner">User</td>
+                    <td data-column="Withdrawal key owner">User</td>
+                    <td data-column="Pool token">No</td>
+                    <td data-column="3rd Party Software">No</td>
+                    <td data-column="Min. Stake">32 ETH</td>
+                    <td data-column="Fee">0% ETH Fee, service based monthly fiat fee</td>
+                    <td data-column="Open Source">No</td>
+                    <td data-column="Social">
+                      <a href="https://discord.gg/JAhtFdJk" target="_blank"><i class="fab fa-discord ml-1 mr-1"></i></a><a href="https://twitter.com/ChainLabo" target="_blank"><i class="fab fa-twitter ml-1 mr-1"></i></a><a href="https://t.me/chainlabo"><i class="fab fa-telegram ml-1 mr-1"></i></a><a href="mailto:info@chainlabo.com"><i class="fa fa-mail-bulk ml-1 mr-1"></i></a>
+                    </td>
+                  </tr>
+                  <tr>
                     <td data-column="Service"><a href="https://www.coinbase.com/earn/staking/ethereum">Coinbase Exchange</a></td>
                     <td data-column="No Supermajority client" style="text-align: center;">❌</td>
                     <td data-column="Validator key owner">Service</td>


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at aac397a</samp>

Add ChainLabo to the list of staking services in `templates/stakingServices.html`. This change updates the table with a new option for users who want to stake their ETH in the beacon chain.
