### PR TITLE
(NOBIDS) destroy session on logout instead of renewing it

### DIFF
--- a/handlers/auth.go
+++ b/handlers/auth.go
@@ -331,9 +331,9 @@ func Logout(w http.ResponseWriter, r *http.Request) {
 	session.DeleteValue("user_id")
 	session.DeleteValue("oauth_redirect_uri")
 
-	err = session.SCS.RenewToken(r.Context())
+	err = session.SCS.Destroy(r.Context())
 	if err != nil {
-		logger.Errorf("error renewing session tokent user: %v", err)
+		logger.Errorf("error destroying session tokent user: %v", err)
 		session.AddFlash(authInternalServerErrorFlashMsg)
 		session.Save(r, w)
 		http.Redirect(w, r, "/login", http.StatusSeeOther)


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4be0571</samp>

Improved security of user logout by destroying session data instead of renewing token. Modified `Logout` function in `handlers/auth.go` as part of a larger authentication and authorization overhaul.
