### PR TITLE
(NOBIDS) fix errgroup ctx handling

### DIFF
--- a/cmd/eth1indexer/main.go
+++ b/cmd/eth1indexer/main.go
@@ -685,7 +685,7 @@ func IndexFromNode(bt *db.Bigtable, client *rpc.ErigonClient, start, end, concur
 		g.Go(func() error {
 			select {
 			case <-gCtx.Done():
-				return nil // halt once processing of a block failed
+				return gCtx.Err()
 			default:
 			}
 

--- a/cmd/misc/main.go
+++ b/cmd/misc/main.go
@@ -198,7 +198,7 @@ func updateAggreationBits(rpcClient *rpc.LighthouseClient, startEpoch uint64, en
 					g.Go(func() error {
 						select {
 						case <-gCtx.Done():
-							return nil // halt once processing of a slot failed
+							return gCtx.Err()
 						default:
 						}
 
@@ -227,7 +227,7 @@ func updateAggreationBits(rpcClient *rpc.LighthouseClient, startEpoch uint64, en
 					g.Go(func() error {
 						select {
 						case <-gCtx.Done():
-							return nil // halt once processing of a slot failed
+							return gCtx.Err()
 						default:
 						}
 						var aggregationbits *[]byte

--- a/db/bigtable.go
+++ b/db/bigtable.go
@@ -1160,7 +1160,7 @@ func (bigtable *Bigtable) GetValidatorBalanceStatistics(startEpoch, endEpoch uin
 		g.Go(func() error {
 			select {
 			case <-gCtx.Done():
-				return nil
+				return gCtx.Err()
 			default:
 			}
 			ranges := bigtable.getEpochRanges(fromEpoch, toEpoch)
@@ -1615,7 +1615,7 @@ func (bigtable *Bigtable) GetAggregatedValidatorIncomeDetailsHistory(validators 
 		g.Go(func() error {
 			select {
 			case <-gCtx.Done():
-				return nil
+				return gCtx.Err()
 			default:
 			}
 			ranges := bigtable.getEpochRanges(fromEpoch, toEpoch)

--- a/db/statistics.go
+++ b/db/statistics.go
@@ -225,7 +225,7 @@ func WriteValidatorTotalPerformance(day uint64) error {
 		g.Go(func() error {
 			select {
 			case <-gCtx.Done():
-				return nil
+				return gCtx.Err()
 			default:
 			}
 			_, err = WriterDb.Exec(`
@@ -654,7 +654,7 @@ func WriteValidatorClIcome(day uint64) error {
 		g.Go(func() error {
 			select {
 			case <-gCtx.Done():
-				return nil
+				return gCtx.Err()
 			default:
 			}
 			_, err := WriterDb.Exec(stmt, valueArgs...)
@@ -755,7 +755,7 @@ func WriteValidatorBalances(day uint64) error {
 		g.Go(func() error {
 			select {
 			case <-gCtx.Done():
-				return nil
+				return gCtx.Err()
 			default:
 			}
 			defer logger.Infof("saving validator balance batch %v completed", start)
@@ -1010,7 +1010,7 @@ func WriteValidatorFailedAttestationsStatisticsForDay(day uint64) error {
 		g.Go(func() error {
 			select {
 			case <-gCtx.Done():
-				return nil
+				return gCtx.Err()
 			default:
 			}
 			ma, err := BigtableClient.GetValidatorMissedAttestationsCount([]uint64{}, fromEpoch, toEpoch)
@@ -1063,7 +1063,7 @@ func WriteValidatorFailedAttestationsStatisticsForDay(day uint64) error {
 		g.Go(func() error {
 			select {
 			case <-gCtx.Done():
-				return nil
+				return gCtx.Err()
 			default:
 			}
 			return saveFailedAttestationBatch(maArr[start:end], day)


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9068aba</samp>

Improved error handling for context-based database operations and indexing. The changes return and handle context errors in various functions that use contexts to cancel queries or writes in case of errors or signals. The affected files are `cmd/misc/main.go`, `db/bigtable.go`, `db/statistics.go`, and `cmd/eth1indexer/main.go`.
