### PR TITLE
(BIDS-1059) Invert notification thresholds

### DIFF
--- a/static/js/notificationsCenter.js
+++ b/static/js/notificationsCenter.js
@@ -148,6 +148,7 @@ function loadMonitoringData(data) {
   }
 
   for (let i = 0; i < data.length; i++) {
+    // monitoring_hdd_almostfull as an exception saves the threshold value inverted, i.e. the remaining free space
     var eventThreshold = data[i].EventThreshold
     if (data[i].EventName === "monitoring_hdd_almostfull") {
       eventThreshold = 1 - eventThreshold

--- a/static/js/notificationsCenter.js
+++ b/static/js/notificationsCenter.js
@@ -148,10 +148,15 @@ function loadMonitoringData(data) {
   }
 
   for (let i = 0; i < data.length; i++) {
+    var eventThreshold = data[i].EventThreshold
+    if (data[i].EventName === "monitoring_hdd_almostfull") {
+      eventThreshold = 1 - eventThreshold
+    }
+
     mdata.push({
       id: data[i].ID,
       notification: data[i].EventName,
-      threshold: data[i].EventThreshold ? 1 - data[i].EventThreshold : data[i].EventThreshold,
+      threshold: eventThreshold,
       mostRecent: data[i].LastSent || 0,
       machine: data[i].EventFilter,
       event: {},


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 754ec45</samp>

Fix disk space notifications in `notificationsCenter.js`. Invert the event threshold for the "monitoring_hdd_almostfull" event to match the disk usage percentage.
