### PR TITLE
(BIDS-2268) switch tx decode  error to warning and enhance

### DIFF
--- a/eth1data/eth1data.go
+++ b/eth1data/eth1data.go
@@ -189,7 +189,7 @@ func GetEth1Transaction(hash common.Hash) (*types.Eth1TxData, error) {
 						err := boundContract.UnpackLogIntoMap(logData, name, *log)
 
 						if err != nil {
-							logger.Errorf("error decoding event %v", name)
+							logger.Warnf("error decoding event [%v] for tx [0x%x]", name, tx.Hash())
 						}
 
 						eth1Event := &types.Eth1EventData{


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e0a8acb</samp>

Improve log message for event decoding errors in `eth1data/eth1data.go`. This helps to debug eth1 data issues and support more event types.
