### PR TITLE
(BIDS-2277) fix timestamp toggles

### DIFF
--- a/handlers/epoch.go
+++ b/handlers/epoch.go
@@ -17,8 +17,12 @@ import (
 
 // Epoch will show the epoch using a go template
 func Epoch(w http.ResponseWriter, r *http.Request) {
-	epochTemplateFiles := append(layoutTemplateFiles, "epoch.html")
-	epochFutureTemplateFiles := append(layoutTemplateFiles, "epochFuture.html")
+	epochTemplateFiles := append(layoutTemplateFiles,
+		"epoch.html",
+		"components/timestamp.html")
+	epochFutureTemplateFiles := append(layoutTemplateFiles,
+		"epochFuture.html",
+		"components/timestamp.html")
 	epochNotFoundTemplateFiles := append(layoutTemplateFiles, "epochnotfound.html")
 	var epochTemplate = templates.GetTemplate(epochTemplateFiles...)
 	var epochFutureTemplate = templates.GetTemplate(epochFutureTemplateFiles...)

--- a/handlers/epochs.go
+++ b/handlers/epochs.go
@@ -14,7 +14,9 @@ import (
 
 // Epochs will return the epochs using a go template
 func Epochs(w http.ResponseWriter, r *http.Request) {
-	templateFiles := append(layoutTemplateFiles, "epochs.html")
+	templateFiles := append(layoutTemplateFiles,
+		"epochs.html",
+		"components/timestamp.html")
 	var epochsTemplate = templates.GetTemplate(templateFiles...)
 
 	w.Header().Set("Content-Type", "text/html")

--- a/handlers/eth1Block.go
+++ b/handlers/eth1Block.go
@@ -28,13 +28,17 @@ func Eth1Block(w http.ResponseWriter, r *http.Request) {
 		"slot/attesterSlashing.html",
 		"slot/proposerSlashing.html",
 		"slot/exits.html",
+		"components/timestamp.html",
 		"slot/overview.html",
 		"slot/execTransactions.html",
 		"slot/withdrawals.html")
 	var blockTemplate = templates.GetTemplate(
 		blockTemplateFiles...,
 	)
-	preMergeTemplateFiles := append(layoutTemplateFiles, "execution/block.html", "slot/execTransactions.html")
+	preMergeTemplateFiles := append(layoutTemplateFiles,
+		"execution/block.html",
+		"slot/execTransactions.html",
+		"components/timestamp.html")
 	notFountTemplateFiles := append(layoutTemplateFiles, "slotnotfound.html")
 	var blockNotFoundTemplate = templates.GetTemplate(notFountTemplateFiles...)
 	var preMergeBlockTemplate = templates.GetTemplate(preMergeTemplateFiles...)

--- a/handlers/slot.go
+++ b/handlers/slot.go
@@ -39,9 +39,12 @@ func Slot(w http.ResponseWriter, r *http.Request) {
 		"slot/attesterSlashing.html",
 		"slot/proposerSlashing.html",
 		"slot/exits.html",
+		"components/timestamp.html",
 		"slot/overview.html",
 		"slot/execTransactions.html")
-	slotFutureTemplateFiles := append(layoutTemplateFiles, "slot/slotFuture.html")
+	slotFutureTemplateFiles := append(layoutTemplateFiles,
+		"slot/slotFuture.html",
+		"components/timestamp.html")
 	blockNotFoundTemplateFiles := append(layoutTemplateFiles, "slotnotfound.html")
 	var slotTemplate = templates.GetTemplate(slotTemplateFiles...)
 	var slotFutureTemplate = templates.GetTemplate(slotFutureTemplateFiles...)

--- a/static/js/layout.js
+++ b/static/js/layout.js
@@ -70,36 +70,35 @@ function setValidatorEffectiveness(elem, eff) {
   }
 }
 
-function setUtc() {
-  if ($("#optionLocal").is(":checked") || $("#optionTs").is(":checked")) {
-    var unixTs = $("#unixTs").text()
-    var ts = luxon.DateTime.fromMillis(unixTs * 1000)
-    $("#timestamp").text(ts.toUTC().toFormat("MMM-dd-yyyy hh:mm:ss a"))
-  }
-}
-
-function setLocal() {
-  if ($("#optionUtc").is(":checked") || $("#optionTs").is(":checked")) {
-    var unixTs = $("#unixTs").text()
-    var ts = luxon.DateTime.fromMillis(unixTs * 1000)
-    $("#timestamp").text(ts.toFormat("MMM-dd-yyyy HH:mm:ss") + " UTC" + ts.toFormat("Z"))
-  }
-}
-
 function setTs() {
-  var unixTs = $("#unixTs").text()
-  var utc = luxon.DateTime.fromMillis(unixTs * 1000)
-  $("#timestamp").text(utc["ts"] / 1000)
+  let timestamp = $("#timestamp")
+  let unixTs = timestamp.attr("aria-ethereum-date")
+  if (!unixTs) {
+    unixTs = $("#unixTs").text()
+  }
+  var ts = luxon.DateTime.fromMillis(unixTs * 1000)
+  let optionName = timestamp.attr("aria-timestamp-options")
+  let selectedOption = document.querySelector(`input[name="${optionName}"]:checked`)?.value
+
+  let text = ""
+  switch (selectedOption) {
+    case "local":
+      text = ts.toFormat("MMM-dd-yyyy HH:mm:ss") + " UTC" + ts.toFormat("Z")
+      break
+    case "utc":
+      text = ts.toUTC().toFormat("MMM-dd-yyyy hh:mm:ss a")
+      break
+    default:
+      text = ts["ts"] / 1000
+      break
+  }
+
+  timestamp.text(text)
 }
 
 function copyTs() {
   var text = $("#timestamp").text()
-  tsArr = text.split(" ")
-  if (tsArr.length > 1) {
-    navigator.clipboard.writeText(tsArr[0] + " " + tsArr[1])
-  } else {
-    navigator.clipboard.writeText(tsArr[0])
-  }
+  navigator.clipboard.writeText(text)
 }
 
 function viewHexDataAs(id, type) {
@@ -546,6 +545,8 @@ function formatAriaEthereumDate(elem) {
     $(elem).text(local.toFormat("MMM-dd-yyyy HH:mm:ss") + " UTC" + local.toFormat("Z"))
     $(elem).attr("data-original-title", formatTimestampsTooltip(local))
     $(elem).attr("data-toggle", "tooltip")
+  } else if (format === "TIMESTAMP") {
+    setTs()
   } else {
     $(elem).text(local.toFormat(format))
   }

--- a/templates/components/timestamp.html
+++ b/templates/components/timestamp.html
@@ -1,0 +1,10 @@
+{{ define "timestamp" }}
+  <div><span aria-ethereum-date="{{ .Unix }}" aria-ethereum-date-format="FROMNOW">{{ . }}</span> (<span id="timestamp" aria-ethereum-date="{{ .Unix }}" aria-ethereum-date-format="TIMESTAMP" aria-timestamp-options="timestampOptions">{{ . }}</span>) <i class="fa fa-copy text-muted p-1" role="button" data-toggle="tooltip" title="Copy to clipboard" onclick="copyTs()"></i></div>
+  <div class="flex-grow-1 text-right">
+    <div class="btn-group btn-group-toggle" data-toggle="buttons">
+      <label class="btn btn-light text-dark active btn-sm" onclick="setTs()"> <input type="radio" name="timestampOptions" id="optionTs" value="ts" autocomplete="off" /> Timestamp </label>
+      <label class="btn btn-light text-dark active btn-sm pl-4 pr-4" onclick="setTs()"> <input type="radio" name="timestampOptions" id="optionUtc" value="utc" autocomplete="off" /> UTC </label>
+      <label class="btn btn-light text-dark btn-sm pl-4 pr-4" onclick="setTs()"> <input type="radio" name="timestampOptions" id="optionLocal" value="local" autocomplete="off" checked /> Local </label>
+    </div>
+  </div>
+{{ end }}

--- a/templates/epoch.html
+++ b/templates/epoch.html
@@ -169,14 +169,8 @@
           </div>
           <div class="row border-bottom p-3 mx-0">
             <div class="col-md-3">Time:</div>
-            <div class="col-md-6"><span aria-ethereum-date="{{ .Ts.Unix }}" aria-ethereum-date-format="FROMNOW">{{ .Ts }}</span> (<span id="timestamp" aria-ethereum-date="{{ .Ts.Unix }}" aria-ethereum-date-format="LOCAL">{{ .Ts }}</span>) <i class="fa fa-copy text-muted p-1" role="button" data-toggle="tooltip" title="Copy to clipboard" onclick="copyTs()"></i></div>
-            <div class="col-md-3 text-right">
-              <div id="unixTs" hidden>{{ .Ts.Unix }}</div>
-              <div class="btn-group btn-group-toggle" data-toggle="buttons">
-                <label class="btn btn-light text-dark active btn-sm" onclick="setTs()"> <input type="radio" name="options" id="optionTs" autocomplete="off" /> Timestamp </label>
-                <label class="btn btn-light text-dark active btn-sm pl-4 pr-4" onclick="setUtc()"> <input type="radio" name="options" id="optionUtc" autocomplete="off" /> UTC </label>
-                <label class="btn btn-light text-dark btn-sm pl-4 pr-4" onclick="setLocal()"> <input type="radio" name="options" id="optionLocal" autocomplete="off" checked /> Local </label>
-              </div>
+            <div class="col-md-9 d-flex justify-between flex-wrap">
+              {{ template "timestamp" .Ts }}
             </div>
           </div>
           <div class="row border-bottom p-3 mx-0">

--- a/templates/epochFuture.html
+++ b/templates/epochFuture.html
@@ -140,14 +140,8 @@
           </div>
           <div class="row border-bottom p-3 mx-0">
             <div class="col-md-3">Time:</div>
-            <div class="col-md-6"><span aria-ethereum-date="{{ .Ts.Unix }}" aria-ethereum-date-format="FROMNOW">{{ .Ts }}</span> (<span id="timestamp" aria-ethereum-date="{{ .Ts.Unix }}" aria-ethereum-date-format="LOCAL">{{ .Ts }}</span>) <i class="fa fa-copy text-muted p-1" role="button" data-toggle="tooltip" title="Copy to clipboard" onclick="copyTs()"></i></div>
-            <div class="col-md-3 text-right">
-              <div id="unixTs" hidden>{{ .Ts.Unix }}</div>
-              <div class="btn-group btn-group-toggle" data-toggle="buttons">
-                <label class="btn btn-light text-dark active btn-sm" onclick="setTs()"> <input type="radio" name="options" id="optionTs" autocomplete="off" /> Timestamp </label>
-                <label class="btn btn-light text-dark active btn-sm pl-4 pr-4" onclick="setUtc()"> <input type="radio" name="options" id="optionUtc" autocomplete="off" /> UTC </label>
-                <label class="btn btn-light text-dark btn-sm pl-4 pr-4" onclick="setLocal()"> <input type="radio" name="options" id="optionLocal" autocomplete="off" checked /> Local </label>
-              </div>
+            <div class="col-md-9 d-flex justify-between flex-wrap">
+              {{ template "timestamp" .Ts }}
             </div>
           </div>
         </div>

--- a/templates/execution/block.html
+++ b/templates/execution/block.html
@@ -90,14 +90,8 @@
               {{ end }}
               <div class="row border-bottom p-3 mx-0">
                 <div class="col-md-2">Time:</div>
-                <div class="col-md-7"><span aria-ethereum-date="{{ .Ts.Unix }}" aria-ethereum-date-format="FROMNOW">{{ .Ts }}</span> (<span id="timestamp" aria-ethereum-date="{{ .Ts.Unix }}" aria-ethereum-date-format="LOCAL">{{ .Ts }}</span>) <i class="fa fa-copy text-muted p-1" role="button" data-toggle="tooltip" title="Copy to clipboard" onclick="copyTs()"></i></div>
-                <div class="col-md-3 text-right">
-                  <div id="unixTs" hidden>{{ .Ts.Unix }}</div>
-                  <div class="btn-group btn-group-toggle" data-toggle="buttons">
-                    <label class="btn btn-light text-dark active btn-sm" onclick="setTs()"> <input type="radio" name="options" id="optionTs" autocomplete="off" /> Timestamp </label>
-                    <label class="btn btn-light text-dark active btn-sm pl-4 pr-4" onclick="setUtc()"> <input type="radio" name="options" id="optionUtc" autocomplete="off" /> UTC </label>
-                    <label class="btn btn-light text-dark btn-sm pl-4 pr-4" onclick="setLocal()"> <input type="radio" name="options" id="optionLocal" autocomplete="off" checked /> Local </label>
-                  </div>
+                <div class="col-md-10 d-flex justify-between flex-wrap">
+                  {{ template "timestamp" .Ts }}
                 </div>
               </div>
               <div class="row border-bottom p-3 mx-0">

--- a/templates/slot/overview.html
+++ b/templates/slot/overview.html
@@ -94,15 +94,7 @@
       <div class="row border-bottom p-3 mx-0">
         <div class="col-md-2">Time:</div>
         <div class="col-md-10 d-flex justify-between flex-wrap">
-          <div><span aria-ethereum-date="{{ .Ts.Unix }}" aria-ethereum-date-format="FROMNOW">{{ .Ts }}</span> (<span id="timestamp" aria-ethereum-date="{{ .Ts.Unix }}" aria-ethereum-date-format="LOCAL">{{ .Ts }}</span>) <i class="fa fa-copy text-muted p-1" role="button" data-toggle="tooltip" title="Copy to clipboard" onclick="copyTs()"></i></div>
-          <div class="flex-grow-1 text-right">
-            <div id="unixTs" hidden>{{ .Ts.Unix }}</div>
-            <div class="btn-group btn-group-toggle" data-toggle="buttons">
-              <label class="btn btn-light text-dark active btn-sm" onclick="setTs()"> <input type="radio" name="options" id="optionTs" autocomplete="off" /> Timestamp </label>
-              <label class="btn btn-light text-dark active btn-sm pl-4 pr-4" onclick="setUtc()"> <input type="radio" name="options" id="optionUtc" autocomplete="off" /> UTC </label>
-              <label class="btn btn-light text-dark btn-sm pl-4 pr-4" onclick="setLocal()"> <input type="radio" name="options" id="optionLocal" autocomplete="off" checked /> Local </label>
-            </div>
-          </div>
+          {{ template "timestamp" .Ts }}
         </div>
       </div>
       {{ if ne .Slot 0 }}

--- a/templates/slot/slotFuture.html
+++ b/templates/slot/slotFuture.html
@@ -47,14 +47,8 @@
               </div>
               <div class="row border-bottom p-3 mx-0">
                 <div class="col-md-2">Time:</div>
-                <div class="col-md-7"><span aria-ethereum-date="{{ .Ts.Unix }}" aria-ethereum-date-format="FROMNOW">{{ .Ts }}</span> (<span id="timestamp" aria-ethereum-date="{{ .Ts.Unix }}" aria-ethereum-date-format="LOCAL">{{ .Ts }}</span>) <i class="fa fa-copy text-muted p-1" role="button" data-toggle="tooltip" title="Copy to clipboard" onclick="copyTs()"></i></div>
-                <div class="col-md-3 text-right">
-                  <div id="unixTs" hidden>{{ .Ts.Unix }}</div>
-                  <div class="btn-group btn-group-toggle" data-toggle="buttons">
-                    <label class="btn btn-light text-dark active btn-sm" onclick="setTs()"> <input type="radio" name="options" id="optionTs" autocomplete="off" /> Timestamp </label>
-                    <label class="btn btn-light text-dark active btn-sm pl-4 pr-4" onclick="setUtc()"> <input type="radio" name="options" id="optionUtc" autocomplete="off" /> UTC </label>
-                    <label class="btn btn-light text-dark btn-sm pl-4 pr-4" onclick="setLocal()"> <input type="radio" name="options" id="optionLocal" autocomplete="off" checked /> Local </label>
-                  </div>
+                <div class="col-md-10 d-flex justify-between flex-wrap">
+                  {{ template "timestamp" .Ts }}
                 </div>
               </div>
             </div>


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1e8791f</samp>

Added a reusable `timestamp` component for displaying and formatting timestamps in various templates. Refactored the code for handling timestamps in `handlers` and `static/js` files to use the new component and avoid duplication. Added a timestamp component to the eth1 block template files.
