### PR TITLE
(NOBIDS) add version-flag

### DIFF
--- a/cmd/ethstore-exporter/main.go
+++ b/cmd/ethstore-exporter/main.go
@@ -7,6 +7,7 @@ import (
 	"eth2-exporter/utils"
 	"eth2-exporter/version"
 	"flag"
+	"fmt"
 
 	_ "github.com/jackc/pgx/v4/stdlib"
 	"github.com/sirupsen/logrus"
@@ -19,8 +20,13 @@ func main() {
 	updateInterval := flag.Duration("update-intv", 0, "Update interval")
 	errorInterval := flag.Duration("error-intv", 0, "Error interval")
 	sleepInterval := flag.Duration("sleep-intv", 0, "Sleep interval")
-
+	versionFlag := flag.Bool("version", false, "Show version and exit")
 	flag.Parse()
+
+	if *versionFlag {
+		fmt.Println(version.Version)
+		return
+	}
 
 	cfg := &types.Config{}
 	err := utils.ReadConfig(cfg, *configPath)

--- a/cmd/explorer/main.go
+++ b/cmd/explorer/main.go
@@ -57,8 +57,13 @@ func init() {
 
 func main() {
 	configPath := flag.String("config", "", "Path to the config file, if empty string defaults will be used")
-
+	versionFlag := flag.Bool("version", false, "Show version and exit")
 	flag.Parse()
+
+	if *versionFlag {
+		fmt.Println(version.Version)
+		return
+	}
 
 	cfg := &types.Config{}
 	err := utils.ReadConfig(cfg, *configPath)

--- a/cmd/frontend-data-updater/main.go
+++ b/cmd/frontend-data-updater/main.go
@@ -19,7 +19,13 @@ import (
 
 func main() {
 	configPath := flag.String("config", "", "Path to the config file, if empty string defaults will be used")
+	versionFlag := flag.Bool("version", false, "Show version and exit")
 	flag.Parse()
+
+	if *versionFlag {
+		fmt.Println(version.Version)
+		return
+	}
 
 	cfg := &types.Config{}
 	err := utils.ReadConfig(cfg, *configPath)

--- a/cmd/migrations/bigtable/main.go
+++ b/cmd/migrations/bigtable/main.go
@@ -5,6 +5,7 @@ import (
 	"eth2-exporter/rpc"
 	"eth2-exporter/types"
 	"eth2-exporter/utils"
+	"eth2-exporter/version"
 	"flag"
 	"fmt"
 	"math/big"
@@ -22,7 +23,13 @@ func main() {
 	start := flag.Uint64("start", 1, "Start epoch")
 	end := flag.Uint64("end", 1, "End epoch")
 
+	versionFlag := flag.Bool("version", false, "Show version and exit")
 	flag.Parse()
+
+	if *versionFlag {
+		fmt.Println(version.Version)
+		return
+	}
 
 	if *start == 1 && *end == 1 {
 		monitor(*configPath)

--- a/cmd/misc/main.go
+++ b/cmd/misc/main.go
@@ -59,7 +59,13 @@ func main() {
 	flag.Uint64Var(&opts.BatchSize, "data.batchSize", 1000, "Batch size")
 	flag.StringVar(&opts.Transformers, "transformers", "", "Comma separated list of transformers used by the eth1 indexer")
 	dryRun := flag.String("dry-run", "true", "if 'false' it deletes all rows starting with the key, per default it only logs the rows that would be deleted, but does not really delete them")
+	versionFlag := flag.Bool("version", false, "Show version and exit")
 	flag.Parse()
+
+	if *versionFlag {
+		fmt.Println(version.Version)
+		return
+	}
 
 	opts.DryRun = *dryRun != "false"
 

--- a/cmd/rewards-exporter/main.go
+++ b/cmd/rewards-exporter/main.go
@@ -29,7 +29,13 @@ func main() {
 	epochEnd := flag.Uint64("epoch-end", 0, "end epoch to export")
 	sleepDuration := flag.Duration("sleep", time.Minute, "duration to sleep between export runs")
 
+	versionFlag := flag.Bool("version", false, "Show version and exit")
 	flag.Parse()
+
+	if *versionFlag {
+		fmt.Println(version.Version)
+		return
+	}
 
 	cfg := &types.Config{}
 	err := utils.ReadConfig(cfg, *configPath)

--- a/cmd/signatures/main.go
+++ b/cmd/signatures/main.go
@@ -7,6 +7,7 @@ import (
 	"eth2-exporter/services"
 	"eth2-exporter/types"
 	"eth2-exporter/utils"
+	"eth2-exporter/version"
 	"flag"
 	"fmt"
 	"io/ioutil"
@@ -30,7 +31,13 @@ func main() {
 	metricsAddr := flag.String("metrics.address", "localhost:9090", "serve metrics on that addr")
 	metricsEnabled := flag.Bool("metrics.enabled", false, "enable serving metrics")
 
+	versionFlag := flag.Bool("version", false, "Show version and exit")
 	flag.Parse()
+
+	if *versionFlag {
+		fmt.Println(version.Version)
+		return
+	}
 
 	cfg := &types.Config{}
 	err := utils.ReadConfig(cfg, *configPath)

--- a/cmd/statistics/main.go
+++ b/cmd/statistics/main.go
@@ -35,7 +35,13 @@ func main() {
 	statisticsValidatorToggle := flag.Bool("validators.enabled", false, "Toggle exporting validator statistics")
 	statisticsChartToggle := flag.Bool("charts.enabled", false, "Toggle exporting chart series")
 
+	versionFlag := flag.Bool("version", false, "Show version and exit")
 	flag.Parse()
+
+	if *versionFlag {
+		fmt.Println(version.Version)
+		return
+	}
 
 	opt = &options{
 		configPath:                *configPath,


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d767cf3</samp>

This pull request adds a `versionFlag` feature to various command-line tools and services in the repository. The feature allows the user to see the program version and exit early without running any logic. The feature is implemented using the `version` package and is consistent across all the affected files.
