### PR TITLE
(NOBIDS) fixed default http timeouts (copy paste issue)

### DIFF
--- a/cmd/explorer/main.go
+++ b/cmd/explorer/main.go
@@ -698,10 +698,10 @@ func main() {
 		n.UseHandler(utils.SessionStore.SCS.LoadAndSave(router))
 
 		if utils.Config.Frontend.HttpWriteTimeout == 0 {
-			utils.Config.Frontend.HttpIdleTimeout = time.Second * 15
+			utils.Config.Frontend.HttpWriteTimeout = time.Second * 15
 		}
 		if utils.Config.Frontend.HttpReadTimeout == 0 {
-			utils.Config.Frontend.HttpIdleTimeout = time.Second * 15
+			utils.Config.Frontend.HttpReadTimeout = time.Second * 15
 		}
 		if utils.Config.Frontend.HttpIdleTimeout == 0 {
 			utils.Config.Frontend.HttpIdleTimeout = time.Second * 60


### PR DESCRIPTION
Fixed an obvious copy paste issue in `cmd/explorer/main.go` when setting the defaults for `Config.Frontend.HttpWriteTimeout` & `Config.Frontend.HttpReadTimeout`

I guess the code was copy pasted from the `Config.Frontend.HttpIdleTimeout` default assignment, and the property name hasn't been changed properly 😉