### PR TITLE
(NOBIDS) make service monitoring configurable

### DIFF
--- a/services/monitoring.go
+++ b/services/monitoring.go
@@ -255,8 +255,13 @@ func startServicesMonitoringService() {
 		//"poolInfoUpdater":  time.Minute * 30,
 	}
 
-	if utils.Config.ServiceMonitoringConfiguration != nil {
-		servicesToCheck = utils.Config.ServiceMonitoringConfiguration
+	if utils.Config.ServiceMonitoringConfigurations != nil {
+
+		servicesToCheck = make(map[string]time.Duration)
+
+		for _, service := range utils.Config.ServiceMonitoringConfigurations {
+			servicesToCheck[service.Name] = service.Duration
+		}
 	}
 
 	for {

--- a/services/monitoring.go
+++ b/services/monitoring.go
@@ -255,6 +255,10 @@ func startServicesMonitoringService() {
 		//"poolInfoUpdater":  time.Minute * 30,
 	}
 
+	if utils.Config.ServiceMonitoringConfiguration != nil {
+		servicesToCheck = utils.Config.ServiceMonitoringConfiguration
+	}
+
 	for {
 		if !firstRun {
 			time.Sleep(time.Minute)

--- a/services/monitoring.go
+++ b/services/monitoring.go
@@ -256,11 +256,12 @@ func startServicesMonitoringService() {
 	}
 
 	if utils.Config.ServiceMonitoringConfigurations != nil {
-
-		servicesToCheck = make(map[string]time.Duration)
-
 		for _, service := range utils.Config.ServiceMonitoringConfigurations {
-			servicesToCheck[service.Name] = service.Duration
+			if service.Duration == 0 {
+				delete(servicesToCheck, service.Name)
+			} else {
+				servicesToCheck[service.Name] = service.Duration
+			}
 		}
 	}
 

--- a/types/config.go
+++ b/types/config.go
@@ -183,6 +183,7 @@ type Config struct {
 		ElEndpoint string `yaml:"elEndpoint" envconfig:"NODE_JOBS_PROCESSOR_EL_ENDPOINT"`
 		ClEndpoint string `yaml:"clEndpoint" envconfig:"NODE_JOBS_PROCESSOR_CL_ENDPOINT"`
 	} `yaml:"nodeJobsProcessor"`
+	ServiceMonitoringConfiguration map[string]time.Duration `yaml:"serviceMonitoringConfiguration" envconfig:"SERVICE_MONITORING_CONFIGURATION"`
 }
 
 type DatabaseConfig struct {

--- a/types/config.go
+++ b/types/config.go
@@ -183,7 +183,7 @@ type Config struct {
 		ElEndpoint string `yaml:"elEndpoint" envconfig:"NODE_JOBS_PROCESSOR_EL_ENDPOINT"`
 		ClEndpoint string `yaml:"clEndpoint" envconfig:"NODE_JOBS_PROCESSOR_CL_ENDPOINT"`
 	} `yaml:"nodeJobsProcessor"`
-	ServiceMonitoringConfiguration map[string]time.Duration `yaml:"serviceMonitoringConfiguration" envconfig:"SERVICE_MONITORING_CONFIGURATION"`
+	ServiceMonitoringConfigurations []ServiceMonitoringConfiguration `yaml:"serviceMonitoringConfigurations" envconfig:"SERVICE_MONITORING_CONFIGURATIONS"`
 }
 
 type DatabaseConfig struct {
@@ -192,4 +192,9 @@ type DatabaseConfig struct {
 	Name     string
 	Host     string
 	Port     string
+}
+
+type ServiceMonitoringConfiguration struct {
+	Name     string        `yaml:"name" envconfig:"NAME"`
+	Duration time.Duration `yaml:"duration" envconfig:"DURATION"`
 }


### PR DESCRIPTION
Makes the service monitoring configurable by adding a `serviceMonitoringConfigurations` to the main config file

Example config:

```
serviceMonitoringConfigurations:
  - name: "eth1indexer"
    duration: "15m"
  - name: "eth1indexer"
    duration: "15m"
  - name: "slotUpdater"
    duration: "15m"
  - name: "latestProposedSlotUpdater"
    duration: "15m"
  - name: "epochUpdater"
    duration: "15m"
  - name: "rewardsExporter"
    duration: "15m"
  - name: "mempoolUpdater"
    duration: "15m"
  - name: "indexPageDataUpdater"
    duration: "15m"
  - name: "latestBlockUpdater"
    duration: "15m"
  - name: "notification-collector"
    duration: "15m"
  - name: "relaysUpdater"
    duration: "15m"
  - name: "ethstoreExporter"
    duration: "30m"
  - name: "statsUpdater"
    duration: "30m"
  - name: "poolsUpdater"
    duration: "30m"
  - name: "epochExporter"
    duration: "15m"
  - name: "statistics"
    duration: "90m"
  - name: "lastBlockInBlocksTableUpdater"
    duration: "10m"
```
If not set, the defaults as written above are used.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8780d4b</samp>

Added support for custom service monitoring configuration in `services/monitoring.go` and `types/config.go`. This allows users to specify which services to monitor and how often to check their status.
