### PR TITLE
(BIDS-2218) fix db.GetValidatorIncomeHistory

### DIFF
--- a/cache/tiered_cache.go
+++ b/cache/tiered_cache.go
@@ -163,7 +163,7 @@ func (cache *tieredCache) Set(key string, value interface{}, expiration time.Dur
 		return err
 	}
 	cache.localGoCache.Set([]byte(key), valueMarshal, int(expiration.Seconds()))
-	return cache.remoteCache.Set(ctx, key, valueMarshal, expiration)
+	return cache.remoteCache.Set(ctx, key, value, expiration)
 }
 
 func (cache *tieredCache) GetWithLocalTimeout(key string, localExpiration time.Duration, returnValue interface{}) (interface{}, error) {


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d5689dd</samp>

Refactor cache system to use pointers for complex types in `db/statistics.go`. This reduces memory consumption and improves performance.
