### PR TITLE
(NOBIDS) limit data read when fetching the last block in the blocks &…

### DIFF
--- a/db/bigtable_eth1.go
+++ b/db/bigtable_eth1.go
@@ -236,13 +236,9 @@ func (bigtable *Bigtable) GetLastBlockInBlocksTable() (int, error) {
 		}
 		c = max_block_number - c
 
-		if c%10000 == 0 {
-			logger.Infof("scanning, currently at block %v", c)
-		}
-
 		lastBlock = c
-		return c == 0
-	}, gcp_bigtable.RowFilter(gcp_bigtable.StripValueFilter()))
+		return c == 0 // required as the block with number 0 will be returned as first block before the most recent one
+	}, gcp_bigtable.LimitRows(2), gcp_bigtable.RowFilter(gcp_bigtable.StripValueFilter()))
 
 	if err != nil {
 		return 0, err
@@ -305,13 +301,9 @@ func (bigtable *Bigtable) GetLastBlockInDataTable() (int, error) {
 		}
 		c = max_block_number - c
 
-		if c%10000 == 0 {
-			logger.Infof("scanning, currently at block %v", c)
-		}
-
 		lastBlock = c
-		return c == 0
-	}, gcp_bigtable.RowFilter(gcp_bigtable.StripValueFilter()))
+		return c == 0 // required as the block with number 0 will be returned as first block before the most recent one
+	}, gcp_bigtable.LimitRows(2), gcp_bigtable.RowFilter(gcp_bigtable.StripValueFilter()))
 
 	if err != nil {
 		return 0, err


### PR DESCRIPTION
… data table

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 54d3362</samp>

Improved the efficiency and readability of scanning eth1 blocks and data from BigTable in `db/bigtable_eth1.go`. Added a limit filter and removed logging to speed up queries. Added comments to explain the scan functions.
