### PR TITLE
(NOBIDS) switch ExpireNX to Expire

### DIFF
--- a/db/bigtable.go
+++ b/db/bigtable.go
@@ -119,7 +119,7 @@ func (bigtable *Bigtable) SaveMachineMetric(process string, userID uint64, machi
 	machineLimitKey := fmt.Sprintf("%s:%d", reversePaddedUserID(userID), ts.Time().Minute()%15)
 	pipe := bigtable.redisCache.Pipeline()
 	pipe.SAdd(ctx, machineLimitKey, machine)
-	pipe.ExpireNX(ctx, machineLimitKey, time.Minute*15)
+	pipe.Expire(ctx, machineLimitKey, time.Minute*15)
 	_, err = pipe.Exec(ctx)
 	if err != nil {
 		return err


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 250e862</samp>

Fixed a bug in `db/bigtable.go` that caused machine metrics to not expire correctly in Redis. This improves the accuracy and freshness of the eth2 beacon chain explorer data.
