### PR TITLE
(NOBIDS) use redis to cache the last block in the block / data table

### DIFF
--- a/cmd/eth1indexer/main.go
+++ b/cmd/eth1indexer/main.go
@@ -716,7 +716,25 @@ func IndexFromNode(bt *db.Bigtable, client *rpc.ErigonClient, start, end, concur
 
 	}
 
-	return g.Wait()
+	err := g.Wait()
+
+	if err != nil {
+		return err
+	}
+
+	lastBlockInCache, err := bt.GetLastBlockInBlocksTable()
+	if err != nil {
+		return err
+	}
+
+	if end > int64(lastBlockInCache) {
+		err := bt.SetLastBlockInBlocksTable(end)
+
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func ImportMainnetERC20TokenMetadataFromTokenDirectory(bt *db.Bigtable) {

--- a/db/bigtable_eth1.go
+++ b/db/bigtable_eth1.go
@@ -230,8 +230,7 @@ func (bigtable *Bigtable) GetLastBlockInBlocksTable() (int, error) {
 	res, err := bigtable.redisCache.Get(ctx, redisKey).Result()
 
 	if err != nil {
-		// key is not yet set, get data from bigtable
-		// key will be set via the eth1indexer
+		// key is not yet set, get data from bigtable and store the key in redis
 		if errors.Is(err, redis.Nil) {
 			lastBlock, err := bigtable.getLastBlockInBlocksTableFromBigtable()
 
@@ -306,8 +305,7 @@ func (bigtable *Bigtable) GetLastBlockInDataTable() (int, error) {
 	res, err := bigtable.redisCache.Get(ctx, redisKey).Result()
 
 	if err != nil {
-		// key is not yet set, get data from bigtable
-		// key will be set via the eth1indexer
+		// key is not yet set, get data from bigtable and store the key in redis
 		if errors.Is(err, redis.Nil) {
 			lastBlock, err := bigtable.getLastBlockInDataTableFromBigtable()
 

--- a/db/bigtable_eth1.go
+++ b/db/bigtable_eth1.go
@@ -32,6 +32,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/math"
 	eth_types "github.com/ethereum/go-ethereum/core/types"
+	"github.com/go-redis/redis/v8"
 
 	"github.com/shopspring/decimal"
 	"github.com/sirupsen/logrus"
@@ -222,30 +223,32 @@ func (bigtable *Bigtable) CheckForGapsInBlocksTable(lookback int) (gapFound bool
 }
 
 func (bigtable *Bigtable) GetLastBlockInBlocksTable() (int, error) {
-
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
 	defer cancel()
+	redisKey := bigtable.chainId + ":lastBlockInBlocksTable"
 
-	prefix := bigtable.chainId + ":"
-	lastBlock := 0
-	err := bigtable.tableBlocks.ReadRows(ctx, gcp_bigtable.PrefixRange(prefix), func(r gcp_bigtable.Row) bool {
-		c, err := strconv.Atoi(strings.Replace(r.Key(), prefix, "", 1))
-
-		if err != nil {
-			logger.Errorf("error parsing block number from key %v: %v", r.Key(), err)
-			return false
-		}
-		c = max_block_number - c
-
-		lastBlock = c
-		return c == 0 // required as the block with number 0 will be returned as first block before the most recent one
-	}, gcp_bigtable.LimitRows(2), gcp_bigtable.RowFilter(gcp_bigtable.StripValueFilter()))
+	res, err := bigtable.redisCache.Get(ctx, redisKey).Result()
 
 	if err != nil {
+		if errors.Is(err, redis.Nil) {
+			return 0, nil
+		}
 		return 0, err
 	}
 
+	lastBlock, err := strconv.Atoi(res)
+	if err != nil {
+		return 0, err
+	}
 	return lastBlock, nil
+}
+
+func (bigtable *Bigtable) SetLastBlockInBlocksTable(lastBlock int64) error {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+	defer cancel()
+	redisKey := bigtable.chainId + ":lastBlockInBlocksTable"
+
+	return bigtable.redisCache.Set(ctx, redisKey, fmt.Sprintf("%d", lastBlock), 0).Err()
 }
 
 func (bigtable *Bigtable) CheckForGapsInDataTable(lookback int) error {
@@ -287,30 +290,32 @@ func (bigtable *Bigtable) CheckForGapsInDataTable(lookback int) error {
 }
 
 func (bigtable *Bigtable) GetLastBlockInDataTable() (int, error) {
-
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
 	defer cancel()
+	redisKey := bigtable.chainId + ":lastBlockInDataTable"
 
-	prefix := bigtable.chainId + ":B:"
-	lastBlock := 0
-	err := bigtable.tableData.ReadRows(ctx, gcp_bigtable.PrefixRange(prefix), func(r gcp_bigtable.Row) bool {
-		c, err := strconv.Atoi(strings.Replace(r.Key(), prefix, "", 1))
-
-		if err != nil {
-			logger.Errorf("error parsing block number from key %v: %v", r.Key(), err)
-			return false
-		}
-		c = max_block_number - c
-
-		lastBlock = c
-		return c == 0 // required as the block with number 0 will be returned as first block before the most recent one
-	}, gcp_bigtable.LimitRows(2), gcp_bigtable.RowFilter(gcp_bigtable.StripValueFilter()))
+	res, err := bigtable.redisCache.Get(ctx, redisKey).Result()
 
 	if err != nil {
+		if errors.Is(err, redis.Nil) {
+			return 0, nil
+		}
 		return 0, err
 	}
 
+	lastBlock, err := strconv.Atoi(res)
+	if err != nil {
+		return 0, err
+	}
 	return lastBlock, nil
+}
+
+func (bigtable *Bigtable) SetLastBlockInDataTable(lastBlock int64) error {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+	defer cancel()
+	redisKey := bigtable.chainId + ":lastBlockInDataTable"
+
+	return bigtable.redisCache.Set(ctx, redisKey, fmt.Sprintf("%d", lastBlock), 0).Err()
 }
 
 func (bigtable *Bigtable) GetMostRecentBlockFromDataTable() (*types.Eth1BlockIndexed, error) {
@@ -765,6 +770,24 @@ func (bigtable *Bigtable) IndexEventsWithTransformers(start, end int64, transfor
 		return err
 	}
 
+	err := g.Wait()
+
+	if err != nil {
+		return err
+	}
+
+	lastBlockInCache, err := bigtable.GetLastBlockInDataTable()
+	if err != nil {
+		return err
+	}
+
+	if end > int64(lastBlockInCache) {
+		err := bigtable.SetLastBlockInDataTable(end)
+
+		if err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/db/bigtable_eth1.go
+++ b/db/bigtable_eth1.go
@@ -233,7 +233,14 @@ func (bigtable *Bigtable) GetLastBlockInBlocksTable() (int, error) {
 		// key is not yet set, get data from bigtable
 		// key will be set via the eth1indexer
 		if errors.Is(err, redis.Nil) {
-			return bigtable.getLastBlockInBlocksTableFromBigtable()
+			lastBlock, err := bigtable.getLastBlockInBlocksTableFromBigtable()
+
+			if err != nil {
+				return 0, err
+			}
+
+			return lastBlock, bigtable.SetLastBlockInBlocksTable(int64(lastBlock))
+
 		}
 		return 0, err
 	}
@@ -302,7 +309,13 @@ func (bigtable *Bigtable) GetLastBlockInDataTable() (int, error) {
 		// key is not yet set, get data from bigtable
 		// key will be set via the eth1indexer
 		if errors.Is(err, redis.Nil) {
-			return bigtable.getLastBlockInDataTableFromBigtable()
+			lastBlock, err := bigtable.getLastBlockInDataTableFromBigtable()
+
+			if err != nil {
+				return 0, err
+			}
+
+			return lastBlock, bigtable.SetLastBlockInDataTable(int64(lastBlock))
 		}
 		return 0, err
 	}


### PR DESCRIPTION
After merging the eth1indexer needs to be updated alongside the frontend

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 28d33e5</samp>

This pull request adds a redis cache for the last block numbers in the eth1 blocks and data tables, and updates it after indexing new data from the node. This reduces the need to query the bigtable, which improves the performance and cost of the eth1 indexer. The changes affect the files `db/bigtable_eth1.go` and `cmd/eth1indexer/main.go`.
