### PR TITLE
(BIDS-2285) Update the boundaries for withdrawals and deposits

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -3156,26 +3156,26 @@ func GetTotalValidatorWithdrawals(validators []uint64, totalWithdrawals *uint64)
 	`, validatorsPQArray)
 }
 
-func GetValidatorDepositsForEpochs(validators []uint64, fromEpoch uint64, toEpoch uint64, deposits *uint64) error {
+func GetValidatorDepositsForSlots(validators []uint64, fromSlot uint64, toSlot uint64, deposits *uint64) error {
 	validatorsPQArray := pq.Array(validators)
 	return ReaderDb.Get(deposits, `
 		SELECT 
 			COALESCE(SUM(amount), 0) 
 		FROM blocks_deposits d
-		INNER JOIN blocks b ON b.blockroot = d.block_root AND b.status = '1' and b.epoch >= $2 and b.epoch <= $3
+		INNER JOIN blocks b ON b.blockroot = d.block_root AND b.status = '1' and b.slot >= $2 and b.slot <= $3
 		WHERE publickey IN (SELECT pubkey FROM validators WHERE validatorindex = ANY($1))
-	`, validatorsPQArray, fromEpoch, toEpoch)
+	`, validatorsPQArray, fromSlot, toSlot)
 }
 
-func GetValidatorWithdrawalsForEpochs(validators []uint64, fromEpoch uint64, toEpoch uint64, withdrawals *uint64) error {
+func GetValidatorWithdrawalsForSlots(validators []uint64, fromSlot uint64, toSlot uint64, withdrawals *uint64) error {
 	validatorsPQArray := pq.Array(validators)
 	return ReaderDb.Get(withdrawals, `
 		SELECT 
 			COALESCE(SUM(amount), 0) 
 		FROM blocks_withdrawals d
-		INNER JOIN blocks b ON b.blockroot = d.block_root AND b.status = '1' and b.epoch >= $2 and b.epoch <= $3        
+		INNER JOIN blocks b ON b.blockroot = d.block_root AND b.status = '1' and b.slot >= $2 and b.slot <= $3        
 		WHERE validatorindex = ANY($1)
-	`, validatorsPQArray, fromEpoch, toEpoch)
+	`, validatorsPQArray, fromSlot, toSlot)
 }
 
 func GetValidatorBalanceForDay(validators []uint64, day uint64, balance *uint64) error {

--- a/handlers/common.go
+++ b/handlers/common.go
@@ -54,8 +54,7 @@ func GetValidatorEarnings(validators []uint64, currency string) (*types.Validato
 	if err != nil {
 		return nil, nil, err
 	}
-	firstEpoch := (lastStatsDay + 1) * utils.EpochsPerDay()
-	firstSlot := (firstEpoch-1)*utils.Config.Chain.Config.SlotsPerEpoch + 1
+	firstSlot := utils.GetLastBalanceInfoSlotForDay(lastStatsDay) + 1
 	lastSlot := latestFinalizedEpoch * utils.Config.Chain.Config.SlotsPerEpoch
 
 	balancesMap := make(map[uint64]*types.Validator, 0)

--- a/handlers/common.go
+++ b/handlers/common.go
@@ -55,6 +55,8 @@ func GetValidatorEarnings(validators []uint64, currency string) (*types.Validato
 		return nil, nil, err
 	}
 	firstEpoch := (lastStatsDay + 1) * utils.EpochsPerDay()
+	firstSlot := (firstEpoch-1)*utils.Config.Chain.Config.SlotsPerEpoch + 1
+	lastSlot := latestFinalizedEpoch * utils.Config.Chain.Config.SlotsPerEpoch
 
 	balancesMap := make(map[uint64]*types.Validator, 0)
 	totalBalance := uint64(0)
@@ -100,12 +102,12 @@ func GetValidatorEarnings(validators []uint64, currency string) (*types.Validato
 
 	var lastDeposits uint64
 	g.Go(func() error {
-		return db.GetValidatorDepositsForEpochs(validators, firstEpoch, latestFinalizedEpoch, &lastDeposits)
+		return db.GetValidatorDepositsForSlots(validators, firstSlot, lastSlot, &lastDeposits)
 	})
 
 	var lastWithdrawals uint64
 	g.Go(func() error {
-		return db.GetValidatorWithdrawalsForEpochs(validators, firstEpoch, latestFinalizedEpoch, &lastWithdrawals)
+		return db.GetValidatorWithdrawalsForSlots(validators, firstSlot, lastSlot, &lastWithdrawals)
 	})
 
 	var lastBalance uint64

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1118,6 +1118,10 @@ func GetFirstAndLastEpochForDay(day uint64) (uint64, uint64) {
 	return firstEpoch, lastEpoch
 }
 
+func GetLastBalanceInfoSlotForDay(day uint64) uint64 {
+	return ((day+1)*EpochsPerDay() - 1) * Config.Chain.Config.SlotsPerEpoch
+}
+
 // ForkVersionAtEpoch returns the forkversion active a specific epoch
 func ForkVersionAtEpoch(epoch uint64) *types.ForkVersion {
 	if epoch >= Config.Chain.Config.CappellaForkEpoch {


### PR DESCRIPTION
See the comments in the BIDS.

The bug that only affects the current day can be tested by searching for a validator that had a withdrawal in the last epoch of the last day but not in the first slot of that epoch.
You can search for slots of withdrawals here /validators/withdrawals

Since the values for the chart are taking from the cache it may have to be deactivated
https://github.com/gobitfly/eth2-beaconchain-explorer/blob/02e8d6c1cd393d9500b720348962b133813c9da2/db/statistics.go#L1173

The other persistent bug requires a reexport of the statistics first and couldn't be tested.