### PR TITLE
(BIDS-2279) Add head parameter to slot endpoint

### DIFF
--- a/handlers/api.go
+++ b/handlers/api.go
@@ -372,11 +372,11 @@ func ApiEpochSlots(w http.ResponseWriter, r *http.Request) {
 }
 
 // ApiSlots godoc
-// @Summary Get a slot by its slot number or root hash
+// @Summary Get a slot by its slot number or root hash. Alternatively get the latest slot or the slot containing the head block.
 // @Tags Slot
-// @Description Returns a slot by its slot number or root hash or the latest slot with string latest
+// @Description Returns a slot by its slot number or root hash, the latest slot with string latest or the slot containing the head block with string head
 // @Produce  json
-// @Param  slotOrHash path string true "Slot or root hash or the string latest"
+// @Param  slotOrHash path string true "Slot or root hash or the string latest or head"
 // @Success 200 {object} types.ApiResponse{data=types.APISlotResponse}
 // @Failure 400 {object} types.ApiResponse
 // @Router /api/v1/slot/{slotOrHash} [get]
@@ -384,25 +384,42 @@ func ApiSlots(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 
 	vars := mux.Vars(r)
-
 	slotOrHash := strings.Replace(vars["slotOrHash"], "0x", "", -1)
+
 	blockSlot := int64(-1)
-	blockRootHash, err := hex.DecodeString(slotOrHash)
-	if slotOrHash != "latest" && (err != nil || len(slotOrHash) != 64) {
-		blockRootHash = []byte{}
-		blockSlot, err = strconv.ParseInt(vars["slotOrHash"], 10, 64)
-		if err != nil {
-			sendErrorResponse(w, r.URL.String(), "could not parse slot number")
+	blockRootHash := []byte{}
+
+	if slotOrHash == "latest" {
+		// simply check the latest slot (might be empty which causes an error)
+		blockSlot = int64(services.LatestSlot())
+	} else if slotOrHash == "head" {
+		// retrieve the slot containing the head block of the chain (cannot return an empty slot unless there is no block in the chain yet)
+		err := db.ReaderDb.Get(&blockRootHash, `
+			SELECT blockroot
+			FROM blocks
+			WHERE status = '1'
+			ORDER BY slot DESC
+			LIMIT 1`)
+
+		if err != nil || len(blockRootHash) != 32 {
+			sendErrorResponse(w, r.URL.String(), "could not retrieve db results")
 			return
+		}
+	} else {
+		var err error
+		blockRootHash, err = hex.DecodeString(slotOrHash)
+		if err != nil || len(slotOrHash) != 64 {
+			// not a valid root hash, try to parse as slot number instead
+			blockRootHash = []byte{}
+			blockSlot, err = strconv.ParseInt(vars["slotOrHash"], 10, 64)
+			if err != nil {
+				sendErrorResponse(w, r.URL.String(), "could not parse slot number")
+				return
+			}
 		}
 	}
 
-	if slotOrHash == "latest" {
-		blockSlot = int64(services.LatestSlot())
-	}
-
 	if len(blockRootHash) != 32 {
-		// blockRootHash is required for the SQL statement below, if none has passed we retrieve it manually
 		err := db.ReaderDb.Get(&blockRootHash, `SELECT blockroot FROM blocks WHERE slot = $1`, blockSlot)
 
 		if err != nil || len(blockRootHash) != 32 {
@@ -456,7 +473,7 @@ func ApiSlots(w http.ResponseWriter, r *http.Request) {
 	LEFT JOIN
 		(SELECT beaconblockroot, sum(array_length(validators, 1)) AS votes FROM blocks_attestations GROUP BY beaconblockroot) ba ON (blocks.blockroot = ba.beaconblockroot)
 	WHERE
-		blocks.blockroot = $1;`, blockRootHash)
+		blocks.blockroot = $1`, blockRootHash)
 
 	if err != nil {
 		logger.WithError(err).Error("could not retrieve db results")

--- a/handlers/api.go
+++ b/handlers/api.go
@@ -393,15 +393,9 @@ func ApiSlots(w http.ResponseWriter, r *http.Request) {
 		// simply check the latest slot (might be empty which causes an error)
 		blockSlot = int64(services.LatestSlot())
 	} else if slotOrHash == "head" {
-		// retrieve the slot containing the head block of the chain (cannot return an empty slot unless there is no block in the chain yet)
-		err := db.ReaderDb.Get(&blockRootHash, `
-			SELECT blockroot
-			FROM blocks
-			WHERE status = '1'
-			ORDER BY slot DESC
-			LIMIT 1`)
-
-		if err != nil || len(blockRootHash) != 32 {
+		// retrieve the slot containing the head block of the chain
+		blockRootHash = services.Eth1HeadBlockRootHash()
+		if len(blockRootHash) != 32 {
 			sendErrorResponse(w, r.URL.String(), "could not retrieve db results")
 			return
 		}

--- a/services/execution_layer.go
+++ b/services/execution_layer.go
@@ -10,6 +10,7 @@ import (
 )
 
 const latestBlockNumberCacheKey = "latestEth1BlockNumber"
+const latestBlockHashRootCacheKey = "latestEth1BlockRootHash"
 
 // latestBlockUpdater updates the most recent eth1 block number variable
 func latestBlockUpdater(wg *sync.WaitGroup) {
@@ -47,8 +48,6 @@ func LatestEth1BlockNumber() uint64 {
 	}
 	return 0
 }
-
-const latestBlockHashRootCacheKey = "latestEth1BlockRootHash"
 
 // headBlockRootHashUpdater updates the hash of the current chain head block
 func headBlockRootHashUpdater(wg *sync.WaitGroup) {

--- a/services/execution_layer.go
+++ b/services/execution_layer.go
@@ -9,6 +9,8 @@ import (
 	"time"
 )
 
+const latestBlockNumberCacheKey = "latestEth1BlockNumber"
+
 // latestBlockUpdater updates the most recent eth1 block number variable
 func latestBlockUpdater(wg *sync.WaitGroup) {
 	firstRun := true
@@ -18,10 +20,10 @@ func latestBlockUpdater(wg *sync.WaitGroup) {
 		if err != nil {
 			logger.WithError(err).Error("error getting most recent eth1 block")
 		}
-		cacheKey := fmt.Sprintf("%d:frontend:latestEth1BlockNumber", utils.Config.Chain.Config.DepositChainID)
+		cacheKey := fmt.Sprintf("%d:frontend:%s", utils.Config.Chain.Config.DepositChainID, latestBlockNumberCacheKey)
 		err = cache.TieredCache.SetUint64(cacheKey, recent.GetNumber(), time.Hour*24)
 		if err != nil {
-			logger.Errorf("error caching latestBlockNumber: %v", err)
+			logger.Errorf("error caching %s: %v", latestBlockNumberCacheKey, err)
 		}
 
 		if firstRun {
@@ -34,14 +36,60 @@ func latestBlockUpdater(wg *sync.WaitGroup) {
 	}
 }
 
-// LatestEth1BlockNumber will return the latest epoch
+// LatestEth1BlockNumber will return most recent eth1 block number
 func LatestEth1BlockNumber() uint64 {
-	cacheKey := fmt.Sprintf("%d:frontend:latestEth1BlockNumber", utils.Config.Chain.Config.DepositChainID)
+	cacheKey := fmt.Sprintf("%d:frontend:%s", utils.Config.Chain.Config.DepositChainID, latestBlockNumberCacheKey)
 
 	if wanted, err := cache.TieredCache.GetUint64WithLocalTimeout(cacheKey, time.Second*5); err == nil {
 		return wanted
 	} else {
-		logger.Errorf("error retrieving latestEth1BlockNumber from cache: %v", err)
+		logger.Errorf("error retrieving %s from cache: %v", latestBlockNumberCacheKey, err)
 	}
 	return 0
+}
+
+const latestBlockHashRootCacheKey = "latestEth1BlockRootHash"
+
+// headBlockRootHashUpdater updates the hash of the current chain head block
+func headBlockRootHashUpdater(wg *sync.WaitGroup) {
+	firstRun := true
+
+	for {
+		blockRootHash := []byte{}
+		err := db.ReaderDb.Get(&blockRootHash, `
+		SELECT blockroot
+		FROM blocks
+		WHERE status = '1'
+		ORDER BY slot DESC
+		LIMIT 1`)
+
+		if err != nil {
+			logger.WithError(err).Error("error getting blockrroot hash for chain head")
+		}
+		cacheKey := fmt.Sprintf("%d:frontend:%s", utils.Config.Chain.Config.DepositChainID, latestBlockHashRootCacheKey)
+		err = cache.TieredCache.SetString(cacheKey, string(blockRootHash), time.Hour*24)
+		if err != nil {
+			logger.Errorf("error caching %s: %v", latestBlockHashRootCacheKey, err)
+		}
+
+		if firstRun {
+			logger.Info("initialized eth1 head block root hash updater")
+			wg.Done()
+			firstRun = false
+		}
+		ReportStatus("headBlockRootHashUpdater", "Running", nil)
+		time.Sleep(time.Second * 10)
+	}
+}
+
+// Eth1HeadBlockRootHash will return the hash of the current chain head block
+func Eth1HeadBlockRootHash() []byte {
+	cacheKey := fmt.Sprintf("%d:frontend:%s", utils.Config.Chain.Config.DepositChainID, latestBlockHashRootCacheKey)
+
+	if wanted, err := cache.TieredCache.GetStringWithLocalTimeout(cacheKey, time.Second*5); err == nil {
+		return []byte(wanted)
+	} else {
+		logger.Errorf("error retrieving %s from cache: %v", latestBlockHashRootCacheKey, err)
+	}
+	return []byte{}
 }

--- a/services/execution_layer.go
+++ b/services/execution_layer.go
@@ -64,7 +64,7 @@ func headBlockRootHashUpdater(wg *sync.WaitGroup) {
 		LIMIT 1`)
 
 		if err != nil {
-			logger.WithError(err).Error("error getting blockrroot hash for chain head")
+			logger.WithError(err).Error("error getting blockroot hash for chain head")
 		}
 		cacheKey := fmt.Sprintf("%d:frontend:%s", utils.Config.Chain.Config.DepositChainID, latestBlockHashRootCacheKey)
 		err = cache.TieredCache.SetString(cacheKey, string(blockRootHash), time.Hour*24)

--- a/services/execution_layer.go
+++ b/services/execution_layer.go
@@ -18,12 +18,12 @@ func latestBlockUpdater(wg *sync.WaitGroup) {
 	for {
 		recent, err := db.BigtableClient.GetMostRecentBlockFromDataTable()
 		if err != nil {
-			logger.WithError(err).Error("error getting most recent eth1 block")
+			utils.LogError(err, "error getting most recent eth1 block", 0)
 		}
 		cacheKey := fmt.Sprintf("%d:frontend:%s", utils.Config.Chain.Config.DepositChainID, latestBlockNumberCacheKey)
 		err = cache.TieredCache.SetUint64(cacheKey, recent.GetNumber(), time.Hour*24)
 		if err != nil {
-			logger.Errorf("error caching %s: %v", latestBlockNumberCacheKey, err)
+			utils.LogError(err, fmt.Sprintf("error caching latest block number with cache key %s", latestBlockNumberCacheKey), 0)
 		}
 
 		if firstRun {
@@ -43,7 +43,7 @@ func LatestEth1BlockNumber() uint64 {
 	if wanted, err := cache.TieredCache.GetUint64WithLocalTimeout(cacheKey, time.Second*5); err == nil {
 		return wanted
 	} else {
-		logger.Errorf("error retrieving %s from cache: %v", latestBlockNumberCacheKey, err)
+		utils.LogError(err, fmt.Sprintf("error retrieving latest block number from cache with key %s", latestBlockNumberCacheKey), 0)
 	}
 	return 0
 }
@@ -64,12 +64,12 @@ func headBlockRootHashUpdater(wg *sync.WaitGroup) {
 		LIMIT 1`)
 
 		if err != nil {
-			logger.WithError(err).Error("error getting blockroot hash for chain head")
+			utils.LogError(err, "error getting blockroot hash for chain head", 0)
 		}
 		cacheKey := fmt.Sprintf("%d:frontend:%s", utils.Config.Chain.Config.DepositChainID, latestBlockHashRootCacheKey)
 		err = cache.TieredCache.SetString(cacheKey, string(blockRootHash), time.Hour*24)
 		if err != nil {
-			logger.Errorf("error caching %s: %v", latestBlockHashRootCacheKey, err)
+			utils.LogError(err, fmt.Sprintf("error caching latest blockroot hash with cache key %s", latestBlockHashRootCacheKey), 0)
 		}
 
 		if firstRun {
@@ -89,7 +89,7 @@ func Eth1HeadBlockRootHash() []byte {
 	if wanted, err := cache.TieredCache.GetStringWithLocalTimeout(cacheKey, time.Second*5); err == nil {
 		return []byte(wanted)
 	} else {
-		logger.Errorf("error retrieving %s from cache: %v", latestBlockHashRootCacheKey, err)
+		utils.LogError(err, fmt.Sprintf("error retrieving latest blockroot hash from cache with key %s", latestBlockHashRootCacheKey), 0)
 	}
 	return []byte{}
 }

--- a/services/monitoring.go
+++ b/services/monitoring.go
@@ -249,6 +249,7 @@ func startServicesMonitoringService() {
 		"mempoolUpdater":            time.Minute * 15,
 		"indexPageDataUpdater":      time.Minute * 15,
 		"latestBlockUpdater":        time.Minute * 15,
+		"headBlockRootHashUpdater":  time.Minute * 15,
 		"notification-collector":    time.Minute * 15,
 		"relaysUpdater":             time.Minute * 15,
 		"ethstoreExporter":          time.Minute * 60,

--- a/services/services.go
+++ b/services/services.go
@@ -49,6 +49,9 @@ func Init() {
 	go latestBlockUpdater(ready)
 
 	ready.Add(1)
+	go headBlockRootHashUpdater(ready)
+
+	ready.Add(1)
 	go slotVizUpdater(ready)
 
 	ready.Add(1)


### PR DESCRIPTION
This PR adds the possibility to use "head" as parameter for the API V1 slot endpoint. When used, it will return the slot containing the chain's head block.
Swagger has been updated accordingly.