### PR TITLE
(NOBIDS) fix potential db deadlock when sending notifications

### DIFF
--- a/services/notifications.go
+++ b/services/notifications.go
@@ -1052,6 +1052,8 @@ func sendWebhookNotifications(useDB *sqlx.DB) error {
 	}
 
 	wg.Wait()
+
+	logger.Infof("webhook notifications sent")
 	return nil
 }
 

--- a/services/notifications.go
+++ b/services/notifications.go
@@ -845,6 +845,11 @@ func queueWebhookNotifications(notificationsByUserID map[uint64]map[types.EventN
 				continue
 			}
 
+			if !utils.IsValidUrl(w.Url) {
+				logrus.Warnf("error invalid webhook url: %v", w.Url)
+				continue
+			}
+
 			if strings.Contains(urlParsed.Hostname(), "beaconcha.in") || strings.Contains(urlParsed.Hostname(), "gnosischa.in") {
 				logrus.Warnf("using beaconcha.in or gnosischa.in as webhook target is not allowed! %v", w.Url)
 				continue

--- a/services/notifications.go
+++ b/services/notifications.go
@@ -1012,7 +1012,7 @@ func sendWebhookNotifications(useDB *sqlx.DB) error {
 			}
 
 			if resp != nil && resp.StatusCode < 400 {
-				_, err := useDB.Exec(`UPDATE notification_queue SET sent = now();`)
+				_, err := useDB.Exec(`UPDATE notification_queue SET sent = now() where id = $1`, n.Id)
 				if err != nil {
 					logger.WithError(err).Errorf("error updating notification_queue table")
 					return

--- a/services/notifications.go
+++ b/services/notifications.go
@@ -1071,7 +1071,7 @@ func sendWebhookNotifications(useDB *sqlx.DB) error {
 			}
 
 			if resp != nil && resp.StatusCode < 400 {
-				_, err := useDB.Exec(`UPDATE notification_queue SET sent = now();`)
+				_, err := useDB.Exec(`UPDATE notification_queue SET sent = now() where id = $1;`, n.Id)
 				if err != nil {
 					logger.WithError(err).Errorf("error updating notification_queue table")
 					return nil

--- a/services/notifications.go
+++ b/services/notifications.go
@@ -840,12 +840,12 @@ func queueWebhookNotifications(notificationsByUserID map[uint64]map[types.EventN
 			urlParsed, err := url.Parse(w.Url)
 
 			if err != nil {
-				logrus.Errorf("error parsing webhook url %v: %v", w.Url, err)
+				logrus.Warnf("error parsing webhook url %v: %v", w.Url, err)
 				continue
 			}
 
 			if strings.Contains(urlParsed.Hostname(), "beaconcha.in") || strings.Contains(urlParsed.Hostname(), "gnosischa.in") {
-				logrus.Errorf("using beaconcha.in or gnosischa.in as webhook target is not allowed! %v", w.Url)
+				logrus.Warnf("using beaconcha.in or gnosischa.in as webhook target is not allowed! %v", w.Url)
 				continue
 			}
 			for event, notifications := range userNotifications {


### PR DESCRIPTION
Fix a bug in webhook notifications that caused db deadlock issues. Modify the `services/notifications.go` file to update only the relevant row in the `notification_queue` table.
