### PR TITLE
(BIDS-2115) add update-aggregation-bits tool

### DIFF
--- a/cmd/misc/main.go
+++ b/cmd/misc/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"eth2-exporter/db"
 	"eth2-exporter/exporter"
@@ -186,29 +187,18 @@ func updateAggreationBits(rpcClient *rpc.LighthouseClient, startEpoch uint64, en
 							return nil // halt once processing of a slot failed
 						default:
 						}
-						var count uint64
-						// let's see if we have attestations for that oprphaned block
-						err := db.ReaderDb.Get(&count, `
-							SELECT COUNT(*)
-							FROM blocks_attestations WHERE 
-								block_slot=$1
-							LIMIT(1)
-						`, block.Slot)
-						if err != nil {
-							return fmt.Errorf("error counting attestations for Slot [%v]: %v", block.Slot, err)
-						}
 
 						// if we have some obsolete attestations we clean them from the db
-						if count > 0 {
-							_, err = db.WriterDb.Exec(`
+						rows, err := db.WriterDb.Exec(`
 								DELETE FROM blocks_attestations
 								WHERE
 									block_slot=$1
 							`, block.Slot)
-							if err != nil {
-								return fmt.Errorf("error deleting obsolete attestations for Slot [%v]:  %v", block.Slot, err)
-							}
-							logrus.Infof("Obsolete attestations removed for Slot[%v]", block.Slot)
+						if err != nil {
+							return fmt.Errorf("error deleting obsolete attestations for Slot [%v]:  %v", block.Slot, err)
+						}
+						if rowsAffected, _ := rows.RowsAffected(); rowsAffected > 0 {
+							logrus.Infof("%v obsolete attestations removed for Slot[%v]", rowsAffected, block.Slot)
 						} else {
 							logrus.Infof("No obsolete attestations found for Slot[%v] so we move on", block.Slot)
 						}
@@ -239,7 +229,7 @@ func updateAggreationBits(rpcClient *rpc.LighthouseClient, startEpoch uint64, en
 							return fmt.Errorf("error getting aggregationbits on Slot [%v] Index [%v] with Sig [%v]: %v", block.Slot, index, att.Signature, err)
 						}
 
-						if fmt.Sprintf("%x", *aggregationbits) != fmt.Sprintf("%x", string(att.AggregationBits)) {
+						if bytes.Equal(*aggregationbits, att.AggregationBits) {
 							_, err = db.WriterDb.Exec(`
 								UPDATE blocks_attestations
 								SET

--- a/cmd/misc/main.go
+++ b/cmd/misc/main.go
@@ -229,7 +229,7 @@ func updateAggreationBits(rpcClient *rpc.LighthouseClient, startEpoch uint64, en
 							return fmt.Errorf("error getting aggregationbits on Slot [%v] Index [%v] with Sig [%v]: %v", block.Slot, index, att.Signature, err)
 						}
 
-						if bytes.Equal(*aggregationbits, att.AggregationBits) {
+						if !bytes.Equal(*aggregationbits, att.AggregationBits) {
 							_, err = db.WriterDb.Exec(`
 								UPDATE blocks_attestations
 								SET

--- a/cmd/misc/main.go
+++ b/cmd/misc/main.go
@@ -164,7 +164,7 @@ func updateAggreationBits(rpcClient *rpc.LighthouseClient, startEpoch uint64, en
 		logrus.Infof("Getting data from the node for epoch %v", epoch)
 		data, err := rpcClient.GetEpochData(epoch, false)
 		if err != nil {
-			logrus.Infof("Error getting epoch[%v] data from the client: %v", epoch, err)
+			utils.LogError(err, fmt.Sprintf("Error getting epoch[%v] data from the client", epoch), 0)
 			return
 		}
 
@@ -200,7 +200,7 @@ func updateAggreationBits(rpcClient *rpc.LighthouseClient, startEpoch uint64, en
 							block_index=$2 AND
 							signature = $3`, block.Slot, index, att.Signature)
 						if err != nil {
-							return fmt.Errorf("error getting aggregationbits on Slot %v: %v", block.Slot, err)
+							return fmt.Errorf("error getting aggregationbits on Slot [%v] Index [%v] with Sig [%v]: %v", block.Slot, index, att.Signature, err)
 						}
 
 						if fmt.Sprintf("%x", *aggregationbits) != fmt.Sprintf("%x", string(att.AggregationBits)) {
@@ -214,7 +214,7 @@ func updateAggreationBits(rpcClient *rpc.LighthouseClient, startEpoch uint64, en
 									signature = $4
 							`, att.AggregationBits, block.Slot, index, att.Signature)
 							if err != nil {
-								return fmt.Errorf("error updating aggregationbits on Slot %v: %v", block.Slot, err)
+								return fmt.Errorf("error updating aggregationbits on Slot [%v] Index [%v] :  %v", block.Slot, index, err)
 							}
 							logrus.Infof("Update of Slot[%v] Index[%v] complete", block.Slot, index)
 						} else {
@@ -231,7 +231,7 @@ func updateAggreationBits(rpcClient *rpc.LighthouseClient, startEpoch uint64, en
 		err = g.Wait()
 
 		if err != nil {
-			utils.LogError(err, "error updating aggregationbits", 0)
+			utils.LogError(err, fmt.Sprintf("error updating aggregationbits for epoch [%v]", epoch), 0)
 			return
 		}
 		logrus.Infof("Update of Epoch[%v] complete", epoch)

--- a/cmd/misc/main.go
+++ b/cmd/misc/main.go
@@ -231,7 +231,7 @@ func updateAggreationBits(rpcClient *rpc.LighthouseClient, startEpoch uint64, en
 		err = g.Wait()
 
 		if err != nil {
-			utils.LogError(err, fmt.Sprintf("error updating aggregationbits"), 0)
+			utils.LogError(err, "error updating aggregationbits", 0)
 			return
 		}
 		logrus.Infof("Update of Epoch[%v] complete", epoch)


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 52ebe57</samp>

Added a new command to update attestation aggregation bits using Lighthouse RPC. The command uses concurrency and error handling to improve performance and reliability. Modified `cmd/misc/main.go` to implement the command.
