### PR TITLE
Bids 2218/cache validatorincomehistory

### DIFF
--- a/db/statistics.go
+++ b/db/statistics.go
@@ -1160,7 +1160,7 @@ func GetValidatorIncomeHistory(validator_indices []uint64, lowerBoundDay uint64,
 	}
 	queryValidatorsStr = utils.UniqueStrings(queryValidatorsStr)
 	sort.Strings(queryValidatorsStr)
-	cacheDur := time.Second * time.Duration(utils.Config.Chain.Config.SecondsPerSlot*utils.Config.Chain.Config.SlotsPerEpoch) // updates every epoch
+	cacheDur := time.Second*time.Duration(utils.Config.Chain.Config.SecondsPerSlot*utils.Config.Chain.Config.SlotsPerEpoch) + 10 // updates every epoch, keep 10sec longer
 	cacheKey := fmt.Sprintf("%d:validatorIncomeHistory:%d:%d:%d:%s", utils.Config.Chain.Config.DepositChainID, lowerBoundDay, upperBoundDay, lastFinalizedEpoch, strings.Join(queryValidatorsStr, ","))
 	if cached, err := cache.TieredCache.GetWithLocalTimeout(cacheKey, cacheDur, []types.ValidatorIncomeHistory{}); err == nil {
 		return cached.([]types.ValidatorIncomeHistory), nil

--- a/db/statistics.go
+++ b/db/statistics.go
@@ -1160,7 +1160,7 @@ func GetValidatorIncomeHistory(validator_indices []uint64, lowerBoundDay uint64,
 	}
 	queryValidatorsStr = utils.UniqueStrings(queryValidatorsStr)
 	sort.Strings(queryValidatorsStr)
-	cacheDur := time.Second*time.Duration(utils.Config.Chain.Config.SecondsPerSlot*utils.Config.Chain.Config.SlotsPerEpoch) + 10 // updates every epoch, keep 10sec longer
+	cacheDur := time.Second * time.Duration(utils.Config.Chain.Config.SecondsPerSlot*utils.Config.Chain.Config.SlotsPerEpoch+10) // updates every epoch, keep 10sec longer
 	cacheKey := fmt.Sprintf("%d:validatorIncomeHistory:%d:%d:%d:%s", utils.Config.Chain.Config.DepositChainID, lowerBoundDay, upperBoundDay, lastFinalizedEpoch, strings.Join(queryValidatorsStr, ","))
 	if cached, err := cache.TieredCache.GetWithLocalTimeout(cacheKey, cacheDur, []types.ValidatorIncomeHistory{}); err == nil {
 		return cached.([]types.ValidatorIncomeHistory), nil

--- a/db/statistics.go
+++ b/db/statistics.go
@@ -1161,7 +1161,7 @@ func GetValidatorIncomeHistory(validator_indices []uint64, lowerBoundDay uint64,
 	queryValidatorsStr = utils.UniqueStrings(queryValidatorsStr)
 	sort.Strings(queryValidatorsStr)
 	cacheDur := time.Second * time.Duration(utils.Config.Chain.Config.SecondsPerSlot*utils.Config.Chain.Config.SlotsPerEpoch) // updates every epoch
-	cacheKey := fmt.Sprintf("%d:validatorIncomeHistory:%d:%d:%d:%s", utils.Config.Chain.Config.DepositChainID, lowerBoundDay, upperBoundDay, lastFinalizedEpoch, queryValidatorsStr)
+	cacheKey := fmt.Sprintf("%d:validatorIncomeHistory:%d:%d:%d:%s", utils.Config.Chain.Config.DepositChainID, lowerBoundDay, upperBoundDay, lastFinalizedEpoch, strings.Join(queryValidatorsStr, ","))
 	if cached, err := cache.TieredCache.GetWithLocalTimeout(cacheKey, cacheDur, []types.ValidatorIncomeHistory{}); err == nil {
 		return cached.([]types.ValidatorIncomeHistory), nil
 	}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1339,3 +1339,16 @@ func CmdPrompt(label string) string {
 	}
 	return strings.TrimSpace(s)
 }
+
+// UniqueStrings returns an array of strings containing each value of s only once
+func UniqueStrings(s []string) []string {
+	seen := make(map[string]bool)
+	var result []string
+	for _, str := range s {
+		if _, ok := seen[str]; !ok {
+			seen[str] = true
+			result = append(result, str)
+		}
+	}
+	return result
+}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -27,6 +27,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"sort"
 	"strings"
 	"time"
 	"unicode/utf8"
@@ -1350,5 +1351,25 @@ func UniqueStrings(s []string) []string {
 			result = append(result, str)
 		}
 	}
+	return result
+}
+
+func SortedUniqueUint64(arr []uint64) []uint64 {
+	if len(arr) <= 1 {
+		return arr
+	}
+
+	sort.Slice(arr, func(i, j int) bool {
+		return arr[i] < arr[j]
+	})
+
+	result := make([]uint64, 1, len(arr))
+	result[0] = arr[0]
+	for i := 1; i < len(arr); i++ {
+		if arr[i-1] != arr[i] {
+			result = append(result, arr[i])
+		}
+	}
+
 	return result
 }


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9c73861</samp>

This pull request improves the performance and scalability of the validator income history API endpoint by adding a cache layer, removing duplicate inputs, and creating missing database indices. It modifies the `db/statistics.go`, `utils/utils.go`, and `db/migrations/20230612084855_add_missing_indices.sql` files.
