### PR TITLE
(BIDS-2178) the next is justified

### DIFF
--- a/handlers/slot.go
+++ b/handlers/slot.go
@@ -245,7 +245,7 @@ func GetSlotPageData(blockSlot uint64) (*types.BlockPageData, error) {
 		LEFT JOIN validator_names ON validators.pubkey = validator_names.publickey
 		LEFT JOIN blocks_tags ON blocks.slot = blocks_tags.slot and blocks.blockroot = blocks_tags.blockroot
 		LEFT JOIN tags ON blocks_tags.tag_id = tags.id
-		LEFT JOIN epochs ON (GREATEST(blocks.slot,1)-1)/$2 = epochs.epoch
+		LEFT JOIN epochs ON GREATEST((blocks.slot-1)/$2,0) = epochs.epoch
 		LEFT JOIN epochs prev_epoch ON GREATEST((blocks.slot-1)/$2-1,0) = prev_epoch.epoch
 		WHERE blocks.slot = $1 
 		group by

--- a/handlers/slot.go
+++ b/handlers/slot.go
@@ -246,7 +246,7 @@ func GetSlotPageData(blockSlot uint64) (*types.BlockPageData, error) {
 		LEFT JOIN blocks_tags ON blocks.slot = blocks_tags.slot and blocks.blockroot = blocks_tags.blockroot
 		LEFT JOIN tags ON blocks_tags.tag_id = tags.id
 		LEFT JOIN epochs ON (GREATEST(blocks.slot,1)-1)/$2 = epochs.epoch
-		LEFT JOIN epochs prev_epoch ON GREATEST(((GREATEST(blocks.slot,1)-1)/$2-1),0) = prev_epoch.epoch
+		LEFT JOIN epochs prev_epoch ON GREATEST((blocks.slot-1)/$2-1,0) = prev_epoch.epoch
 		WHERE blocks.slot = $1 
 		group by
 			blocks.epoch,

--- a/templates/slot/overview.html
+++ b/templates/slot/overview.html
@@ -77,7 +77,7 @@
                   <span class="badge badge-light text-black px-1"><i class="fas fa-exclamation-circle"></i> Not Included</span>
                 </span>
               {{ end }}
-            {{ else if and (gtf .EpochParticipationRate 0.66) (ltf .EpochParticipationRate 1) (le .Status 1 ) }}
+            {{ else if and (gtf .EpochParticipationRate 0.66) (ltf .EpochParticipationRate 1) (le .Status 1 ) .PrevEpochFinalized }}
               <span data-html="true" data-toggle="tooltip" data-placement="bottom" title="" data-original-title="This block can be considered as safe, and is highly unlikely to be reverted." data-container="body">
                 <span class="badge badge-secondary text-white px-1"><i class="fas fa-check"></i> Not Finalized (Safe)</span>
               </span>

--- a/templates/slotViz.html
+++ b/templates/slotViz.html
@@ -114,7 +114,7 @@
                   .attr("style", "font-size: .7rem; z-index: 99;")
                   .text((d) => {
                     if (d.participation) {
-                      var txt = d.finalized ? "finalized" : "justifying"
+                      var txt = d.finalized ? "finalized" : d.justified ? "justified" :"justifying"
                       return txt + " " + d.participation + "%"
                     } else {
                       return d.slots[0].Slot ? "processing..." : ""
@@ -126,7 +126,7 @@
 
                   .text((d) => {
                     if (d.participation) {
-                      var txt = d.finalized ? "finalized" : "justifying"
+                      var txt = d.finalized ? "finalized" : d.justified ? "justified" : "justifying"
                       return txt + " " + d.participation + "%"
                     } else {
                       return d.slots[0].Slot ? "processing..." : ""
@@ -182,9 +182,11 @@
                     .attr("x", (d, i) => x(i))
                     .attr("y", (d, i) => y.bandwidth() / 2 - 7.5)
                     .attr("slot", (d) => d.Slot)
-                    .on("click", (d) => {
+                    .on("mouseup", (d) => {
                       var slot = d.target.getAttribute("slot")
-                      if (slot) {
+                      if (d.which == 2 ){
+                        window.open(`/slot/${slot}`,"_blank");
+                      } else if (d.which == 1){
                         window.location = "/slot/" + slot
                       }
                     })
@@ -321,9 +323,13 @@
                   .attr("data-original-title", (d, i) => `epoch ${d.epoch} participation ${d.participation}%`)
                   .attr("data-toggle", "tooltip")
                   .attr("epoch", (d) => d.epoch)
-                  .on("click", (d) => {
+                  .on("mouseup", (d) => {
                     var epoch = d.target.getAttribute("epoch")
-                    window.location = "/epoch/" + epoch
+                    if (d.which == 2 ){
+                      window.open(`/epoch/${epoch}`,"_blank");
+                    } else if (d.which == 1){
+                      window.location = "/epoch/" + epoch
+                    }
                   })
               },
               (update) => {

--- a/types/templates.go
+++ b/types/templates.go
@@ -622,6 +622,7 @@ type VotesVisChartData struct {
 type BlockPageData struct {
 	Epoch                  uint64  `db:"epoch"`
 	EpochFinalized         bool    `db:"epoch_finalized"`
+	PrevEpochFinalized     bool    `db:"prev_epoch_finalized"`
 	EpochParticipationRate float64 `db:"epoch_participation_rate"`
 	Ts                     time.Time
 	NextSlot               uint64


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d6b62d6</samp>

This pull request adds a block status badge to the slot overview page, which indicates if the block is finalized or not, and if the previous epoch was finalized or not. It also enhances the slot visualization page with more information and functionality. It modifies the `handlers/slot.go`, `templates/slotViz.html`, `templates/slot/overview.html`, and `types/templates.go` files.
