### PR TITLE
(BIDS-2271) Handle chain reorg error

### DIFF
--- a/cmd/eth1indexer/main.go
+++ b/cmd/eth1indexer/main.go
@@ -467,8 +467,8 @@ func HandleChainReorgs(bt *db.Bigtable, client *rpc.ErigonClient, depth int) err
 					}
 					return err
 				}
-				logrus.Infof("deleting block at height %v with hash %x", dbBlock.Number, dbBlock.Hash)
-				err = bt.DeleteBlock(dbBlock.Number, dbBlock.Hash)
+				logrus.Infof("deleting block at height %v with hash %x or %x", dbBlock.Number, dbBlock.Hash, nodeBlock.Hash().Bytes())
+				err = bt.DeleteBlock(dbBlock.Number, dbBlock.Hash, nodeBlock.Hash().Bytes())
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 330d0c7</samp>

This pull request enhances the Ethereum 1.0 event indexing and reorg handling logic in the `db/bigtable_eth1.go` and `cmd/eth1indexer/main.go` files. It improves the logging, error handling, and deletion logic of the database operations, and adds more information to the `DeleteBlock` function call to handle potential discrepancies between the db and the node block hashes.
