### PR TITLE
(NOBIDS) Switch error to warning validator query

### DIFF
--- a/handlers/dashboard.go
+++ b/handlers/dashboard.go
@@ -39,7 +39,7 @@ func handleValidatorsQuery(w http.ResponseWriter, r *http.Request, checkValidato
 	// Parse all the validator indices and pubkeys from the query string
 	queryValidatorIndices, queryValidatorPubkeys, err := parseValidatorsFromQueryString(q.Get("validators"), validatorLimit)
 	if err != nil && (checkValidatorLimit || err != ErrTooManyValidators) {
-		utils.LogError(err, fmt.Errorf("error parsing validators from query string"), 0, fieldMap)
+		logger.Warnf("error parsing validators from query string: %v; Route: %v", err, r.URL.String())
 		http.Error(w, "Invalid query", http.StatusBadRequest)
 		return nil, nil, false, err
 	}


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fe15e24</samp>

Refactor error logging in `handleValidatorsQuery` function. Use `logger.Warnf` instead of `utils.LogError` to avoid duplicate logging in `handlers/dashboard.go`.
