### PR TITLE
(BIDS-1694) method label replace regexp

### DIFF
--- a/db/bigtable_eth1.go
+++ b/db/bigtable_eth1.go
@@ -3449,7 +3449,7 @@ func (bigtable *Bigtable) GetMethodLabel(id []byte, invokesContract bool) string
 				sig, err := bigtable.GetSignature(method, types.MethodSignature)
 				if err == nil {
 					if sig != nil {
-						method = utils.RemoveAllBrackets(*sig)
+						method = utils.RemoveRoundBracketsIncludingContent(*sig)
 					}
 					cache.TieredCache.Set(cacheKey, method, time.Hour)
 				}

--- a/db/bigtable_eth1.go
+++ b/db/bigtable_eth1.go
@@ -16,7 +16,6 @@ import (
 	"fmt"
 	"log"
 	"math/big"
-	"regexp"
 	"sort"
 	"strings"
 	"sync"
@@ -3446,12 +3445,11 @@ func (bigtable *Bigtable) GetMethodLabel(id []byte, invokesContract bool) string
 		if invokesContract {
 			method = fmt.Sprintf("0x%x", id)
 			cacheKey := fmt.Sprintf("M:H2L:%s", method)
-			if _, err := cache.TieredCache.GetWithLocalTimeout(cacheKey, time.Hour, &method); err != nil {
+			if _, err := cache.TieredCache.GetWithLocalTimeout(cacheKey+"x", time.Hour, &method); err != nil {
 				sig, err := bigtable.GetSignature(method, types.MethodSignature)
 				if err == nil {
 					if sig != nil {
-						reg := regexp.MustCompile(`\((?:[^)(]+|\((?:[^)(]+|\([^)(]*\))*\))*\)`)
-						method = reg.ReplaceAllString(*sig, "")
+						method = utils.RemoveAllBrackets(*sig)
 					}
 					cache.TieredCache.Set(cacheKey, method, time.Hour)
 				}

--- a/db/bigtable_eth1.go
+++ b/db/bigtable_eth1.go
@@ -3445,7 +3445,7 @@ func (bigtable *Bigtable) GetMethodLabel(id []byte, invokesContract bool) string
 		if invokesContract {
 			method = fmt.Sprintf("0x%x", id)
 			cacheKey := fmt.Sprintf("M:H2L:%s", method)
-			if _, err := cache.TieredCache.GetWithLocalTimeout(cacheKey+"x", time.Hour, &method); err != nil {
+			if _, err := cache.TieredCache.GetWithLocalTimeout(cacheKey, time.Hour, &method); err != nil {
 				sig, err := bigtable.GetSignature(method, types.MethodSignature)
 				if err == nil {
 					if sig != nil {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1271,3 +1271,29 @@ func AddSyncStats(validators []uint64, syncDutiesHistory map[uint64][]*types.Val
 	}
 	return *stats
 }
+
+func RemoveAllBrackets(input string) string {
+	openCount := 0
+	result := ""
+	for {
+		if len(input) == 0 {
+			break
+		}
+		openIndex := strings.Index(input, "(")
+		closeIndex := strings.Index(input, ")")
+		if openIndex == -1 && closeIndex == -1 {
+			result += input
+			break
+		} else if openIndex != -1 && openIndex < closeIndex {
+			openCount++
+			if openCount == 1 {
+				result += input[:openIndex]
+			}
+			input = input[openIndex+1:]
+		} else {
+			openCount--
+			input = input[closeIndex+1:]
+		}
+	}
+	return result
+}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1272,7 +1272,8 @@ func AddSyncStats(validators []uint64, syncDutiesHistory map[uint64][]*types.Val
 	return *stats
 }
 
-func RemoveAllBrackets(input string) string {
+// To remove all round brackets (including its content) from a string
+func RemoveRoundBracketsIncludingContent(input string) string {
 	openCount := 0
 	result := ""
 	for {
@@ -1282,7 +1283,9 @@ func RemoveAllBrackets(input string) string {
 		openIndex := strings.Index(input, "(")
 		closeIndex := strings.Index(input, ")")
 		if openIndex == -1 && closeIndex == -1 {
-			result += input
+			if openCount == 0 {
+				result += input
+			}
 			break
 		} else if openIndex != -1 && (openIndex < closeIndex || closeIndex == -1) {
 			openCount++
@@ -1291,7 +1294,11 @@ func RemoveAllBrackets(input string) string {
 			}
 			input = input[openIndex+1:]
 		} else {
-			openCount--
+			if openCount > 0 {
+				openCount--
+			} else if openIndex == -1 && len(result) == 0 {
+				result += input[:closeIndex]
+			}
 			input = input[closeIndex+1:]
 		}
 	}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1284,7 +1284,7 @@ func RemoveAllBrackets(input string) string {
 		if openIndex == -1 && closeIndex == -1 {
 			result += input
 			break
-		} else if openIndex != -1 && openIndex < closeIndex {
+		} else if openIndex != -1 && (openIndex < closeIndex || closeIndex == -1) {
 			openCount++
 			if openCount == 1 {
 				result += input[:openIndex]


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7a39fc4</samp>

Improved method name extraction from eth1 logs and added a utility function to remove brackets from signatures. These changes enhanced the `db` and `utils` packages and supported the eth2 beacon chain explorer functionality.
