### PR TITLE
(BIDS-2252) remove errors from search input

### DIFF
--- a/handlers/search.go
+++ b/handlers/search.go
@@ -81,7 +81,7 @@ func SearchAhead(w http.ResponseWriter, r *http.Request) {
 		}
 		result = &types.SearchAheadSlotsResult{}
 		if searchLikeRE.MatchString(search) {
-			if _, convertErr := strconv.Atoi(search); convertErr == nil {
+			if _, convertErr := strconv.ParseInt(search, 10, 32); convertErr == nil {
 				err = db.ReaderDb.Select(result, `
 				SELECT slot, ENCODE(blockroot, 'hex') AS blockroot 
 				FROM blocks 
@@ -154,7 +154,7 @@ func SearchAhead(w http.ResponseWriter, r *http.Request) {
 	case "validators":
 		// find all validators that have a index, publickey or name like the search-query
 		result = &types.SearchAheadValidatorsResult{}
-		indexNumeric, errParse := strconv.ParseInt(search, 10, 64)
+		indexNumeric, errParse := strconv.ParseInt(search, 10, 32)
 		if errParse == nil { // search the validator by its index
 			err = db.ReaderDb.Select(result, `SELECT validatorindex AS index, pubkeyhex as pubkey FROM validators WHERE validatorindex = $1`, indexNumeric)
 			if err != nil {

--- a/handlers/search.go
+++ b/handlers/search.go
@@ -225,7 +225,7 @@ func SearchAhead(w http.ResponseWriter, r *http.Request) {
 	case "indexed_validators":
 		// find all validators that have a publickey or index like the search-query
 		result = &types.SearchAheadValidatorsResult{}
-		indexNumeric, errParse := strconv.ParseInt(search, 10, 64)
+		indexNumeric, errParse := strconv.ParseInt(search, 10, 32)
 		if errParse == nil { // search the validator by its index
 			err = db.ReaderDb.Select(result, `SELECT validatorindex AS index, pubkeyhex as pubkey FROM validators WHERE validatorindex = $1`, indexNumeric)
 			if err != nil {


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 345b7d1</samp>

Fix overflow bugs in slot and validator search functions. Use `strconv.ParseInt` instead of `strconv.Atoi` in `handlers/search.go`.
