### PR TITLE
(BIDS-1123) Change missed slot tooltip

### DIFF
--- a/utils/format.go
+++ b/utils/format.go
@@ -41,7 +41,7 @@ func FormatSyncParticipationStatus(status, blockSlot uint64) template.HTML {
 	} else if status == 2 {
 		return `<span class="badge badge-pill bg-light text-dark" style="font-size: 12px; font-weight: 500;">Scheduled</span>`
 	} else if status == 3 {
-		return template.HTML(fmt.Sprintf(`<span class="badge badge-pill bg-warning text-white" style="font-size: 12px; font-weight: 500;" data-toggle="tooltip" data-html="true" data-placement="top" title='Slot %v was missed'>Missed</span>`, FormatAddCommas(blockSlot)))
+		return template.HTML(fmt.Sprintf(`<span class="badge badge-pill bg-warning text-white" style="font-size: 12px; font-weight: 500;" data-toggle="tooltip" data-html="true" data-placement="top" title='Slot %v was missed, it does not contain a block'>Missed</span>`, FormatAddCommas(blockSlot)))
 	} else {
 		return "Unknown"
 	}


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3f2c7e7</samp>

Updated tooltip text for missed status badge in `utils/format.go`. This improves the clarity of the sync participation page.
