### PR TITLE
(BIDS-2204) Fix null issue for last attestation slot

### DIFF
--- a/handlers/api.go
+++ b/handlers/api.go
@@ -1500,7 +1500,7 @@ func apiValidator(w http.ResponseWriter, r *http.Request) {
 			activationeligibilityepoch,
 			activationepoch,
 			exitepoch,
-			lastattestationslot,
+			COALESCE(lastattestationslot, 0) as lastattestationslot,
 			status,
 			COALESCE(n.name, '') AS name,
 			COALESCE(w.total, 0) as total_withdrawals


### PR DESCRIPTION
The query threw an error because it tried to save NULL in int64.

See the linked NOBIDS in the comments which probably caused this bug.
To me it looked like we saved 0 instead of NULL before these changes.