### PR TITLE
(NOBIDS) Fix contract metadata load

### DIFF
--- a/types/templates.go
+++ b/types/templates.go
@@ -1635,7 +1635,7 @@ func (metadata ERC20Metadata) UnmarshalBinary(data []byte) error {
 
 type ContractMetadata struct {
 	Name    string
-	ABI     *abi.ABI `msgpack:"-"`
+	ABI     *abi.ABI `msgpack:"-" json:"-"`
 	ABIJson []byte
 }
 


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5620b50</samp>

Omit `ABI` field from JSON and msgpack encoding of `ContractMetadata` type. This improves contract service efficiency and simplifies code.
