### PR TITLE
Nobids/fix false posivive monitoring

### DIFF
--- a/db/bigtable_eth1.go
+++ b/db/bigtable_eth1.go
@@ -156,7 +156,7 @@ func (bigtable *Bigtable) SaveBlocks(block *types.Eth1Block) error {
 
 func (bigtable *Bigtable) GetBlockFromBlocksTable(number uint64) (*types.Eth1Block, error) {
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
 	defer cancel()
 
 	paddedNumber := reversedPaddedBlockNumber(number)

--- a/services/monitoring.go
+++ b/services/monitoring.go
@@ -249,7 +249,7 @@ func startServicesMonitoringService() {
 		"statsUpdater":                  time.Minute * 30,
 		"poolsUpdater":                  time.Minute * 30,
 		"epochExporter":                 time.Minute * 15,
-		"statistics":                    time.Minute * 15,
+		"statistics":                    time.Minute * 90,
 		"lastBlockInBlocksTableUpdater": time.Minute * 10,
 		//"notification-sender", //exclude for now as the sender is only running on mainnet
 		//"poolInfoUpdater":  time.Minute * 30,


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8abf1cc</samp>

Increased timeouts and intervals for Bigtable operations in `db/bigtable_eth1.go` and `services/monitoring.go`. This improves the reliability and performance of the eth2-beaconchain-explorer service when querying the Bigtable.
