### PR TITLE
(NOBIDS) only update last attestation slot for validators that are on…

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -1165,7 +1165,7 @@ func saveValidators(data *types.EpochData, tx *sqlx.Tx, client rpc.Client) error
 			}
 
 			if c.LastAttestationSlot != v.LastAttestationSlot && v.LastAttestationSlot.Valid && c.LastAttestationSlot.Int64 < v.LastAttestationSlot.Int64 {
-				logger.Infof("LastAttestationSlot changed for validator %v from %v to %v", v.Index, c.LastAttestationSlot.Int64, v.LastAttestationSlot.Int64)
+				// logger.Infof("LastAttestationSlot changed for validator %v from %v to %v", v.Index, c.LastAttestationSlot.Int64, v.LastAttestationSlot.Int64)
 
 				// queries.WriteString(fmt.Sprintf("UPDATE validators SET lastattestationslot = %d WHERE validatorindex = %d;\n", v.LastAttestationSlot.Int64, c.Index))
 				// updates++

--- a/db/db.go
+++ b/db/db.go
@@ -1164,8 +1164,8 @@ func saveValidators(data *types.EpochData, tx *sqlx.Tx, client rpc.Client) error
 				v.Status = "active_online"
 			}
 
-			if c.LastAttestationSlot != v.LastAttestationSlot && v.LastAttestationSlot.Valid {
-				// logger.Infof("LastAttestationSlot changed for validator %v from %v to %v", v.Index, c.LastAttestationSlot.Int64, v.LastAttestationSlot.Int64)
+			if c.LastAttestationSlot != v.LastAttestationSlot && v.LastAttestationSlot.Valid && c.LastAttestationSlot.Int64 < v.LastAttestationSlot.Int64 {
+				logger.Infof("LastAttestationSlot changed for validator %v from %v to %v", v.Index, c.LastAttestationSlot.Int64, v.LastAttestationSlot.Int64)
 
 				// queries.WriteString(fmt.Sprintf("UPDATE validators SET lastattestationslot = %d WHERE validatorindex = %d;\n", v.LastAttestationSlot.Int64, c.Index))
 				// updates++
@@ -1234,42 +1234,29 @@ func saveValidators(data *types.EpochData, tx *sqlx.Tx, client rpc.Client) error
 		logger.Infof("update completed, took %v", time.Since(updateStart))
 	}
 
-	batchSize := 30000 // max parameters: 65535
-	for b := 0; b < len(validatorLastAttestationSlotUpdate); b += batchSize {
-		start := b
-		end := b + batchSize
-		if len(validatorLastAttestationSlotUpdate) < end {
-			end = len(validatorLastAttestationSlotUpdate)
-		}
+	logger.Infof("updating the last attestation slot for %v validators", len(validatorLastAttestationSlotUpdate))
+	s := time.Now()
+	validatorIndexArray := make([]int64, 0, len(validatorLastAttestationSlotUpdate))
+	lastAttestationSlotArray := make([]int64, 0, len(validatorLastAttestationSlotUpdate))
 
-		numArgs := 2
-		valueStrings := make([]string, 0, batchSize)
-		valueArgs := make([]interface{}, 0, batchSize*numArgs)
-		for i, v := range validatorLastAttestationSlotUpdate[start:end] {
-			valueStrings = append(valueStrings, fmt.Sprintf("($%d::int, $%d::int)", i*numArgs+1, i*numArgs+2))
-			valueArgs = append(valueArgs, v.Validator)
-			valueArgs = append(valueArgs, v.LastAttestationSlot)
-		}
-
-		stmt := fmt.Sprintf(`
-			UPDATE validators AS v SET
-			lastattestationslot = GREATEST(v.lastattestationslot, v2.lastattestationslot)
-			FROM (VALUES
-				%[1]s
-			) AS v2(validatorindex, lastattestationslot)
-			WHERE v2.validatorindex = v.validatorindex;
-	`, strings.Join(valueStrings, ","))
-
-		_, err := tx.Exec(stmt, valueArgs...)
-		if err != nil {
-			utils.LogError(err, "error executing transaction", 0)
-			return err
-		}
-
-		logger.Infof("saving validator batch %v completed", b)
+	for _, u := range validatorLastAttestationSlotUpdate {
+		validatorIndexArray = append(validatorIndexArray, int64(u.Validator))
+		lastAttestationSlotArray = append(lastAttestationSlotArray, u.LastAttestationSlot)
 	}
 
-	s := time.Now()
+	_, err = tx.Exec(`UPDATE validators AS v SET
+	lastattestationslot = GREATEST(v.lastattestationslot, v2.lastattestationslot)
+	FROM (SELECT * FROM UNNEST($1::INT[], $2::INT[])) AS v2(validatorindex, lastattestationslot)
+	WHERE v2.validatorindex = v.validatorindex;
+	`, validatorIndexArray, lastAttestationSlotArray)
+	if err != nil {
+		utils.LogError(err, "error executing transaction", 0)
+		return err
+	}
+
+	logger.Infof("last attestation slot update completed, took %v", time.Since(s))
+
+	s = time.Now()
 	newValidators := []struct {
 		Validatorindex  uint64
 		ActivationEpoch uint64

--- a/db/db.go
+++ b/db/db.go
@@ -1234,7 +1234,7 @@ func saveValidators(data *types.EpochData, tx *sqlx.Tx, client rpc.Client) error
 		logger.Infof("update completed, took %v", time.Since(updateStart))
 	}
 
-	batchSize := 65000 // max parameters: 65535
+	batchSize := 30000 // max parameters: 65535
 	for b := 0; b < len(validatorLastAttestationSlotUpdate); b += batchSize {
 		start := b
 		end := b + batchSize

--- a/db/db.go
+++ b/db/db.go
@@ -989,8 +989,6 @@ func saveValidators(data *types.EpochData, tx *sqlx.Tx, client rpc.Client) error
 		}
 	}
 
-	validators := data.Validators
-
 	validatorsByIndex := make(map[uint64]*types.Validator, len(data.Validators))
 	for _, v := range data.Validators {
 		validatorsByIndex[v.Index] = v

--- a/db/db.go
+++ b/db/db.go
@@ -1236,7 +1236,7 @@ func saveValidators(data *types.EpochData, tx *sqlx.Tx, client rpc.Client) error
 		logger.Infof("update completed, took %v", time.Since(updateStart))
 	}
 
-	batchSize := 30000 // max parameters: 65535
+	batchSize := 65000 // max parameters: 65535
 	for b := 0; b < len(validatorLastAttestationSlotUpdate); b += batchSize {
 		start := b
 		end := b + batchSize

--- a/db/db.go
+++ b/db/db.go
@@ -1240,8 +1240,8 @@ func saveValidators(data *types.EpochData, tx *sqlx.Tx, client rpc.Client) error
 	for b := 0; b < len(validatorLastAttestationSlotUpdate); b += batchSize {
 		start := b
 		end := b + batchSize
-		if len(validators) < end {
-			end = len(validators)
+		if len(validatorLastAttestationSlotUpdate) < end {
+			end = len(validatorLastAttestationSlotUpdate)
 		}
 
 		numArgs := 2


### PR DESCRIPTION
only update last attestation slot for validators that are online

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 38f0d4a</samp>

Added a new struct and slice to cache validator last attestation slots in `db/db.go`. This improves the performance of database operations related to validators.
