### PR TITLE
(BIDS-2061) Change bigtable query to include start epoch

### DIFF
--- a/db/bigtable.go
+++ b/db/bigtable.go
@@ -1702,21 +1702,21 @@ func (bigtable *Bigtable) getSlotRanges(startEpoch uint64, endEpoch uint64) gcp_
 
 	ranges := gcp_bigtable.RowRangeList{}
 	if startEpoch == 0 { // special case when the 0 epoch is included
-		rangeEnd := fmt.Sprintf("%s:e:%s:s:%s", bigtable.chainId, reversedPaddedEpoch(0), "A")
+		rangeEnd := fmt.Sprintf("%s:e:%s:s:%s", bigtable.chainId, reversedPaddedEpoch(0), ":")
 		rangeStart := fmt.Sprintf("%s:e:%s:s:", bigtable.chainId, reversedPaddedEpoch(0))
 		ranges = append(ranges, gcp_bigtable.NewRange(rangeStart, rangeEnd))
 
 		// epochs are sorted descending, so start with the larges epoch and end with the smallest
-		// add 'A', a character lexicographically after digits, to make the range inclusive
+		// add ':', a character lexicographically after digits, to make the range inclusive
 		if startEpoch < endEpoch {
-			rangeEnd = fmt.Sprintf("%s:e:%s:s:%s", bigtable.chainId, reversedPaddedEpoch(startEpoch+1), "A")
+			rangeEnd = fmt.Sprintf("%s:e:%s:s:%s", bigtable.chainId, reversedPaddedEpoch(startEpoch+1), ":")
 			rangeStart = fmt.Sprintf("%s:e:%s:s:", bigtable.chainId, reversedPaddedEpoch(endEpoch))
 			ranges = append(ranges, gcp_bigtable.NewRange(rangeStart, rangeEnd))
 		}
 	} else {
 		// epochs are sorted descending, so start with the larges epoch and end with the smallest
-		// add 'A', a character lexicographically after digits, to make the range inclusive
-		rangeEnd := fmt.Sprintf("%s:e:%s:s:%s", bigtable.chainId, reversedPaddedEpoch(startEpoch), "A")
+		// add ':', a character lexicographically after digits, to make the range inclusive
+		rangeEnd := fmt.Sprintf("%s:e:%s:s:%s", bigtable.chainId, reversedPaddedEpoch(startEpoch), ":")
 		rangeStart := fmt.Sprintf("%s:e:%s:s:", bigtable.chainId, reversedPaddedEpoch(endEpoch))
 		ranges = append(ranges, gcp_bigtable.NewRange(rangeStart, rangeEnd))
 	}

