### PR TITLE
(BIDS-2294) Add limit handling to ApiETH1ExecBlocks

### DIFF
--- a/handlers/api_eth1.go
+++ b/handlers/api_eth1.go
@@ -80,6 +80,11 @@ func ApiETH1ExecBlocks(w http.ResponseWriter, r *http.Request) {
 		blockList = append(blockList, temp)
 	}
 
+	if len(blockList) > int(limit) {
+		sendErrorResponse(w, r.URL.String(), fmt.Sprintf("only a maximum of %d query parameters are allowed", limit))
+		return
+	}
+
 	blocks, err := db.BigtableClient.GetBlocksIndexedMultiple(blockList, limit)
 	if err != nil {
 		logger.Errorf("Can not retrieve blocks from bigtable %v", err)


### PR DESCRIPTION
This PR adds limit handling to ApiETH1ExecBlocks. If more than `limit` blocks are queried, the endpoint now returns a proper error response.