### PR TITLE
add MarsProtocol to stakingservice page

### DIFF
--- a/templates/stakingServices.html
+++ b/templates/stakingServices.html
@@ -663,6 +663,20 @@
                       <i class="fab fa-discord ml-1 mr-1"></i><a href="https://twitter.com/swissborg" target="_blank"><i class="fab fa-twitter ml-1 mr-1"></i></a><i class="fab fa-telegram ml-1 mr-1"></i><i class="fa fa-mail-bulk ml-1 mr-1"></i>
                     </td>
                   </tr>
+                  <tr>
+                    <td data-column="Service"><a href="https://www.marsprotocol.com">MarsProtocol</a></td>
+                    <td data-column="No Supermajority client" style="text-align: center;">❓</td>
+                    <td data-column="Validator key owner">Service</td>
+                    <td data-column="Withdrawal key owner">User</td>
+                    <td data-column="Pool token">No</td>
+                    <td data-column="3rd Party Software">No</td>
+                    <td data-column="Min. Stake">32ETH</td>
+                    <td data-column="Fee">10% of rewards</td>
+                    <td data-column="Open Source">No</td>
+                    <td data-column="Social">
+                      <i class="fab fa-discord ml-1 mr-1"></i><a href="https://twitter.com/marsprotocol22" target="_blank"><i class="fab fa-twitter ml-1 mr-1"></i></a><i class="fab fa-telegram ml-1 mr-1"></i></a><i class="fa fa-mail-bulk ml-1 mr-1"></i>
+                    </td>
+                  </tr>
                 </tbody>
               </table>
             </div>


### PR DESCRIPTION
Adding MarsProtocol to the Beacon Chain Explorer [Staking Services Page](https://beaconcha.in/stakingServices).
Name Of Service- MarsProtocol
Website- www.marsprotocol.com

Our users are institutions, so the registration needs to be reviewed, and the fee is also charged in the form of a bill, so if you want to register, please give me your account number?
