### PR TITLE
(NOBIDS) Fix typo for too many webhooks and improve error output

### DIFF
--- a/handlers/user.go
+++ b/handlers/user.go
@@ -2753,7 +2753,7 @@ func UsersAddWebhook(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if webhookCount >= allowed {
-		http.Error(w, "Too man webhooks exist already", 400)
+		http.Error(w, fmt.Sprintf("Too many webhooks (%v / %v) exist already", webhookCount, allowed), 400)
 		utils.SetFlash(w, r, authSessionName, "Error: We could not add another webhook, you've already reached the maximum allowed, which.")
 		http.Redirect(w, r, "/user/webhooks", http.StatusSeeOther)
 		return

--- a/handlers/user.go
+++ b/handlers/user.go
@@ -2754,7 +2754,7 @@ func UsersAddWebhook(w http.ResponseWriter, r *http.Request) {
 
 	if webhookCount >= allowed {
 		http.Error(w, fmt.Sprintf("Too many webhooks (%v / %v) exist already", webhookCount, allowed), 400)
-		utils.SetFlash(w, r, authSessionName, "Error: We could not add another webhook, you've already reached the maximum allowed, which.")
+		utils.SetFlash(w, r, authSessionName, fmt.Sprintf("Error: We could not add another webhook because you have already reached the maximum number allowed (%v, %v).", webhookCount, allowed))
 		http.Redirect(w, r, "/user/webhooks", http.StatusSeeOther)
 		return
 	}


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bfd8624</samp>

Improved error message for webhook limit in `handlers/user.go`. The change enhances the user feedback and experience of the webhook feature.