--- a/db/bigtable.go
+++ b/db/bigtable.go
@@ -1122,7 +1122,7 @@ func (bigtable *Bigtable) GetValidatorSyncDutiesStatistics(validators []uint64, 
 
 // returns the validator attestation effectiveness in %
 func (bigtable *Bigtable) GetValidatorEffectiveness(validators []uint64, epoch uint64) ([]*types.ValidatorEffectiveness, error) {
-	data, err := bigtable.GetValidatorAttestationHistory(validators, epoch-100, epoch)
+	data, err := bigtable.GetValidatorAttestationHistory(validators, epoch-99, epoch)
 
 	if err != nil {
 		return nil, err
@@ -1702,25 +1702,21 @@ func (bigtable *Bigtable) getSlotRanges(startEpoch uint64, endEpoch uint64) gcp_
 
 	ranges := gcp_bigtable.RowRangeList{}
 	if startEpoch == 0 { // special case when the 0 epoch is included
-		rangeEnd := fmt.Sprintf("%s:e:%s:s:%s", bigtable.chainId, reversedPaddedEpoch(0), "\x00")
+		rangeEnd := fmt.Sprintf("%s:e:%s:s:%s", bigtable.chainId, reversedPaddedEpoch(0), "A")
 		rangeStart := fmt.Sprintf("%s:e:%s:s:", bigtable.chainId, reversedPaddedEpoch(0))
 		ranges = append(ranges, gcp_bigtable.NewRange(rangeStart, rangeEnd))
 
 		// epochs are sorted descending, so start with the larges epoch and end with the smallest
-		// add \x00 to make the range inclusive
+		// add 'A', a character lexicographically after digits, to make the range inclusive
 		if startEpoch < endEpoch {
-			rangeEnd = fmt.Sprintf("%s:e:%s:s:%s", bigtable.chainId, reversedPaddedEpoch(startEpoch+1), "\x00")
+			rangeEnd = fmt.Sprintf("%s:e:%s:s:%s", bigtable.chainId, reversedPaddedEpoch(startEpoch+1), "A")
 			rangeStart = fmt.Sprintf("%s:e:%s:s:", bigtable.chainId, reversedPaddedEpoch(endEpoch))
 			ranges = append(ranges, gcp_bigtable.NewRange(rangeStart, rangeEnd))
 		}
-	} else if startEpoch == endEpoch { // special case, only retrieve data for one epoch
-		rangeEnd := fmt.Sprintf("%s:e:%s:s:", bigtable.chainId, reversedPaddedEpoch(startEpoch-1))
-		rangeStart := fmt.Sprintf("%s:e:%s:s:", bigtable.chainId, reversedPaddedEpoch(startEpoch))
-		ranges = append(ranges, gcp_bigtable.NewRange(rangeStart, rangeEnd))
 	} else {
 		// epochs are sorted descending, so start with the larges epoch and end with the smallest
-		// add \x00 to make the range inclusive
-		rangeEnd := fmt.Sprintf("%s:e:%s:s:%s", bigtable.chainId, reversedPaddedEpoch(startEpoch), "\x00")
+		// add 'A', a character lexicographically after digits, to make the range inclusive
+		rangeEnd := fmt.Sprintf("%s:e:%s:s:%s", bigtable.chainId, reversedPaddedEpoch(startEpoch), "A")
 		rangeStart := fmt.Sprintf("%s:e:%s:s:", bigtable.chainId, reversedPaddedEpoch(endEpoch))
 		ranges = append(ranges, gcp_bigtable.NewRange(rangeStart, rangeEnd))
 	}

--- a/db/statistics.go
+++ b/db/statistics.go
@@ -507,7 +507,7 @@ func WriteValidatorStatisticsForDay(day uint64) error {
 	start = time.Now()
 
 	logger.Infof("exporting sync statistics")
-	syncStats, err := BigtableClient.GetValidatorSyncDutiesStatistics([]uint64{}, firstEpoch, lastEpoch) //+1 is needed because the function uses limit instead of end epoch
+	syncStats, err := BigtableClient.GetValidatorSyncDutiesStatistics([]uint64{}, firstEpoch, lastEpoch)
 	if err != nil {
 		return err
 	}

--- a/handlers/api.go
+++ b/handlers/api.go
@@ -1162,7 +1162,7 @@ func getSyncCommitteeSlotsStatistics(validators []uint64, epoch uint64) (types.S
 			}
 
 			// get sync stats from bigtable
-			res, err := db.BigtableClient.GetValidatorSyncDutiesHistory(vs, lastExportedEpoch, epoch)
+			res, err := db.BigtableClient.GetValidatorSyncDutiesHistory(vs, lastExportedEpoch+1, epoch)
 			if err != nil {
 				return retv, fmt.Errorf("error retrieving validator sync participations data from bigtable: %v", err)
 			}
@@ -2340,7 +2340,7 @@ func ApiValidatorAttestations(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	history, err := db.BigtableClient.GetValidatorAttestationHistory(queryIndices, services.LatestEpoch()-101, services.LatestEpoch())
+	history, err := db.BigtableClient.GetValidatorAttestationHistory(queryIndices, services.LatestEpoch()-100, services.LatestEpoch())
 	if err != nil {
 		sendErrorResponse(w, r.URL.String(), "could not retrieve db results")
 		return

--- a/handlers/api.go
+++ b/handlers/api.go
@@ -2319,7 +2319,7 @@ func ApiValidatorDeposits(w http.ResponseWriter, r *http.Request) {
 }
 
 // ApiValidatorAttestations godoc
-// @Summary Get all attestations during the last 10 epochs for up to 100 validators
+// @Summary Get all attestations during the last 100 epochs for up to 100 validators
 // @Tags Validator
 // @Produce  json
 // @Param  indexOrPubkey path string true "Up to 100 validator indicesOrPubkeys, comma separated"
@@ -2340,13 +2340,13 @@ func ApiValidatorAttestations(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	history, err := db.BigtableClient.GetValidatorAttestationHistory(queryIndices, services.LatestEpoch()-100, services.LatestEpoch())
+	history, err := db.BigtableClient.GetValidatorAttestationHistory(queryIndices, services.LatestEpoch()-99, services.LatestEpoch())
 	if err != nil {
 		sendErrorResponse(w, r.URL.String(), "could not retrieve db results")
 		return
 	}
 
-	responseData := make([]*types.ApiValidatorAttestationsResponse, 0, len(history)*101)
+	responseData := make([]*types.ApiValidatorAttestationsResponse, 0, len(history)*100)
 
 	epochsPerWeek := utils.EpochsPerDay() * 7
 	for validatorIndex, balances := range history {

--- a/handlers/validator.go
+++ b/handlers/validator.go
@@ -706,8 +706,7 @@ func Validator(w http.ResponseWriter, r *http.Request) {
 			lastExportedEpoch := (lastStatsDay+1)*utils.EpochsPerDay() - 1
 			lastSyncPeriod := actualSyncPeriods[0]
 			if lastSyncPeriod.LastEpoch > lastExportedEpoch {
-				lookback := int64(latestEpoch - lastExportedEpoch - 1)
-				res, err := db.BigtableClient.GetValidatorSyncDutiesHistory([]uint64{index}, latestEpoch-uint64(lookback), latestEpoch)
+				res, err := db.BigtableClient.GetValidatorSyncDutiesHistory([]uint64{index}, lastExportedEpoch+1, latestEpoch)
 				if err != nil {
 					return fmt.Errorf("error retrieving validator sync participations data from bigtable: %v", err)
 				}

--- a/services/notifications.go
+++ b/services/notifications.go
@@ -1370,8 +1370,8 @@ func collectAttestationAndOfflineValidatorNotifications(notificationsByUserID ma
 		EventFilter    []byte `db:"pubkey"`
 	}
 
-	// get attestations for all validators for the last n epochs
-	attestations, err := db.BigtableClient.GetValidatorAttestationHistory([]uint64{}, epoch-4, epoch) // retrieve attestation data of the last 3 epochs
+	// get attestations for all validators for the last 4 epochs
+	attestations, err := db.BigtableClient.GetValidatorAttestationHistory([]uint64{}, epoch-3, epoch)
 	if err != nil {
 		return fmt.Errorf("error getting validator attestations from bigtable %w", err)
 	}


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 233825d</samp>

This pull request fixes several bugs related to querying Bigtable data for validator attestation and sync duties. The bugs caused some data to be inaccurate, missing, or duplicated in the API and the notification service. The changes affect the files `db/bigtable.go`, `handlers/api.go`, `handlers/validator.go`, `db/statistics.go`, and `services/notifications.go`.
