### PR TITLE
(BIDS-2323) Fixing special case that triggers error

### DIFF
--- a/handlers/eth1Account.go
+++ b/handlers/eth1Account.go
@@ -288,7 +288,7 @@ func Eth1AddressTransactions(w http.ResponseWriter, r *http.Request) {
 	// logger.Infof("GETTING TRANSACTION table data for address: %v search: %v draw: %v start: %v length: %v", address, search, draw, start, length)
 	data, err := db.BigtableClient.GetAddressTransactionsTableData(addressBytes, search, pageToken)
 	if err != nil {
-		logger.WithError(err).Errorf("error getting eth1 block table data")
+		utils.LogError(err, "error getting eth1 block table data", 0)
 	}
 
 	// logger.Infof("GOT TX: %+v", data)
@@ -315,7 +315,7 @@ func Eth1AddressBlocksMined(w http.ResponseWriter, r *http.Request) {
 	search := ""
 	data, err := db.BigtableClient.GetAddressBlocksMinedTableData(address, search, pageToken)
 	if err != nil {
-		logger.WithError(err).Errorf("error getting eth1 block table data")
+		utils.LogError(err, "error getting eth1 block table data", 0)
 	}
 
 	err = json.NewEncoder(w).Encode(data)
@@ -340,7 +340,7 @@ func Eth1AddressUnclesMined(w http.ResponseWriter, r *http.Request) {
 	search := ""
 	data, err := db.BigtableClient.GetAddressUnclesMinedTableData(address, search, pageToken)
 	if err != nil {
-		logger.WithError(err).Errorf("error getting eth1 block table data")
+		utils.LogError(err, "error getting eth1 block table data", 0)
 	}
 
 	err = json.NewEncoder(w).Encode(data)
@@ -410,7 +410,7 @@ func Eth1AddressInternalTransactions(w http.ResponseWriter, r *http.Request) {
 
 	data, err := db.BigtableClient.GetAddressInternalTableData(addressBytes, search, pageToken)
 	if err != nil {
-		logger.WithError(err).Errorf("error getting eth1 block table data")
+		utils.LogError(err, "error getting eth1 block table data", 0)
 	}
 
 	// logger.Infof("GOT TX: %+v", data)
@@ -466,7 +466,7 @@ func Eth1AddressErc721Transactions(w http.ResponseWriter, r *http.Request) {
 	// logger.Infof("GETTING TRANSACTION table data for address: %v search: %v draw: %v start: %v length: %v", address, search, draw, start, length)
 	data, err := db.BigtableClient.GetAddressErc721TableData(address, search, pageToken)
 	if err != nil {
-		logger.WithError(err).Errorf("error getting eth1 block table data")
+		utils.LogError(err, "error getting eth1 block table data", 0)
 	}
 
 	// logger.Infof("GOT TX: %+v", data)

--- a/handlers/eth1Blocks.go
+++ b/handlers/eth1Blocks.go
@@ -64,7 +64,7 @@ func Eth1BlocksData(w http.ResponseWriter, r *http.Request) {
 
 	data, err := getEth1BlocksTableData(draw, start, length, recordsTotal)
 	if err != nil {
-		logger.WithError(err).Errorf("error getting eth1 block table data")
+		utils.LogError(err, "error getting eth1 block table data", 0)
 	}
 
 	err = json.NewEncoder(w).Encode(data)
@@ -129,7 +129,7 @@ func getEth1BlocksTableData(draw, start, length, recordsTotal uint64) (*types.Da
 	}
 
 	displayStart := start
-	if start > recordsTotal {
+	if start >= recordsTotal {
 		start = 1
 	} else {
 		start = recordsTotal - start

--- a/handlers/eth1Token.go
+++ b/handlers/eth1Token.go
@@ -137,7 +137,7 @@ func Eth1TokenTransfers(w http.ResponseWriter, r *http.Request) {
 	// logger.Infof("GETTING TRANSACTION table data for address: %v search: %v draw: %v start: %v length: %v", address, search, draw, start, length)
 	data, err := db.BigtableClient.GetTokenTransactionsTableData(token, address, pageToken)
 	if err != nil {
-		logger.WithError(err).Errorf("error getting eth1 block table data")
+		utils.LogError(err, "error getting eth1 block table data", 0)
 	}
 
 	// logger.Infof("GOT TX: %+v", data)


### PR DESCRIPTION
I could not reproduce this error.
What seems to happen is that for the blocks page https://beaconcha.in/blocks we reach a page after the last page that has no block entries. The error gets thrown if the last legitimate page shows the max amount of blocks, e.g. if you show 10 blocks per page the last page must show the blocks 10 to 1 and not less. How you would then reach one page after this last page I don't know, maybe some bad JS timing.

There already was some handling implemented for reaching a page after the last page, it just didn't consider the case that we show max blocks on the last page.
I extended the handling with that.

Since the error message "error getting eth1 block table data" appears quite a few times I also changed it to our new error logging.