### PR TITLE
(BIDS-1838) dynamic change the offline/online detection limit

### DIFF
--- a/services/notifications.go
+++ b/services/notifications.go
@@ -1526,25 +1526,21 @@ func collectAttestationAndOfflineValidatorNotifications(notificationsByUserID ma
 		}
 	}
 
-	var offlineValidatorsLimit int
-	if utils.Config.Notifications.OfflineDetectionLimit != nil {
-		offlineValidatorsLimit = *utils.Config.Notifications.OfflineDetectionLimit
-	} else {
-		offlineValidatorsLimit = 5000
+	offlineValidatorsLimit := 5000
+	if utils.Config.Notifications.OfflineDetectionLimit != 0 {
+		offlineValidatorsLimit = utils.Config.Notifications.OfflineDetectionLimit
 	}
 
-	var onlineValidatorsLimit int
-	if utils.Config.Notifications.OnlineDetectionLimit != nil {
-		onlineValidatorsLimit = *utils.Config.Notifications.OnlineDetectionLimit
-	} else {
-		onlineValidatorsLimit = 5000
+	onlineValidatorsLimit := 5000
+	if utils.Config.Notifications.OnlineDetectionLimit != 0 {
+		onlineValidatorsLimit = utils.Config.Notifications.OnlineDetectionLimit
 	}
 
-	if len(offlineValidators) > int(offlineValidatorsLimit) {
+	if len(offlineValidators) > offlineValidatorsLimit {
 		return fmt.Errorf("retrieved more than %v offline validators notifications: %v, exiting", offlineValidatorsLimit, len(offlineValidators))
 	}
 
-	if len(onlineValidators) > int(onlineValidatorsLimit) {
+	if len(onlineValidators) > onlineValidatorsLimit {
 		return fmt.Errorf("retrieved more than %v online validators notifications: %v, exiting", onlineValidatorsLimit, len(onlineValidators))
 	}
 

--- a/services/notifications.go
+++ b/services/notifications.go
@@ -1526,12 +1526,26 @@ func collectAttestationAndOfflineValidatorNotifications(notificationsByUserID ma
 		}
 	}
 
-	if len(offlineValidators) > 5000 {
-		return fmt.Errorf("retrieved more than 5000 offline validators notifications: %v, exiting", len(offlineValidators))
+	var offlineValidatorsLimit int
+	if utils.Config.Notifications.OfflineDetectionLimit != nil {
+		offlineValidatorsLimit = *utils.Config.Notifications.OfflineDetectionLimit
+	} else {
+		offlineValidatorsLimit = 5000
 	}
 
-	if len(onlineValidators) > 5000 {
-		return fmt.Errorf("retrieved more than 5000 online validators notifications: %v, exiting", len(onlineValidators))
+	var onlineValidatorsLimit int
+	if utils.Config.Notifications.OnlineDetectionLimit != nil {
+		onlineValidatorsLimit = *utils.Config.Notifications.OnlineDetectionLimit
+	} else {
+		onlineValidatorsLimit = 5000
+	}
+
+	if len(offlineValidators) > int(offlineValidatorsLimit) {
+		return fmt.Errorf("retrieved more than %v offline validators notifications: %v, exiting", offlineValidatorsLimit, len(offlineValidators))
+	}
+
+	if len(onlineValidators) > int(onlineValidatorsLimit) {
+		return fmt.Errorf("retrieved more than %v online validators notifications: %v, exiting", onlineValidatorsLimit, len(onlineValidators))
 	}
 
 	_, subMap, err = db.GetSubsForEventFilter(types.ValidatorIsOfflineEventName)

--- a/types/config.go
+++ b/types/config.go
@@ -167,8 +167,8 @@ type Config struct {
 		FirebaseCredentialsPath                       string `yaml:"firebaseCredentialsPath" envconfig:"NOTIFICATIONS_FIREBASE_CRED_PATH"`
 		ValidatorBalanceDecreasedNotificationsEnabled bool   `yaml:"validatorBalanceDecreasedNotificationsEnabled" envconfig:"VALIDATOR_BALANCE_DECREASED_NOTIFICATIONS_ENABLED"`
 		PubkeyCachePath                               string `yaml:"pubkeyCachePath" envconfig:"NOTIFICATIONS_PUBKEY_CACHE_PATH"`
-		OnlineDetectionLimit                          *int   `yaml:"onlineDetectionLimit" envconfig:"ONLINE_DETECTION_LIMIT"`
-		OfflineDetectionLimit                         *int   `yaml:"offlineDetectionLimit" envconfig:"OFFLINE_DETECTION_LIMIT"`
+		OnlineDetectionLimit                          int    `yaml:"onlineDetectionLimit" envconfig:"ONLINE_DETECTION_LIMIT"`
+		OfflineDetectionLimit                         int    `yaml:"offlineDetectionLimit" envconfig:"OFFLINE_DETECTION_LIMIT"`
 	} `yaml:"notifications"`
 	SSVExporter struct {
 		Enabled bool   `yaml:"enabled" envconfig:"SSV_EXPORTER_ENABLED"`

--- a/types/config.go
+++ b/types/config.go
@@ -167,6 +167,8 @@ type Config struct {
 		FirebaseCredentialsPath                       string `yaml:"firebaseCredentialsPath" envconfig:"NOTIFICATIONS_FIREBASE_CRED_PATH"`
 		ValidatorBalanceDecreasedNotificationsEnabled bool   `yaml:"validatorBalanceDecreasedNotificationsEnabled" envconfig:"VALIDATOR_BALANCE_DECREASED_NOTIFICATIONS_ENABLED"`
 		PubkeyCachePath                               string `yaml:"pubkeyCachePath" envconfig:"NOTIFICATIONS_PUBKEY_CACHE_PATH"`
+		OnlineDetectionLimit                          *int   `yaml:"onlineDetectionLimit" envconfig:"ONLINE_DETECTION_LIMIT"`
+		OfflineDetectionLimit                         *int   `yaml:"offlineDetectionLimit" envconfig:"OFFLINE_DETECTION_LIMIT"`
 	} `yaml:"notifications"`
 	SSVExporter struct {
 		Enabled bool   `yaml:"enabled" envconfig:"SSV_EXPORTER_ENABLED"`


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6fec741</samp>

Added configurable limits for online and offline validators notifications in `services/notifications.go` and `types/config.go`. This allows users to adjust the thresholds for triggering notifications based on their preferences.
