### PR TITLE
(NOBIDS) update validator deposit leaderboard only every 6 hours

### DIFF
--- a/exporter/eth1.go
+++ b/exporter/eth1.go
@@ -2,9 +2,7 @@ package exporter
 
 import (
 	"context"
-	"database/sql"
 	"eth2-exporter/db"
-	"eth2-exporter/metrics"
 	"eth2-exporter/types"
 	"eth2-exporter/utils"
 	"fmt"
@@ -121,15 +119,6 @@ func eth1DepositsExporter() {
 			logger.WithError(err).Errorf("error saving eth1-deposits")
 			time.Sleep(time.Second * 5)
 			continue
-		}
-
-		if len(depositsToSave) > 0 {
-			err = aggregateDeposits()
-			if err != nil {
-				logger.WithError(err).Errorf("error saving eth1-deposits-leaderboard")
-				time.Sleep(time.Second * 5)
-				continue
-			}
 		}
 
 		// make sure we are progressing even if there are no deposits in the last batch
@@ -363,48 +352,4 @@ func eth1BatchRequestHeadersAndTxs(blocksToFetch []uint64, txsToFetch []string) 
 	}
 
 	return headers, txs, nil
-}
-
-func aggregateDeposits() error {
-	start := time.Now()
-	defer func() {
-		metrics.TaskDuration.WithLabelValues("exporter_aggregate_eth1_deposits").Observe(time.Since(start).Seconds())
-	}()
-	_, err := db.WriterDb.Exec(`
-		INSERT INTO eth1_deposits_aggregated (from_address, amount, validcount, invalidcount, slashedcount, totalcount, activecount, pendingcount, voluntary_exit_count)
-		SELECT
-			eth1.from_address,
-			SUM(eth1.amount) as amount,
-			SUM(eth1.validcount) AS validcount,
-			SUM(eth1.invalidcount) AS invalidcount,
-			COUNT(CASE WHEN v.status = 'slashed' THEN 1 END) AS slashedcount,
-			COUNT(v.pubkey) AS totalcount,
-			COUNT(CASE WHEN v.status = 'active_online' OR v.status = 'active_offline' THEN 1 END) as activecount,
-			COUNT(CASE WHEN v.status = 'deposited' THEN 1 END) AS pendingcount,
-			COUNT(CASE WHEN v.status = 'exited' THEN 1 END) AS voluntary_exit_count
-		FROM (
-			SELECT 
-				from_address,
-				publickey,
-				SUM(amount) AS amount,
-				COUNT(CASE WHEN valid_signature = 't' THEN 1 END) AS validcount,
-				COUNT(CASE WHEN valid_signature = 'f' THEN 1 END) AS invalidcount
-			FROM eth1_deposits
-			GROUP BY from_address, publickey
-		) eth1
-		LEFT JOIN (SELECT pubkey, status FROM validators) v ON v.pubkey = eth1.publickey
-		GROUP BY eth1.from_address
-		ON CONFLICT (from_address) DO UPDATE SET
-			amount               = excluded.amount,
-			validcount           = excluded.validcount,
-			invalidcount         = excluded.invalidcount,
-			slashedcount         = excluded.slashedcount,
-			totalcount           = excluded.totalcount,
-			activecount          = excluded.activecount,
-			pendingcount         = excluded.pendingcount,
-			voluntary_exit_count = excluded.voluntary_exit_count`)
-	if err != nil && err != sql.ErrNoRows {
-		return nil
-	}
-	return err
 }


### PR DESCRIPTION
Currently we update the validator deposit leaderboard after every new deposit. The update is done by re-calculating all deposits over all validators which, given the amount of new deposits on ETH mainnet, imposes a significant load on the database. Ideally updating the deposit leaderboard should be an incremental process. While a new process is implemented, this PR will reduce the update interval of the leaderboard to every 6 hours to lessen the load on the database.

copilot:summary
