### PR TITLE
Bids 2269/handle empty tokens properly

### DIFF
--- a/db/bigtable_eth1.go
+++ b/db/bigtable_eth1.go
@@ -2935,7 +2935,7 @@ func (bigtable *Bigtable) GetERC20MetadataForAddress(address []byte) (*types.ERC
 				Symbol:      "UNKNOWN",
 				TotalSupply: []byte{0x0}}
 
-			err = cache.TieredCache.Set(cacheKey, metadata, time.Hour*24*365)
+			err = cache.TieredCache.Set(cacheKey, metadata, time.Minute*10)
 			if err != nil {
 				return nil, err
 			}

--- a/rpc/erigon.go
+++ b/rpc/erigon.go
@@ -647,6 +647,14 @@ func (client *ErigonClient) GetERC20TokenMetadata(token []byte) (*types.ERC20Met
 	})
 	err = g.Wait()
 
+	if err == nil && len(ret.Decimals) == 0 && ret.Symbol == "" && len(ret.TotalSupply) == 0 {
+		// it's possible that a token contract implements the ERC20 interfaces but does not return any values; we use a backup in this case
+		ret = &types.ERC20Metadata{
+			Decimals:    []byte{0x0},
+			Symbol:      "UNKNOWN",
+			TotalSupply: []byte{0x0}}
+	}
+
 	return ret, err
 }
 

--- a/rpc/geth.go
+++ b/rpc/geth.go
@@ -411,5 +411,13 @@ func (client *GethClient) GetERC20TokenMetadata(token []byte) (*types.ERC20Metad
 	})
 	err = g.Wait()
 
+	if err == nil && len(ret.Decimals) == 0 && ret.Symbol == "" && len(ret.TotalSupply) == 0 {
+		// it's possible that a token contract implements the ERC20 interfaces but does not return any values; we use a backup in this case
+		ret = &types.ERC20Metadata{
+			Decimals:    []byte{0x0},
+			Symbol:      "UNKNOWN",
+			TotalSupply: []byte{0x0}}
+	}
+
 	return ret, err
 }


### PR DESCRIPTION
When a smart contract implements the ERC20 interfaces but does not return any values for `decimals`, `symbol` and `totalSupply`, we ask bigtable to save token information but don't create any mutations in `SaveERC20Metadata`. This causes an error.

With this PR, `GetERC20TokenMetadata` now returns `"UNKNOWN"` for `symbol` in this case.
Furthermore, if `GetERC20TokenMetadata` returns an error, we cache `"UNKNOWN"` not for a year but for 10 minutes only.