### PR TITLE
(BIDS-2178) lets not finalize too early

### DIFF
--- a/handlers/slot.go
+++ b/handlers/slot.go
@@ -241,7 +241,7 @@ func GetSlotPageData(blockSlot uint64) (*types.BlockPageData, error) {
 		LEFT JOIN validator_names ON validators.pubkey = validator_names.publickey
 		LEFT JOIN blocks_tags ON blocks.slot = blocks_tags.slot and blocks.blockroot = blocks_tags.blockroot
 		LEFT JOIN tags ON blocks_tags.tag_id = tags.id
-		LEFT JOIN epochs ON (GREATEST(blocks.slot,1)-1)/32 = epochs.epoch
+		LEFT JOIN epochs ON (GREATEST(blocks.slot,1)-1)/$2 = epochs.epoch
 		WHERE blocks.slot = $1 
 		group by
 			blocks.epoch,
@@ -252,7 +252,7 @@ func GetSlotPageData(blockSlot uint64) (*types.BlockPageData, error) {
 			epoch_participation_rate
 		ORDER BY blocks.blockroot DESC, blocks.status ASC limit 1
 		`,
-		blockSlot)
+		blockSlot, utils.Config.Chain.Config.SlotsPerEpoch)
 	if err != nil {
 		return nil, err
 	}

--- a/handlers/slot.go
+++ b/handlers/slot.go
@@ -204,6 +204,7 @@ func getAttestationsData(slot uint64, onlyFirst bool) ([]*types.BlockPageAttesta
 func GetSlotPageData(blockSlot uint64) (*types.BlockPageData, error) {
 	blockPageData := types.BlockPageData{}
 	blockPageData.Mainnet = utils.Config.Chain.Config.ConfigName == "mainnet"
+	// for the first slot in an epoch the previous epoch defines the finalized state
 	err := db.ReaderDb.Get(&blockPageData, `
 		SELECT
 			blocks.epoch,
@@ -240,7 +241,7 @@ func GetSlotPageData(blockSlot uint64) (*types.BlockPageData, error) {
 		LEFT JOIN validator_names ON validators.pubkey = validator_names.publickey
 		LEFT JOIN blocks_tags ON blocks.slot = blocks_tags.slot and blocks.blockroot = blocks_tags.blockroot
 		LEFT JOIN tags ON blocks_tags.tag_id = tags.id
-		LEFT JOIN epochs ON blocks.epoch = epochs.epoch
+		LEFT JOIN epochs ON (GREATEST(blocks.slot,1)-1)/32 = epochs.epoch
 		WHERE blocks.slot = $1 
 		group by
 			blocks.epoch,

--- a/rpc/lighthouse.go
+++ b/rpc/lighthouse.go
@@ -149,12 +149,18 @@ func (lc *LighthouseClient) GetChainHead() (*types.ChainHead, error) {
 		return nil, fmt.Errorf("error parsing finality checkpoints of head: %v", err)
 	}
 
+	// The epoch in the Finalized Object is not the finalized epoch, but the epoch for the checkpoint - the 'real' finalized epoch is the one before
+	var finalizedEpoch = uint64(parsedFinality.Data.Finalized.Epoch)
+	if finalizedEpoch > 0 {
+		finalizedEpoch--
+	}
+
 	return &types.ChainHead{
 		HeadSlot:                   uint64(parsedHead.Data.Header.Message.Slot),
 		HeadEpoch:                  uint64(parsedHead.Data.Header.Message.Slot) / utils.Config.Chain.Config.SlotsPerEpoch,
 		HeadBlockRoot:              utils.MustParseHex(parsedHead.Data.Root),
-		FinalizedSlot:              uint64(parsedFinality.Data.Finalized.Epoch) * utils.Config.Chain.Config.SlotsPerEpoch,
-		FinalizedEpoch:             uint64(parsedFinality.Data.Finalized.Epoch),
+		FinalizedSlot:              (finalizedEpoch + 1) * utils.Config.Chain.Config.SlotsPerEpoch, // The first Slot of the next epoch is finalized.
+		FinalizedEpoch:             finalizedEpoch,
 		FinalizedBlockRoot:         utils.MustParseHex(parsedFinality.Data.Finalized.Root),
 		JustifiedSlot:              uint64(parsedFinality.Data.CurrentJustified.Epoch) * utils.Config.Chain.Config.SlotsPerEpoch,
 		JustifiedEpoch:             uint64(parsedFinality.Data.CurrentJustified.Epoch),


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b8c65ab</samp>

This pull request fixes two bugs related to the display and calculation of finalized epochs and slots in the slot page and the Lighthouse RPC client. It adjusts the join condition in `handlers/slot.go` and the epoch parsing in `rpc/lighthouse.go` to account for the different ways that finalized checkpoints are represented by the database and the Lighthouse API.
