### PR TITLE
(BIDS-2250) remove last attestation slot from the exporter process

### DIFF
--- a/cmd/misc/main.go
+++ b/cmd/misc/main.go
@@ -47,7 +47,7 @@ var opts = struct {
 
 func main() {
 	configPath := flag.String("config", "config/default.config.yml", "Path to the config file")
-	flag.StringVar(&opts.Command, "command", "", "command to run, available: updateAPIKey, applyDbSchema, epoch-export, debug-rewards, clear-bigtable, index-old-eth1-blocks, update-aggregation-bits, historic-prices-export")
+	flag.StringVar(&opts.Command, "command", "", "command to run, available: updateAPIKey, applyDbSchema, epoch-export, debug-rewards, clear-bigtable, index-old-eth1-blocks, update-aggregation-bits, historic-prices-export, migrate-last-attestation-slot-bigtable")
 	flag.Uint64Var(&opts.StartEpoch, "start-epoch", 0, "start epoch")
 	flag.Uint64Var(&opts.EndEpoch, "end-epoch", 0, "end epoch")
 	flag.Uint64Var(&opts.User, "user", 0, "user id")

--- a/cmd/misc/main.go
+++ b/cmd/misc/main.go
@@ -187,7 +187,7 @@ func migrateLastAttestationSlotToBigtable() {
 	}
 
 	for _, validator := range validators {
-		logrus.Infof("setting last attestation slot %v for validator %v", validator.Index, validator.LastAttestationSlot)
+		logrus.Infof("setting last attestation slot %v for validator %v", validator.LastAttestationSlot, validator.Index)
 
 		err := db.BigtableClient.SetLastAttestationSlot(validator.Index, uint64(validator.LastAttestationSlot.Int64))
 		if err != nil {

--- a/db/bigtable.go
+++ b/db/bigtable.go
@@ -612,6 +612,7 @@ func (bigtable *Bigtable) SaveAttestations(blocks map[uint64]map[string]*types.B
 	return nil
 }
 
+// This method is only to be used for migrating the last attestation slot to bigtable and should not be used for any other purpose
 func (bigtable *Bigtable) SetLastAttestationSlot(validator uint64, lastAttestationSlot uint64) error {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
 	defer cancel()

--- a/db/bigtable.go
+++ b/db/bigtable.go
@@ -612,6 +612,20 @@ func (bigtable *Bigtable) SaveAttestations(blocks map[uint64]map[string]*types.B
 	return nil
 }
 
+func (bigtable *Bigtable) SetLastAttestationSlot(validator uint64, lastAttestationSlot uint64) error {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+	defer cancel()
+
+	mutLastAttestationSlot := gcp_bigtable.NewMutation()
+	mutLastAttestationSlot.Set(ATTESTATIONS_FAMILY, fmt.Sprintf("%d", validator), gcp_bigtable.Timestamp(lastAttestationSlot*1000), []byte{})
+	err := bigtable.tableValidators.Apply(ctx, fmt.Sprintf("%s:lastAttestationSlot", bigtable.chainId), mutLastAttestationSlot)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func (bigtable *Bigtable) SaveProposals(blocks map[uint64]map[string]*types.Block) error {
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)

--- a/db/db.go
+++ b/db/db.go
@@ -1053,18 +1053,23 @@ func saveValidators(data *types.EpochData, tx *sqlx.Tx, client rpc.Client) error
 	}
 
 	var currentState []*types.Validator
-	err := tx.Select(&currentState, "SELECT validatorindex, withdrawableepoch, withdrawalcredentials, slashed, activationeligibilityepoch, activationepoch, exitepoch, lastattestationslot, status FROM validators;")
+	err := tx.Select(&currentState, "SELECT validatorindex, withdrawableepoch, withdrawalcredentials, slashed, activationeligibilityepoch, activationepoch, exitepoch, status FROM validators;")
 
 	if err != nil {
 		return err
+	}
+
+	lastAttestationSlots, err := BigtableClient.GetLastAttestationSlots([]uint64{})
+	if err != nil {
+		return fmt.Errorf("error getting validator last attestation slots from bigtable: %w", err)
 	}
 
 	currentStateMap := make(map[uint64]*types.Validator, len(currentState))
 	latestBlock := uint64(0)
 
 	for _, v := range currentState {
-		if uint64(v.LastAttestationSlot.Int64) > latestBlock {
-			latestBlock = uint64(v.LastAttestationSlot.Int64)
+		if lastAttestationSlots[v.Index] > latestBlock {
+			latestBlock = lastAttestationSlots[v.Index]
 		}
 		currentStateMap[v.Index] = v
 	}
@@ -1078,11 +1083,6 @@ func saveValidators(data *types.EpochData, tx *sqlx.Tx, client rpc.Client) error
 
 	var queries strings.Builder
 
-	type ValidatorLastAttestationSlot struct {
-		Validator           uint64
-		LastAttestationSlot int64
-	}
-	validatorLastAttestationSlotUpdate := make([]ValidatorLastAttestationSlot, 0, len(data.Validators))
 	updates := 0
 	for _, v := range data.Validators {
 
@@ -1098,10 +1098,6 @@ func saveValidators(data *types.EpochData, tx *sqlx.Tx, client rpc.Client) error
 		}
 		if v.ActivationEpoch == farFutureEpoch {
 			v.ActivationEpoch = maxSqlNumber
-		}
-
-		if currentStateMap[v.Index] != nil && currentStateMap[v.Index].LastAttestationSlot.Int64 > v.LastAttestationSlot.Int64 {
-			v.LastAttestationSlot.Int64 = currentStateMap[v.Index].LastAttestationSlot.Int64
 		}
 
 		c := currentStateMap[v.Index]
@@ -1121,10 +1117,9 @@ func saveValidators(data *types.EpochData, tx *sqlx.Tx, client rpc.Client) error
 				activationepoch,
 				exitepoch,
 				pubkeyhex,
-				status,
-				lastattestationslot
+				status
 			)
-			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13);`,
+			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12);`,
 				v.Index,
 				v.PublicKey,
 				v.WithdrawableEpoch,
@@ -1137,7 +1132,6 @@ func saveValidators(data *types.EpochData, tx *sqlx.Tx, client rpc.Client) error
 				v.ExitEpoch,
 				fmt.Sprintf("%x", v.PublicKey),
 				v.Status,
-				v.LastAttestationSlot,
 			)
 
 			if err != nil {
@@ -1158,16 +1152,7 @@ func saveValidators(data *types.EpochData, tx *sqlx.Tx, client rpc.Client) error
 			// ELSE 'active_online'
 			// END
 
-			offline := false
-
-			lastSeen := c.LastAttestationSlot.Int64
-			if v.LastAttestationSlot.Int64 > lastSeen {
-				lastSeen = v.LastAttestationSlot.Int64
-			}
-
-			if lastSeen < int64(thresholdSlot) {
-				offline = true
-			}
+			offline := lastAttestationSlots[v.Index] < thresholdSlot
 
 			if v.ExitEpoch <= latestEpoch && v.Slashed {
 				v.Status = "slashed"
@@ -1189,17 +1174,6 @@ func saveValidators(data *types.EpochData, tx *sqlx.Tx, client rpc.Client) error
 				v.Status = "active_offline"
 			} else {
 				v.Status = "active_online"
-			}
-
-			if c.LastAttestationSlot != v.LastAttestationSlot && v.LastAttestationSlot.Valid && c.LastAttestationSlot.Int64 < v.LastAttestationSlot.Int64 {
-				// logger.Infof("LastAttestationSlot changed for validator %v from %v to %v", v.Index, c.LastAttestationSlot.Int64, v.LastAttestationSlot.Int64)
-
-				// queries.WriteString(fmt.Sprintf("UPDATE validators SET lastattestationslot = %d WHERE validatorindex = %d;\n", v.LastAttestationSlot.Int64, c.Index))
-				// updates++
-				validatorLastAttestationSlotUpdate = append(validatorLastAttestationSlotUpdate, ValidatorLastAttestationSlot{
-					Validator:           v.Index,
-					LastAttestationSlot: v.LastAttestationSlot.Int64,
-				})
 			}
 
 			if c.Status != v.Status {
@@ -1261,29 +1235,7 @@ func saveValidators(data *types.EpochData, tx *sqlx.Tx, client rpc.Client) error
 		logger.Infof("update completed, took %v", time.Since(updateStart))
 	}
 
-	logger.Infof("updating the last attestation slot for %v validators", len(validatorLastAttestationSlotUpdate))
 	s := time.Now()
-	validatorIndexArray := make([]int64, 0, len(validatorLastAttestationSlotUpdate))
-	lastAttestationSlotArray := make([]int64, 0, len(validatorLastAttestationSlotUpdate))
-
-	for _, u := range validatorLastAttestationSlotUpdate {
-		validatorIndexArray = append(validatorIndexArray, int64(u.Validator))
-		lastAttestationSlotArray = append(lastAttestationSlotArray, u.LastAttestationSlot)
-	}
-
-	_, err = tx.Exec(`UPDATE validators AS v SET
-	lastattestationslot = GREATEST(v.lastattestationslot, v2.lastattestationslot)
-	FROM (SELECT * FROM UNNEST($1::INT[], $2::INT[])) AS v2(validatorindex, lastattestationslot)
-	WHERE v2.validatorindex = v.validatorindex;
-	`, validatorIndexArray, lastAttestationSlotArray)
-	if err != nil {
-		utils.LogError(err, "error executing transaction", 0)
-		return err
-	}
-
-	logger.Infof("last attestation slot update completed, took %v", time.Since(s))
-
-	s = time.Now()
 	newValidators := []struct {
 		Validatorindex  uint64
 		ActivationEpoch uint64


### PR DESCRIPTION
this is a cleanup PR that removes writing the last attestation slot to the postgres db and will significantly improve the epoch export speed

includes a one time migration script that writes the last attestation slot that is currently in postgres to bigtable. this can safely be done for active validators as bigtable will only keep the most recent last attestation slot. the misc tool needs to be run with the `migrate-last-attestation-slot-bigtable` command.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5189fe6</samp>

This pull request improves the efficiency and reliability of the validator attestation queries by using Bigtable as a cache layer. It refactors the code in `./db/db.go` to replace the PostgreSQL queries with Bigtable calls.
