### PR TITLE
(BIDS-1414) let's not start with a full chart day

### DIFF
--- a/db/statistics.go
+++ b/db/statistics.go
@@ -1271,13 +1271,15 @@ func WriteChartSeriesForDay(day int64) error {
 	dateTrunc := time.Date(startDate.Year(), startDate.Month(), startDate.Day(), 0, 0, 0, 0, time.UTC)
 
 	// inclusive slot
-	firstSlot := utils.TimeToSlot(uint64(dateTrunc.Unix()))
-
-	epochOffset := firstSlot % utils.Config.Chain.Config.SlotsPerEpoch
-	firstSlot = firstSlot - epochOffset
+	firstSlot := utils.TimeToFirstSlotOfEpoch(uint64(dateTrunc.Unix()))
 	firstEpoch := firstSlot / utils.Config.Chain.Config.SlotsPerEpoch
 	// exclusive slot
 	lastSlot := int64(firstSlot) + int64(epochsPerDay*utils.Config.Chain.Config.SlotsPerEpoch)
+	// The first day is not a whole day, so we take the first slot from the next day as lastSlot
+	if firstSlot == 0 {
+		nextDateTrunc := time.Date(startDate.Year(), startDate.Month(), startDate.Day()+1, 0, 0, 0, 0, time.UTC)
+		lastSlot = int64(utils.TimeToFirstSlotOfEpoch(uint64(nextDateTrunc.Unix())))
+	}
 	lastEpoch := lastSlot / int64(utils.Config.Chain.Config.SlotsPerEpoch)
 
 	finalizedCount, err := CountFinalizedEpochs(firstEpoch, uint64(lastEpoch))

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -324,6 +324,13 @@ func TimeToSlot(timestamp uint64) uint64 {
 	return (timestamp - Config.Chain.GenesisTimestamp) / Config.Chain.Config.SecondsPerSlot
 }
 
+func TimeToFirstSlotOfEpoch(timestamp uint64) uint64 {
+	slot := TimeToSlot(timestamp)
+	lastEpochOffset := slot % Config.Chain.Config.SlotsPerEpoch
+	slot = slot - lastEpochOffset
+	return slot
+}
+
 // EpochToTime will return a time.Time for an epoch
 func EpochToTime(epoch uint64) time.Time {
 	return time.Unix(int64(Config.Chain.GenesisTimestamp+epoch*Config.Chain.Config.SecondsPerSlot*Config.Chain.Config.SlotsPerEpoch), 0)


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b880fa1</samp>

Fixed a bug in the chart series data calculation for the first and last slot of a day, and added a helper function to find the first slot of an epoch given a timestamp. The changes affect the files `db/statistics.go` and `utils/utils.go`.
