### PR TITLE
Bids 1989/validator page replace root hash with cl reward

### DIFF
--- a/db/bigtable.go
+++ b/db/bigtable.go
@@ -1446,10 +1446,24 @@ func (bigtable *Bigtable) GetValidatorIncomeDetailsHistory(validators []uint64, 
 		startEpoch = 0
 	}
 
+	ranges := bigtable.getEpochRanges(startEpoch, endEpoch)
+
+	return bigtable.getValidatorIncomeDetails(validators, ranges)
+}
+
+func (bigtable *Bigtable) GetValidatorIncomeDetailsIndexedMultiple(validators []uint64, epochs []uint64) (map[uint64]map[uint64]*itypes.ValidatorEpochIncome, error) {
+	rowList := gcp_bigtable.RowList{}
+	for _, epoch := range epochs {
+		rowList = append(rowList, fmt.Sprintf("%s:e:b:%s", bigtable.chainId, reversedPaddedEpoch(epoch)))
+	}
+
+	return bigtable.getValidatorIncomeDetails(validators, rowList)
+}
+
+func (bigtable *Bigtable) getValidatorIncomeDetails(validators []uint64, rowSet gcp_bigtable.RowSet) (map[uint64]map[uint64]*itypes.ValidatorEpochIncome, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*180)
 	defer cancel()
 
-	ranges := bigtable.getEpochRanges(startEpoch, endEpoch)
 	res := make(map[uint64]map[uint64]*itypes.ValidatorEpochIncome, len(validators))
 
 	valLen := len(validators)
@@ -1483,7 +1497,7 @@ func (bigtable *Bigtable) GetValidatorIncomeDetailsHistory(validators []uint64, 
 		)
 	}
 
-	err := bigtable.tableBeaconchain.ReadRows(ctx, ranges, func(r gcp_bigtable.Row) bool {
+	err := bigtable.tableBeaconchain.ReadRows(ctx, rowSet, func(r gcp_bigtable.Row) bool {
 		keySplit := strings.Split(r.Key(), ":")
 
 		epoch, err := strconv.ParseUint(keySplit[3], 10, 64)

--- a/templates/validator/tables.html
+++ b/templates/validator/tables.html
@@ -9,7 +9,7 @@
           <th>Time</th>
           <th>Status</th>
           <th>Proposer Reward (EL)</th>
-          <th>Root Hash</th>
+          <th>Consensus Reward (CL)</th>
           <th>Proposer Reward Recipient</th>
           <th>Graffiti</th>
         </tr>
@@ -627,7 +627,7 @@
     <table class="table" style="margin-top: 0 !important" width="100%">
       <tbody style="font-size: 0.875rem;">
         <tr>
-          <th scope="style-table-header"  style="border-top: 0" scope="row">Total Rewards</th>
+          <th scope="style-table-header" style="border-top: 0" scope="row">Total Rewards</th>
           <td class="style-table-data pl-0" style="border-top: 0">
             {{ .IncomeTotalFormatted }}
           </td>

--- a/templates/validator/tables.html
+++ b/templates/validator/tables.html
@@ -9,7 +9,7 @@
           <th>Time</th>
           <th>Status</th>
           <th>Proposer Reward (EL)</th>
-          <th>Consensus Reward (CL)</th>
+          <th>Proposer Reward (CL)</th>
           <th>Proposer Reward Recipient</th>
           <th>Graffiti</th>
         </tr>


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7ba6e40</samp>

This pull request improves the performance and accuracy of querying validator income data from bigtable, and displays the proposer reward for each block proposed by a validator in the validator details page. It also removes an unused field and fixes a visual bug in the templates.
