### PR TITLE
(BIDS-2221) remove orphaned attestations

### DIFF
--- a/db/bigtable.go
+++ b/db/bigtable.go
@@ -844,29 +844,15 @@ func (bigtable *Bigtable) GetValidatorAttestationHistory(validators []uint64, st
 	return res, nil
 }
 
-func (bigtable *Bigtable) GetValidatorFailedAttestationHistory(validators []uint64, startEpoch uint64, endEpoch uint64) (map[uint64]map[uint64]uint8, error) {
+func (bigtable *Bigtable) GetValidatorMissedAttestationHistory(validators []uint64, startEpoch uint64, endEpoch uint64) (map[uint64]map[uint64]bool, error) {
 	valLen := len(validators)
 
 	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(time.Minute*20))
 	defer cancel()
 
-	slots := []uint64{}
-
-	for slot := startEpoch * utils.Config.Chain.Config.SlotsPerEpoch; slot < (endEpoch+1)*utils.Config.Chain.Config.SlotsPerEpoch; slot++ {
-		slots = append(slots, slot)
-	}
-	orphanedSlots, err := GetOrphanedSlots(slots)
-	if err != nil {
-		return nil, err
-	}
-	orphanedSlotsMap := make(map[uint64]bool)
-	for _, slot := range orphanedSlots {
-		orphanedSlotsMap[slot] = true
-	}
-
 	ranges := bigtable.getSlotRanges(startEpoch, endEpoch)
 
-	res := make(map[uint64]map[uint64]uint8)
+	res := make(map[uint64]map[uint64]bool)
 
 	columnFilters := []gcp_bigtable.Filter{}
 	if valLen < 1000 {
@@ -896,7 +882,7 @@ func (bigtable *Bigtable) GetValidatorFailedAttestationHistory(validators []uint
 		)
 	}
 
-	err = bigtable.tableBeaconchain.ReadRows(ctx, ranges, func(r gcp_bigtable.Row) bool {
+	err := bigtable.tableBeaconchain.ReadRows(ctx, ranges, func(r gcp_bigtable.Row) bool {
 		keySplit := strings.Split(r.Key(), ":")
 
 		attesterSlot, err := strconv.ParseUint(keySplit[4], 10, 64)
@@ -921,16 +907,12 @@ func (bigtable *Bigtable) GetValidatorFailedAttestationHistory(validators []uint
 				return false
 			}
 
-			if status == 0 || orphanedSlotsMap[attesterSlot] {
+			if status == 0 {
 				if res[validator] == nil {
-					res[validator] = make(map[uint64]uint8, 0)
+					res[validator] = make(map[uint64]bool, 0)
 				}
-				if orphanedSlotsMap[attesterSlot] {
-					res[validator][attesterSlot] = 3
-				} else {
-					res[validator][attesterSlot] = 2
-				}
-			} else if res[validator] != nil && res[validator][attesterSlot] > 0 {
+				res[validator][attesterSlot] = true
+			} else if res[validator] != nil && res[validator][attesterSlot] {
 				delete(res[validator], attesterSlot)
 			}
 		}
@@ -1036,14 +1018,14 @@ func (bigtable *Bigtable) GetValidatorSyncDutiesHistory(validators []uint64, sta
 	return res, nil
 }
 
-func (bigtable *Bigtable) GetValidatorFailedAttestationsCount(validators []uint64, firstEpoch uint64, lastEpoch uint64) (map[uint64]*types.ValidatorFailedAttestationsStatistic, error) {
+func (bigtable *Bigtable) GetValidatorMissedAttestationsCount(validators []uint64, firstEpoch uint64, lastEpoch uint64) (map[uint64]*types.ValidatorMissedAttestationsStatistic, error) {
 	if firstEpoch > lastEpoch {
 		return nil, fmt.Errorf("GetValidatorMissedAttestationsCount received an invalid firstEpoch (%d) and lastEpoch (%d) combination", firstEpoch, lastEpoch)
 	}
 
-	res := make(map[uint64]*types.ValidatorFailedAttestationsStatistic)
+	res := make(map[uint64]*types.ValidatorMissedAttestationsStatistic)
 
-	data, err := bigtable.GetValidatorFailedAttestationHistory(validators, firstEpoch, lastEpoch)
+	data, err := bigtable.GetValidatorMissedAttestationHistory(validators, firstEpoch, lastEpoch)
 
 	if err != nil {
 		return nil, err
@@ -1055,19 +1037,9 @@ func (bigtable *Bigtable) GetValidatorFailedAttestationsCount(validators []uint6
 		if len(attestations) == 0 {
 			continue
 		}
-		missed := uint64(0)
-		orphaned := uint64(0)
-		for _, state := range attestations {
-			if state == 3 {
-				orphaned++
-			} else {
-				missed++
-			}
-		}
-		res[validator] = &types.ValidatorFailedAttestationsStatistic{
-			Index:                validator,
-			MissedAttestations:   missed,
-			OrphanedAttestations: orphaned,
+		res[validator] = &types.ValidatorMissedAttestationsStatistic{
+			Index:              validator,
+			MissedAttestations: uint64(len(attestations)),
 		}
 	}
 

--- a/db/statistics.go
+++ b/db/statistics.go
@@ -994,7 +994,7 @@ func WriteValidatorFailedAttestationsStatisticsForDay(day uint64) error {
 	logrus.Infof("exporting 'failed attestations' statistics firstEpoch: %v lastEpoch: %v", firstEpoch, lastEpoch)
 
 	// first key is the batch start index and the second is the validator id
-	failed := map[uint64]map[uint64]*types.ValidatorFailedAttestationsStatistic{}
+	failed := map[uint64]map[uint64]*types.ValidatorMissedAttestationsStatistic{}
 	mux := sync.Mutex{}
 	g, gCtx := errgroup.WithContext(ctx)
 	epochBatchSize := uint64(2) // Fetching 2 Epochs per batch seems to be the fastest way to go
@@ -1012,7 +1012,7 @@ func WriteValidatorFailedAttestationsStatisticsForDay(day uint64) error {
 				return nil
 			default:
 			}
-			ma, err := BigtableClient.GetValidatorFailedAttestationsCount([]uint64{}, fromEpoch, toEpoch)
+			ma, err := BigtableClient.GetValidatorMissedAttestationsCount([]uint64{}, fromEpoch, toEpoch)
 			if err != nil {
 				logrus.Errorf("error getting 'failed attestations' %v", err)
 				return err
@@ -1028,7 +1028,7 @@ func WriteValidatorFailedAttestationsStatisticsForDay(day uint64) error {
 		return err
 	}
 
-	validatorMap := map[uint64]*types.ValidatorFailedAttestationsStatistic{}
+	validatorMap := map[uint64]*types.ValidatorMissedAttestationsStatistic{}
 	for _, f := range failed {
 
 		for key, val := range f {
@@ -1036,14 +1036,13 @@ func WriteValidatorFailedAttestationsStatisticsForDay(day uint64) error {
 				validatorMap[key] = val
 			} else {
 				validatorMap[key].MissedAttestations += val.MissedAttestations
-				validatorMap[key].OrphanedAttestations += val.OrphanedAttestations
 			}
 		}
 	}
 
 	logrus.Infof("fetching 'failed attestations' done in %v, now we export them to the db", time.Since(start))
 	start = time.Now()
-	maArr := make([]*types.ValidatorFailedAttestationsStatistic, 0, len(validatorMap))
+	maArr := make([]*types.ValidatorMissedAttestationsStatistic, 0, len(validatorMap))
 
 	for _, stat := range validatorMap {
 		maArr = append(maArr, stat)
@@ -1084,7 +1083,7 @@ func WriteValidatorFailedAttestationsStatisticsForDay(day uint64) error {
 	return nil
 }
 
-func saveFailedAttestationBatch(batch []*types.ValidatorFailedAttestationsStatistic, day uint64) error {
+func saveFailedAttestationBatch(batch []*types.ValidatorMissedAttestationsStatistic, day uint64) error {
 	var failedAttestationBatchNumArgs int = 4
 	batchSize := len(batch)
 	valueStrings := make([]string, 0, failedAttestationBatchNumArgs)
@@ -1095,7 +1094,7 @@ func saveFailedAttestationBatch(batch []*types.ValidatorFailedAttestationsStatis
 		valueArgs = append(valueArgs, stat.Index)
 		valueArgs = append(valueArgs, day)
 		valueArgs = append(valueArgs, stat.MissedAttestations)
-		valueArgs = append(valueArgs, stat.OrphanedAttestations)
+		valueArgs = append(valueArgs, 0)
 	}
 	stmt := fmt.Sprintf(`
 		insert into validator_stats (validatorindex, day, missed_attestations, orphaned_attestations) VALUES

--- a/handlers/api.go
+++ b/handlers/api.go
@@ -1640,7 +1640,7 @@ func ApiValidatorDailyStats(w http.ResponseWriter, r *http.Request) {
 		min_effective_balance,
 		max_effective_balance,
 		COALESCE(missed_attestations, 0) AS missed_attestations,
-		COALESCE(orphaned_attestations, 0) AS orphaned_attestations,
+		0 AS orphaned_attestations,
 		COALESCE(proposed_blocks, 0) AS proposed_blocks,
 		COALESCE(missed_blocks, 0) AS missed_blocks,
 		COALESCE(orphaned_blocks, 0) AS orphaned_blocks,

--- a/handlers/validator.go
+++ b/handlers/validator.go
@@ -580,11 +580,11 @@ func Validator(w http.ResponseWriter, r *http.Request) {
 			lookback := int64(lastFinalizedEpoch - (lastStatsDay+1)*utils.EpochsPerDay())
 			if lookback > 0 {
 				// logger.Infof("retrieving attestations not yet in stats, lookback is %v", lookback)
-				attestations, err := db.BigtableClient.GetValidatorMissedAttestationHistory([]uint64{index}, lastFinalizedEpoch-uint64(lookback), lastFinalizedEpoch)
+				missedAttestations, err := db.BigtableClient.GetValidatorMissedAttestationHistory([]uint64{index}, lastFinalizedEpoch-uint64(lookback), lastFinalizedEpoch)
 				if err != nil {
 					return fmt.Errorf("error retrieving validator attestations not in stats from bigtable: %v", err)
 				}
-				attestationStats.MissedAttestations += uint64(len(attestations[index]))
+				attestationStats.MissedAttestations += uint64(len(missedAttestations[index]))
 			}
 
 			validatorPageData.MissedAttestationsCount = attestationStats.MissedAttestations

--- a/handlers/validator.go
+++ b/handlers/validator.go
@@ -567,11 +567,10 @@ func Validator(w http.ResponseWriter, r *http.Request) {
 		if validatorPageData.AttestationsCount > 0 {
 			// get attestationStats from validator_stats
 			attestationStats := struct {
-				MissedAttestations   uint64 `db:"missed_attestations"`
-				OrphanedAttestations uint64 `db:"orphaned_attestations"`
+				MissedAttestations uint64 `db:"missed_attestations"`
 			}{}
 			if lastStatsDay > 0 {
-				err = db.ReaderDb.Get(&attestationStats, "select coalesce(sum(missed_attestations), 0) as missed_attestations, coalesce(sum(orphaned_attestations), 0) as orphaned_attestations from validator_stats where validatorindex = $1", index)
+				err = db.ReaderDb.Get(&attestationStats, "select coalesce(sum(missed_attestations), 0) as missed_attestations from validator_stats where validatorindex = $1", index)
 				if err != nil {
 					return fmt.Errorf("error retrieving validator attestationStats: %v", err)
 				}
@@ -581,27 +580,15 @@ func Validator(w http.ResponseWriter, r *http.Request) {
 			lookback := int64(lastFinalizedEpoch - (lastStatsDay+1)*utils.EpochsPerDay())
 			if lookback > 0 {
 				// logger.Infof("retrieving attestations not yet in stats, lookback is %v", lookback)
-				attestations, err := db.BigtableClient.GetValidatorFailedAttestationHistory([]uint64{index}, lastFinalizedEpoch-uint64(lookback), lastFinalizedEpoch)
+				attestations, err := db.BigtableClient.GetValidatorMissedAttestationHistory([]uint64{index}, lastFinalizedEpoch-uint64(lookback), lastFinalizedEpoch)
 				if err != nil {
 					return fmt.Errorf("error retrieving validator attestations not in stats from bigtable: %v", err)
 				}
-				missed := uint64(0)
-				orphaned := uint64(0)
-				for _, state := range attestations[index] {
-					if state == 3 {
-						orphaned++
-					} else {
-						missed++
-					}
-				}
-				attestationStats.MissedAttestations += missed
-				attestationStats.OrphanedAttestations += orphaned
-
+				attestationStats.MissedAttestations += uint64(len(attestations[index]))
 			}
 
 			validatorPageData.MissedAttestationsCount = attestationStats.MissedAttestations
-			validatorPageData.OrphanedAttestationsCount = attestationStats.OrphanedAttestations
-			validatorPageData.ExecutedAttestationsCount = validatorPageData.AttestationsCount - validatorPageData.MissedAttestationsCount - validatorPageData.OrphanedAttestationsCount
+			validatorPageData.ExecutedAttestationsCount = validatorPageData.AttestationsCount - validatorPageData.MissedAttestationsCount
 			validatorPageData.UnmissedAttestationsPercentage = float64(validatorPageData.ExecutedAttestationsCount) / float64(validatorPageData.AttestationsCount)
 		}
 		return nil
@@ -1799,7 +1786,6 @@ func ValidatorStatsTable(w http.ResponseWriter, r *http.Request) {
 	min_effective_balance,
 	max_effective_balance,
 	COALESCE(missed_attestations, 0) AS missed_attestations,
-	COALESCE(orphaned_attestations, 0) AS orphaned_attestations,
 	COALESCE(proposed_blocks, 0) AS proposed_blocks,
 	COALESCE(missed_blocks, 0) AS missed_blocks,
 	COALESCE(orphaned_blocks, 0) AS orphaned_blocks,

--- a/templates/validator/overview.html
+++ b/templates/validator/overview.html
@@ -237,7 +237,7 @@
       <span id="blockCount" style="cursor: pointer;" data-toggle="tooltip" title="Blocks (Proposed: {{ .ProposedBlocksCount }}, Missed: {{ .MissedBlocksCount }}, Orphaned: {{ .OrphanedBlocksCount }}, Scheduled: {{ .ScheduledBlocksCount }})"><i class="fas fa-cubes poin"></i> {{ .BlocksCount }}{{ if ne .BlocksCount 0 }}({{ formatPercentageColoredEmoji .UnmissedBlocksPercentage }}){{ end }}</span>
     </div>
     <div class="mx-3">
-      <span id="attestationCount" style="cursor: pointer;" data-toggle="tooltip" title="Attestation Assignments (Executed: {{ .ExecutedAttestationsCount }}, Missed: {{ .MissedAttestationsCount }}, Orphaned: {{ .OrphanedAttestationsCount }})"><i class="fas fa-file-signature"></i> {{ .AttestationsCount }}{{ if ne .AttestationsCount 0 }}({{ formatPercentageColoredEmoji .UnmissedAttestationsPercentage }}){{ end }}</span>
+      <span id="attestationCount" style="cursor: pointer;" data-toggle="tooltip" title="Attestation Assignments (Executed: {{ .ExecutedAttestationsCount }}, Missed: {{ .MissedAttestationsCount }})"><i class="fas fa-file-signature"></i> {{ .AttestationsCount }}{{ if ne .AttestationsCount 0 }}({{ formatPercentageColoredEmoji .UnmissedAttestationsPercentage }}){{ end }}</span>
     </div>
     <div class="mx-3">
       <span id="syncCount" style="cursor: pointer;" data-toggle="tooltip" title="Sync Participations (Participated: {{ .ParticipatedSyncCountSlots }}, Missed: {{ .MissedSyncCountSlots }}, Orphaned: {{ .OrphanedSyncCountSlots }}, Scheduled: {{ .ScheduledSyncCountSlots }})">

--- a/templates/validator_stats_table.html
+++ b/templates/validator_stats_table.html
@@ -66,7 +66,6 @@
             <th title="Balance at the start of the day" data-toggle="tooltip">Start</th>
             <th title="Balance at the end of the day" data-toggle="tooltip">End</th>
             <th title="Amount of missed attestations" data-toggle="tooltip">M</th>
-            <th title="Amount of orphaned attestations" data-toggle="tooltip">O</th>
             <th title="Amount of proposed blocks" data-toggle="tooltip">P</th>
             <th title="Amount of missed blocks" data-toggle="tooltip">M</th>
             <th title="Amount of orphaned blocks" data-toggle="tooltip">O</th>
@@ -84,7 +83,6 @@
               <td>{{ formatBalanceSql .StartBalance $.Rates.Currency }}</td>
               <td>{{ formatBalanceSql .EndBalance $.Rates.Currency }}</td>
               <td>{{ formatSqlInt64 .MissedAttestations }}</td>
-              <td>{{ formatSqlInt64 .OrphanedAttestations }}</td>
               <td>{{ formatSqlInt64 .ProposedBlocks }}</td>
               <td>{{ formatSqlInt64 .MissedBlocks }}</td>
               <td>{{ formatSqlInt64 .OrphanedBlocks }}</td>

--- a/templates/validator_stats_table.html
+++ b/templates/validator_stats_table.html
@@ -55,7 +55,7 @@
           <tr>
             <th>Day</th>
             <th colspan="3">Balance</th>
-            <th colspan="2">Attestations</th>
+            <th colspan="1">Attestations</th>
             <th colspan="3">Blocks</th>
             <th colspan="2">Slashings</th>
             <th colspan="2">Deposits</th>

--- a/types/bigtable.go
+++ b/types/bigtable.go
@@ -17,10 +17,9 @@ type ValidatorBalanceStatistic struct {
 	EndBalance            uint64
 }
 
-type ValidatorFailedAttestationsStatistic struct {
-	Index                uint64
-	MissedAttestations   uint64
-	OrphanedAttestations uint64
+type ValidatorMissedAttestationsStatistic struct {
+	Index              uint64
+	MissedAttestations uint64
 }
 
 type ValidatorSyncDutiesStatistic struct {

--- a/types/templates.go
+++ b/types/templates.go
@@ -362,7 +362,6 @@ type ValidatorPageData struct {
 	AttestationsCount                        uint64
 	ExecutedAttestationsCount                uint64
 	MissedAttestationsCount                  uint64
-	OrphanedAttestationsCount                uint64
 	UnmissedAttestationsPercentage           float64 // missed/(executed+orphaned)
 	StatusProposedCount                      uint64
 	StatusMissedCount                        uint64
@@ -475,7 +474,6 @@ type ValidatorStatsTableRow struct {
 	MinEffectiveBalance    sql.NullInt64 `db:"min_effective_balance"`
 	MaxEffectiveBalance    sql.NullInt64 `db:"max_effective_balance"`
 	MissedAttestations     sql.NullInt64 `db:"missed_attestations"`
-	OrphanedAttestations   sql.NullInt64 `db:"orphaned_attestations"`
 	ProposedBlocks         sql.NullInt64 `db:"proposed_blocks"`
 	MissedBlocks           sql.NullInt64 `db:"missed_blocks"`
 	OrphanedBlocks         sql.NullInt64 `db:"orphaned_blocks"`


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f95a0aa</samp>

Removed the concept of orphaned attestations from the eth2-beaconchain-explorer codebase, as it is no longer relevant for the eth2 specification. Updated the logic and UI to count and display only missed attestations for validator performance. Renamed and refactored the types and functions related to attestation statistics accordingly. Affected files include `db/bigtable.go`, `db/statistics.go`, `handlers/validator.go`, `handlers/api.go`, `templates/validator_stats_table.html`, `templates/validator/overview.html`, `types/templates.go`, and `types/bigtable.go`.
