### PR TITLE
(BIDS-1695) Don't show historical value on testnets

### DIFF
--- a/db/frontend.go
+++ b/db/frontend.go
@@ -520,7 +520,11 @@ func getMachineStatsGap(resultCount uint64) int {
 	return 1
 }
 
-func GetHistoricPrice(currency string, day uint64) (float64, error) {
+func GetHistoricalPrice(chainId uint64, currency string, day uint64) (float64, error) {
+	if chainId != 1 {
+		// Don't show a historical price for testnets
+		return 0.0, nil
+	}
 	if currency == "ETH" {
 		currency = "USD"
 	}

--- a/handlers/eth1tx.go
+++ b/handlers/eth1tx.go
@@ -88,18 +88,18 @@ func Eth1TransactionTx(w http.ResponseWriter, r *http.Request) {
 				logrus.Error(err)
 			}
 
-			txData.HistoricEtherPrice = ""
+			txData.HistoricalEtherPrice = ""
 			currentDay := latestEpoch / utils.EpochsPerDay()
 
 			if txDay < currentDay {
-				// Do not show the historic price if it is the current day
-				price, err := db.GetHistoricPrice(GetCurrency(r), txDay)
+				// Do not show the historical price if it is the current day
+				price, err := db.GetHistoricalPrice(utils.Config.Chain.Config.DepositChainID, GetCurrency(r), txDay)
 				if err != nil {
-					logrus.Errorf("error retrieving historic prices %v", err)
+					logrus.Errorf("error retrieving historical prices %v", err)
 				} else {
-					historicEthPrice := new(big.Float).Mul(etherValue, big.NewFloat(price))
-					hPrice, _ := historicEthPrice.Float64()
-					txData.HistoricEtherPrice = template.HTML(p.Sprintf(`<span>%s%.2f <i class="far fa-clock"></i></span>`, symbol, hPrice))
+					historicalEthPrice := new(big.Float).Mul(etherValue, big.NewFloat(price))
+					hPrice, _ := historicalEthPrice.Float64()
+					txData.HistoricalEtherPrice = template.HTML(p.Sprintf(`<span>%s%.2f <i class="far fa-clock"></i></span>`, symbol, hPrice))
 				}
 			}
 

--- a/templates/eth1tx.html
+++ b/templates/eth1tx.html
@@ -216,7 +216,7 @@
                 <div class="col-md-3">Value:</div>
                 <div class="col-md-9">
                   {{ formatBytesAmount .Value "Ether" 8 }}
-                  <span id="valuePriceButton" class="badge badge-pill align-middle bg-dark text-white" data-html="true" data-toggle="tooltip" data-placement="bottom" data-original-title="Current Value" {{ if .HistoricEtherPrice }}onclick="togglePriceContent('{{ .CurrentEtherPrice }}','{{ .HistoricEtherPrice }}')" style="cursor: pointer;"{{ end }}>
+                  <span id="valuePriceButton" class="badge badge-pill align-middle bg-dark text-white" data-html="true" data-toggle="tooltip" data-placement="bottom" data-original-title="Current Value" {{ if .HistoricalEtherPrice }}onclick="togglePriceContent('{{ .CurrentEtherPrice }}','{{ .HistoricalEtherPrice }}')" style="cursor: pointer;"{{ end }}>
                     {{ .CurrentEtherPrice }}
                   </span>
                 </div>

--- a/types/templates.go
+++ b/types/templates.go
@@ -1708,7 +1708,7 @@ type Eth1TxData struct {
 	Transfers                   []*Transfer
 	DepositContractInteractions []DepositContractInteraction
 	CurrentEtherPrice           template.HTML
-	HistoricEtherPrice          template.HTML
+	HistoricalEtherPrice        template.HTML
 }
 
 type Eth1EventData struct {


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0419587</samp>

Renamed `GetHistoricPrice` to `GetHistoricalPrice` and added `chainId` parameter to support different deposit contract chains. Updated `Eth1TxData` type, `eth1tx.html` template, and `Eth1TransactionTx` handler to use the new function and field names. The purpose was to improve the accuracy and clarity of the eth1 transaction data on the explorer.
