### PR TITLE
(NOBIDS) increase charts-update interval

### DIFF
--- a/services/charts_updater.go
+++ b/services/charts_updater.go
@@ -112,7 +112,7 @@ func chartsPageDataUpdater(wg *sync.WaitGroup) {
 		}
 		if latestEpoch == 0 {
 			ReportStatus("chartsPageDataUpdater", "Running", nil)
-			time.Sleep(time.Second * 60 * 10)
+			time.Sleep(time.Second * 60 * 60)
 		}
 	}
 }


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ea5798d</samp>

Reduced the frequency of charts data updates when the beacon chain is not active or the database is empty. Changed the sleep duration in `chartsPageDataUpdater` from 10 to 60 minutes in `services/charts_updater.go`.
