### PR TITLE
(NOBIDS) db: add index idx_blocks_withdrawals_withdrawalindex

### DIFF
--- a/db/migrations/20230628120206_add_index_for_withrawalsindex.sql
+++ b/db/migrations/20230628120206_add_index_for_withrawalsindex.sql
@@ -1,0 +1,13 @@
+-- +goose NO TRANSACTION
+-- +goose Up
+
+SELECT 'create idx_blocks_withdrawals_withdrawalindex';
+-- +goose StatementBegin
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_blocks_withdrawals_withdrawalindex ON public.blocks_withdrawals USING btree (withdrawalindex DESC);
+-- +goose StatementEnd
+
+-- +goose Down
+SELECT 'drop idx_blocks_withdrawals_withdrawalindex';
+-- +goose StatementBegin
+DROP INDEX CONCURRENTLY idx_blocks_withdrawals_withdrawalindex;
+-- +goose StatementEnd


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f4e640a</samp>

Add a concurrent index on `withdrawalindex` column of `blocks_withdrawals` table to improve query performance for withdrawals feature.
