### PR TITLE
(BIDS-2224) Do a double check for machine offline

### DIFF
--- a/services/notifications.go
+++ b/services/notifications.go
@@ -2376,6 +2376,10 @@ func collectMonitoringMachine(
 			return nil
 		}
 	}
+	if eventName == types.MonitoringMachineOfflineEventName {
+		// Notifications will be sent, reset the flag
+		isFirstNotificationCheck = true
+	}
 
 	for _, r := range result {
 

--- a/services/notifications.go
+++ b/services/notifications.go
@@ -2359,7 +2359,7 @@ func collectMonitoringMachine(
 		return err
 	}
 
-	// If less than 10 users are subscribed send the notifications
+	// If there are too few users subscribed to this event, we always send the notifications
 	if subScriptionCount >= subThreshold {
 		subRatioThreshold := subSecondRatioThreshold
 		// For the machine offline check we do a low threshold check first and the next time a high threshold check
@@ -2371,10 +2371,6 @@ func collectMonitoringMachine(
 			utils.LogError(nil, fmt.Errorf("error too many users would be notified concerning: %v", eventName), 0)
 			return nil
 		}
-	}
-	if eventName == types.MonitoringMachineOfflineEventName {
-		// Notifications will be sent, reset the flag
-		isFirstNotificationCheck = true
 	}
 
 	for _, r := range result {
@@ -2396,6 +2392,11 @@ func collectMonitoringMachine(
 		}
 		notificationsByUserID[r.UserID][n.GetEventName()] = append(notificationsByUserID[r.UserID][n.GetEventName()], n)
 		metrics.NotificationsCollected.WithLabelValues(string(n.GetEventName())).Inc()
+	}
+
+	if eventName == types.MonitoringMachineOfflineEventName {
+		// Notifications will be sent, reset the flag
+		isFirstNotificationCheck = true
 	}
 
 	return nil

--- a/services/notifications.go
+++ b/services/notifications.go
@@ -2344,10 +2344,6 @@ func collectMonitoringMachine(
 		}
 	}
 
-	if len(result) == 0 {
-		return nil
-	}
-
 	const subThreshold = 10
 	const subFirstRatioThreshold = 0.3
 	const subSecondRatioThreshold = 0.9

--- a/services/notifications.go
+++ b/services/notifications.go
@@ -2344,9 +2344,20 @@ func collectMonitoringMachine(
 		}
 	}
 
-	const subThreshold = 10
-	const subFirstRatioThreshold = 0.3
-	const subSecondRatioThreshold = 0.9
+	subThreshold := uint64(10)
+	if utils.Config.Notifications.MachineEventThreshold != 0 {
+		subThreshold = utils.Config.Notifications.MachineEventThreshold
+	}
+
+	subFirstRatioThreshold := 0.3
+	if utils.Config.Notifications.MachineEventFirstRatioThreshold != 0 {
+		subFirstRatioThreshold = utils.Config.Notifications.MachineEventFirstRatioThreshold
+	}
+
+	subSecondRatioThreshold := 0.9
+	if utils.Config.Notifications.MachineEventSecondRatioThreshold != 0 {
+		subSecondRatioThreshold = utils.Config.Notifications.MachineEventSecondRatioThreshold
+	}
 
 	var subScriptionCount uint64
 	err = db.FrontendWriterDB.Get(&subScriptionCount,

--- a/types/config.go
+++ b/types/config.go
@@ -168,12 +168,15 @@ type Config struct {
 		Pprof   bool   `yaml:"pprof" envconfig:"METRICS_PPROF"`
 	} `yaml:"metrics"`
 	Notifications struct {
-		UserDBNotifications                           bool   `yaml:"userDbNotifications" envconfig:"USERDB_NOTIFICATIONS_ENABLED"`
-		FirebaseCredentialsPath                       string `yaml:"firebaseCredentialsPath" envconfig:"NOTIFICATIONS_FIREBASE_CRED_PATH"`
-		ValidatorBalanceDecreasedNotificationsEnabled bool   `yaml:"validatorBalanceDecreasedNotificationsEnabled" envconfig:"VALIDATOR_BALANCE_DECREASED_NOTIFICATIONS_ENABLED"`
-		PubkeyCachePath                               string `yaml:"pubkeyCachePath" envconfig:"NOTIFICATIONS_PUBKEY_CACHE_PATH"`
-		OnlineDetectionLimit                          int    `yaml:"onlineDetectionLimit" envconfig:"ONLINE_DETECTION_LIMIT"`
-		OfflineDetectionLimit                         int    `yaml:"offlineDetectionLimit" envconfig:"OFFLINE_DETECTION_LIMIT"`
+		UserDBNotifications                           bool    `yaml:"userDbNotifications" envconfig:"USERDB_NOTIFICATIONS_ENABLED"`
+		FirebaseCredentialsPath                       string  `yaml:"firebaseCredentialsPath" envconfig:"NOTIFICATIONS_FIREBASE_CRED_PATH"`
+		ValidatorBalanceDecreasedNotificationsEnabled bool    `yaml:"validatorBalanceDecreasedNotificationsEnabled" envconfig:"VALIDATOR_BALANCE_DECREASED_NOTIFICATIONS_ENABLED"`
+		PubkeyCachePath                               string  `yaml:"pubkeyCachePath" envconfig:"NOTIFICATIONS_PUBKEY_CACHE_PATH"`
+		OnlineDetectionLimit                          int     `yaml:"onlineDetectionLimit" envconfig:"ONLINE_DETECTION_LIMIT"`
+		OfflineDetectionLimit                         int     `yaml:"offlineDetectionLimit" envconfig:"OFFLINE_DETECTION_LIMIT"`
+		MachineEventThreshold                         uint64  `yaml:"machineEventThreshold" envconfig:"MACHINE_EVENT_THRESHOLD"`
+		MachineEventFirstRatioThreshold               float64 `yaml:"machineEventFirstRatioThreshold" envconfig:"MACHINE_EVENT_FIRST_RATIO_THRESHOLD"`
+		MachineEventSecondRatioThreshold              float64 `yaml:"machineEventSecondRatioThreshold" envconfig:"MACHINE_EVENT_SECOND_RATIO_THRESHOLD"`
 	} `yaml:"notifications"`
 	SSVExporter struct {
 		Enabled bool   `yaml:"enabled" envconfig:"SSV_EXPORTER_ENABLED"`


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c9692e4</samp>

Improved the logic and flexibility of machine offline notifications in `services/notifications.go`. Introduced a variable to allow for a higher tolerance of offline ratio for the first check, and handled various cases of machine status and user settings.
