### PR TITLE
(BIDS-2182) miss att in orph slots

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -3192,3 +3192,15 @@ func GetOrphanedSlots(slots []uint64) ([]uint64, error) {
 
 	return orphaned, err
 }
+
+func GetOrphanedSlotsMap(slots []uint64) (map[uint64]bool, error) {
+	orphanedSlots, err := GetOrphanedSlots(slots)
+	if err != nil {
+		return nil, err
+	}
+	orphanedSlotsMap := make(map[uint64]bool)
+	for _, slot := range orphanedSlots {
+		orphanedSlotsMap[slot] = true
+	}
+	return orphanedSlotsMap, nil
+}


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7106039</samp>

This pull request enhances the validator attestation history feature by excluding attestations from orphaned blocks, using a new function `GetOrphanedSlotsMap` in `db/bigtable.go` and `db/db.go`. It also fixes some minor bugs and improves the code quality.
