### PR TITLE
(BIDS-2256) use ens names for addresses

### DIFF
--- a/db/bigtable_eth1.go
+++ b/db/bigtable_eth1.go
@@ -3074,6 +3074,9 @@ func (bigtable *Bigtable) GetAddressName(address []byte) (string, error) {
 }
 
 func (bigtable *Bigtable) GetAddressNames(addresses map[string]string) error {
+	if len(addresses) == 0 {
+		return nil
+	}
 	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(time.Second*30))
 	defer cancel()
 

--- a/db/bigtable_eth1.go
+++ b/db/bigtable_eth1.go
@@ -2588,16 +2588,23 @@ func (bigtable *Bigtable) GetAddressErc721TableData(address string, search strin
 		return nil, err
 	}
 
+	names := make(map[string]string)
+	for _, t := range transactions {
+		names[string(t.From)] = ""
+		names[string(t.To)] = ""
+	}
+	names, _, err = BigtableClient.GetAddressesNamesArMetadata(&names, nil)
+	if err != nil {
+		return nil, err
+	}
+
 	tableData := make([][]interface{}, len(transactions))
 	for i, t := range transactions {
-		from := utils.FormatAddressWithLimits(t.From, "", false, "", 13, 0, false)
-		if fmt.Sprintf("%x", t.From) != address {
-			from = utils.FormatAddressAsLink(t.From, "", false, false)
-		}
-		to := utils.FormatAddressWithLimits(t.To, "", false, "", 13, 0, false)
-		if fmt.Sprintf("%x", t.To) != address {
-			to = utils.FormatAddressAsLink(t.To, "", false, false)
-		}
+		fromName := names[string(t.From)]
+		toName := names[string(t.To)]
+		from := utils.FormatAddress(t.From, t.TokenAddress, fromName, false, false, fmt.Sprintf("%x", t.From) != address)
+		to := utils.FormatAddress(t.To, t.TokenAddress, toName, false, false, fmt.Sprintf("%x", t.To) != address)
+
 		tableData[i] = []interface{}{
 			utils.FormatTransactionHash(t.ParentHash),
 			utils.FormatTimestamp(t.Time.AsTime().Unix()),
@@ -2675,15 +2682,23 @@ func (bigtable *Bigtable) GetAddressErc1155TableData(address string, search stri
 	}
 
 	tableData := make([][]interface{}, len(transactions))
+
+	names := make(map[string]string)
+	for _, t := range transactions {
+		names[string(t.From)] = ""
+		names[string(t.To)] = ""
+	}
+	names, _, err = BigtableClient.GetAddressesNamesArMetadata(&names, nil)
+	if err != nil {
+		return nil, err
+	}
+
 	for i, t := range transactions {
-		from := utils.FormatAddressWithLimits(t.From, "", false, "", 13, 0, false)
-		if fmt.Sprintf("%x", t.From) != address {
-			from = utils.FormatAddressAsLink(t.From, "", false, false)
-		}
-		to := utils.FormatAddressWithLimits(t.To, "", false, "", 13, 0, false)
-		if fmt.Sprintf("%x", t.To) != address {
-			to = utils.FormatAddressAsLink(t.To, "", false, false)
-		}
+		fromName := names[string(t.From)]
+		toName := names[string(t.To)]
+		from := utils.FormatAddress(t.From, t.TokenAddress, fromName, false, false, fmt.Sprintf("%x", t.From) != address)
+		to := utils.FormatAddress(t.To, t.TokenAddress, toName, false, false, fmt.Sprintf("%x", t.To) != address)
+
 		tableData[i] = []interface{}{
 			utils.FormatTransactionHash(t.ParentHash),
 			utils.FormatTimestamp(t.Time.AsTime().Unix()),
@@ -3029,6 +3044,13 @@ func (bigtable *Bigtable) GetAddressName(address []byte) (string, error) {
 	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(time.Second*30))
 	defer cancel()
 
+	add := common.Address{}
+	add.SetBytes(address)
+	name, err := GetEnsNameForAddress(add)
+	if err == nil && name != nil && len(*name) > 0 {
+		return *name, nil
+	}
+
 	rowKey := fmt.Sprintf("%s:%x", bigtable.chainId, address)
 	cacheKey := bigtable.chainId + ":NAME:" + rowKey
 
@@ -3057,8 +3079,14 @@ func (bigtable *Bigtable) GetAddressNames(addresses map[string]string) error {
 
 	keys := make([]string, 0, len(addresses))
 
-	for address := range addresses {
-		keys = append(keys, fmt.Sprintf("%s:%x", bigtable.chainId, address))
+	if err := GetEnsNamesForAddress(addresses); err != nil {
+		return err
+	}
+
+	for address, label := range addresses {
+		if label == "" {
+			keys = append(keys, fmt.Sprintf("%s:%x", bigtable.chainId, address))
+		}
 	}
 
 	filter := gcp_bigtable.ChainFilters(gcp_bigtable.FamilyFilter(ACCOUNT_METADATA_FAMILY), gcp_bigtable.ColumnFilter(ACCOUNT_COLUMN_NAME))

--- a/db/ens.go
+++ b/db/ens.go
@@ -588,6 +588,9 @@ func GetEnsNameForAddress(address common.Address) (name *string, err error) {
 }
 
 func GetEnsNamesForAddress(addressMap map[string]string) error {
+	if len(addressMap) == 0 {
+		return nil
+	}
 	type pair struct {
 		Address []byte `db:"address"`
 		EnsName string `db:"ens_name"`
@@ -602,10 +605,15 @@ func GetEnsNamesForAddress(addressMap map[string]string) error {
 	SELECT address, ens_name 
 	FROM ens
 	WHERE
-		address = ANY($1) 
+		address = ANY($1) AND
+		is_primary_name AND
+		valid_to >= now()
 	;`, addresses)
+	if err != nil {
+		return err
+	}
 	for _, foundling := range dbAddresses {
 		addressMap[string(foundling.Address)] = foundling.EnsName
 	}
-	return err
+	return nil
 }

--- a/db/ens.go
+++ b/db/ens.go
@@ -586,3 +586,26 @@ func GetEnsNameForAddress(address common.Address) (name *string, err error) {
 	;`, address.Bytes())
 	return name, err
 }
+
+func GetEnsNamesForAddress(addressMap map[string]string) error {
+	type pair struct {
+		Address []byte `db:"address"`
+		EnsName string `db:"ens_name"`
+	}
+	dbAddresses := []pair{}
+	addresses := make([][]byte, 0, len(addressMap))
+	for add := range addressMap {
+		addresses = append(addresses, []byte(add))
+	}
+
+	err := ReaderDb.Select(&dbAddresses, `
+	SELECT address, ens_name 
+	FROM ens
+	WHERE
+		address = ANY($1) 
+	;`, addresses)
+	for _, foundling := range dbAddresses {
+		addressMap[string(foundling.Address)] = foundling.EnsName
+	}
+	return err
+}

--- a/handlers/eth1Account.go
+++ b/handlers/eth1Account.go
@@ -28,15 +28,13 @@ func Eth1Address(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/html")
 	vars := mux.Vars(r)
 	address := template.HTMLEscapeString(vars["address"])
-	if utils.IsValidEnsDomain(address) {
-		ensData, err := GetEnsDomain(address)
-		if err != nil {
-			handleNotFoundHtml(w, r)
-			return
-		}
-		if len(ensData.Address) > 0 {
-			address = ensData.Address
-		}
+	ensData, err := GetEnsDomain(address)
+	if err != nil && utils.IsValidEnsDomain(address) {
+		handleNotFoundHtml(w, r)
+		return
+	}
+	if len(ensData.Address) > 0 {
+		address = ensData.Address
 	}
 
 	isValid := utils.IsEth1Address(address)
@@ -250,6 +248,7 @@ func Eth1Address(w http.ResponseWriter, r *http.Request) {
 
 	data.Data = types.Eth1AddressPageData{
 		Address:            address,
+		EnsName:            ensData.Domain,
 		IsContract:         isContract,
 		QRCode:             pngStr,
 		QRCodeInverse:      pngStrInverse,

--- a/static/css/layout.css
+++ b/static/css/layout.css
@@ -1,5 +1,5 @@
 /* Revive ad server responsive images */
-ins[data-revive-zoneid]>a>img {
+ins[data-revive-zoneid] > a > img {
   max-width: 100%;
   height: auto;
 }
@@ -8,7 +8,7 @@ a:not(.nav-link) {
   text-decoration: none !important;
   background-repeat: no-repeat;
   background-image: linear-gradient(180deg, transparent 65%, var(--highlight) 0);
-  transition: background-size .25s ease;
+  transition: background-size 0.25s ease;
   background-size: 0% 100%;
 }
 
@@ -30,7 +30,7 @@ table {
   line-height: 0;
   padding: 0;
   border-radius: 50%;
-  font-size: .531376rem;
+  font-size: 0.531376rem;
   width: 1.3rem;
   height: 1.3rem;
 }
@@ -44,14 +44,14 @@ table {
 }
 
 .main-navigation .nav-link:focus {
-  outline:none;
+  outline: none;
 }
 
 .main-navigation .dropdown-menu.dropdown-menu-right.show {
   display: flex;
 }
 
-.main-navigation .dropdown-item svg{
+.main-navigation .dropdown-item svg {
   width: 1rem;
   margin-right: 0.5rem;
 }
@@ -64,20 +64,20 @@ table {
 }
 
 .page-item {
-  margin: 0 .2rem;
+  margin: 0 0.2rem;
 }
 
-.page-item>a {
-  border-radius: .225rem;
-  font-size: .95rem;
+.page-item > a {
+  border-radius: 0.225rem;
+  font-size: 0.95rem;
 }
 
 .paginate_input {
-  padding: .25rem .5rem;
-  font-size: .875rem;
+  padding: 0.25rem 0.5rem;
+  font-size: 0.875rem;
   height: 100%;
   line-height: 1.5;
-  border-radius: .2rem;
+  border-radius: 0.2rem;
   display: block;
   width: 100%;
   font-weight: 400;
@@ -86,9 +86,9 @@ table {
   background-color: var(--bg-color-secondary);
   background-clip: padding-box;
   border: 1px solid var(--input-border-color);
-  border-radius: .25rem;
-  box-shadow: inset 0 1px 1px rgba(0, 0, 0, .075);
-  transition: border-color .15s ease-in-out, box-shadow .15s ease-in-out;
+  border-radius: 0.25rem;
+  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
+  transition: border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
 }
 
 .paginate_button,
@@ -99,7 +99,7 @@ table {
 }
 
 .page-item.disabled .page-link {
-  opacity: .5;
+  opacity: 0.5;
   background-color: var(--bg-color-secondary);
 }
 
@@ -110,7 +110,7 @@ table {
 
 .paginate_of,
 .paginate_total {
-  padding-top: .5rem;
+  padding-top: 0.5rem;
 }
 
 .visually-hidden {
@@ -126,19 +126,19 @@ table {
 }
 
 /* Stakewise banner  */
-[data-theme='light'] #stakewise-banner-text {
+[data-theme="light"] #stakewise-banner-text {
   fill: #000000;
 }
 
-[data-theme='light'] #stakewise-logo-text {
+[data-theme="light"] #stakewise-logo-text {
   fill: #000000;
 }
 
-[data-theme='light'] #stakewise-banner-bg {
+[data-theme="light"] #stakewise-banner-bg {
   fill: #fefdfb;
 }
 
-[data-theme='light'] #stakewise-gradient-banner-bg {
+[data-theme="light"] #stakewise-gradient-banner-bg {
   display: none;
 }
 
@@ -371,24 +371,23 @@ table {
 
 @keyframes blinking {
   0% {
-    opacity: 0.2
+    opacity: 0.2;
   }
 
   100% {
-    opacity: 1
+    opacity: 1;
   }
 }
 
-.nav-icon img{
+.nav-icon img {
   width: 1rem;
   height: auto;
   aspect-ratio: 1;
 }
 
-
 @media (max-width: 1140px) {
   .dropdown-item {
-    padding: .5rem 1.5rem;
+    padding: 0.5rem 1.5rem;
   }
 
   .nav-icon {
@@ -433,7 +432,6 @@ table {
 }
 
 @media (max-width: 450px) {
-
   .pagination .first,
   .pagination .last {
     display: none;
@@ -451,10 +449,9 @@ table {
 }
 
 @media (min-width: 768px) {
-
-  #slashings-table_wrapper>div:nth-child(2),
-  #blocks-table_wrapper>div:nth-child(2),
-  #attestations-table_wrapper>div:nth-child(2) {
+  #slashings-table_wrapper > div:nth-child(2),
+  #blocks-table_wrapper > div:nth-child(2),
+  #attestations-table_wrapper > div:nth-child(2) {
     margin-bottom: 1.55rem;
   }
 }
@@ -477,12 +474,10 @@ label.btn.btn-light:hover {
   color: var(--font-color);
 }
 
-
 .form-check-input {
   width: 1.1rem;
   height: 1.1rem;
 }
-
 
 :root {
   --theme-ethereum-blue: #2a7ee6;
@@ -501,13 +496,11 @@ label.btn.btn-light:hover {
 
 [data-theme="dark"]:root {
   --theme-bg-color-secondary: #413938;
-  --theme-bg-card-body: rgba(92,78,78,0.333333);
+  --theme-bg-card-body: rgba(92, 78, 78, 0.333333);
   --body-color-inverted: #343a40;
 }
 
-:root
-
-.thousands-separator:before{
+:root .thousands-separator:before {
   content: ",";
 }
 
@@ -519,21 +512,21 @@ label.btn.btn-light:hover {
   font-variant-ligatures: none;
 }
 
-.custom-remove-modal { 
+.custom-remove-modal {
   position: relative;
   min-width: 280px;
   padding: 2rem 4rem 3rem;
 }
-.custom-remove-modal-close { 
-  position: relative; 
-  top: -1rem; 
+.custom-remove-modal-close {
+  position: relative;
+  top: -1rem;
   right: -2.5rem;
 }
-.custom-remove-modal-close button:hover { 
+.custom-remove-modal-close button:hover {
   color: var(--dark);
 }
 
-.checkbox-custom-size { 
+.checkbox-custom-size {
   width: 1.1rem;
   height: 1.1rem;
 }
@@ -561,7 +554,7 @@ label.btn.btn-light:hover {
   width: 100%;
   max-height: 19rem;
   margin-top: 4px;
-  padding: .5rem;
+  padding: 0.5rem;
   background-color: var(--bg-color);
   -webkit-border-radius: 4px;
   -moz-border-radius: 4px;
@@ -577,20 +570,20 @@ label.btn.btn-light:hover {
   padding-right: 1rem;
 }
 
-.heading { 
+.heading {
   font-size: 1.8rem;
   letter-spacing: 2px;
 }
-.heading-l2 { 
+.heading-l2 {
   font-size: 1.4rem;
-  letter-spacing: .5px;
+  letter-spacing: 0.5px;
 }
 .heading-l3 {
   font-size: 1.05rem;
   letter-spacing: 1px;
 }
-.heading-l4 { 
-  font-size: .9rem;
+.heading-l4 {
+  font-size: 0.9rem;
   font-weight: 400;
   line-height: 1.45rem !important;
 }
@@ -611,10 +604,10 @@ label.btn.btn-light:hover {
     border: 0;
     border-radius: 0;
   }
-  .custom-remove-modal { 
+  .custom-remove-modal {
     padding: 1.3rem 1.8rem 2.5rem;
   }
-  .custom-remove-modal-close { 
+  .custom-remove-modal-close {
     right: -1rem;
   }
 }
@@ -630,4 +623,9 @@ label.btn.btn-light:hover {
   100% {
     transform: rotate(360deg);
   }
+}
+
+.badge-ens {
+  background: #3e4461;
+  color: #ffffff;
 }

--- a/templates/eth1tx.html
+++ b/templates/eth1tx.html
@@ -128,7 +128,12 @@
               </div>
               <div class="row border-bottom p-3 mx-0">
                 <div class="col-md-3">From:</div>
-                <div class="col-md-9">{{ formatEth1AddressFull .From }}</div>
+                <div class="col-md-9 d-flex flex-wrap">
+                  {{ formatEth1AddressFull .From }}
+                  {{ if ne .FromName "" }}
+                    <div class="ml-2 flex-shrink-1"><span class="badge badge-pill badge-ens align-middle">{{ .FromName }}</span></div>
+                  {{ end }}
+                </div>
               </div>
               <div class="row border-bottom p-3 mx-0" style="border-width:4px !important;">
                 <div class="col-md-3">{{ if .IsContractCreation }}Created{{ else if .TargetIsContract }}Interacted With{{ else }}To{{ end }}:</div>
@@ -148,7 +153,7 @@
                             {{ end }}
                           {{ end }}
                           {{ if ne .ToName "" }}
-                            <div class="flex-shrink-1"><span class="badge badge-dark align-middle text-white">Name: {{ .ToName }}</span></div>
+                            <div class="flex-shrink-1"><span class="badge badge-pill badge-ens align-middle">{{ .ToName }}</span></div>
                           {{ end }}
                         </div>
                       </div>

--- a/templates/eth1tx.html
+++ b/templates/eth1tx.html
@@ -133,6 +133,7 @@
                   {{ if ne .FromName "" }}
                     <div class="ml-2 flex-shrink-1"><span class="badge badge-pill badge-ens align-middle">{{ .FromName }}</span></div>
                   {{ end }}
+                  <i class="fa fa-copy text-muted p-1 ml-1" role="button" data-toggle="tooltip" title="Copy to clipboard" data-clipboard-text="{{ .From }}"></i>
                 </div>
               </div>
               <div class="row border-bottom p-3 mx-0" style="border-width:4px !important;">
@@ -155,6 +156,7 @@
                           {{ if ne .ToName "" }}
                             <div class="flex-shrink-1"><span class="badge badge-pill badge-ens align-middle">{{ .ToName }}</span></div>
                           {{ end }}
+                          <i class="fa fa-copy text-muted p-1" role="button" data-toggle="tooltip" title="Copy to clipboard" data-clipboard-text="{{ .To }}"></i>
                         </div>
                       </div>
                     </div>

--- a/templates/execution/address.html
+++ b/templates/execution/address.html
@@ -376,8 +376,7 @@
       <div class="mb-1 mb-md-0 mt-md-3 d-flex justify-content-between">
         <h1 class="font-weight-bold header-address">
           <span class="mr-1">{{ if .Data.IsContract }}Contract{{ else }}Address{{ end }}</span>
-          <span data-toggle="tooltip" title="View address QR Code" class="mx-1">{{ template "QRCode" . }}</span>
-          <i class="fa fa-copy text-muted text-white p-1 mx-1" style="vertical-align: text-bottom; font-size: .95rem; border-radius: 35%; background-color: var(--shadow-light);" role="button" data-toggle="tooltip" title="Copy to clipboard" data-clipboard-text="{{ fixAddressCasing .Data.Address }}"></i>
+          {{ if len .Data.EnsName }}<span class="badge badge-pill badge-ens">{{ .Data.EnsName }}</span>{{ end }}
         </h1>
         <div class="dropdown">
           <button class="btn btn-sm btn-primary text-white dropdown-toggle" type="button" data-toggle="dropdown" aria-expanded="false">More</button>
@@ -391,6 +390,8 @@
       </div>
       <h4 class="h4 text-monospace mb-md-3 header-address text-truncate">
         {{ .Data.Address | formatAddressLong }}
+        <span data-toggle="tooltip" title="View address QR Code" class="mx-1">{{ template "QRCode" . }}</span>
+        <i class="fa fa-copy text-muted text-white p-1 mx-1" style="vertical-align: text-bottom; font-size: .95rem; border-radius: 35%; background-color: var(--shadow-light);" role="button" data-toggle="tooltip" title="Copy to clipboard" data-clipboard-text="{{ fixAddressCasing .Data.Address }}"></i>
       </h4>
       <div>
         {{ if .Data.Metadata.Name }}<span class="badge badge-secondary text-light my-2">{{ .Data.Metadata.Name }}</span>{{ end }}

--- a/types/templates.go
+++ b/types/templates.go
@@ -1570,6 +1570,7 @@ type DataTableSaveStateColumns struct {
 
 type Eth1AddressPageData struct {
 	Address            string `json:"address"`
+	EnsName            string `json:"ensName"`
 	IsContract         bool
 	QRCode             string `json:"qr_code_base64"`
 	QRCodeInverse      string

--- a/utils/eth1.go
+++ b/utils/eth1.go
@@ -158,6 +158,7 @@ func formatAddress(address []byte, token []byte, name string, isContract bool, l
 		}
 		name = fmt.Sprintf(`<span class="text-monospace">%s</span>`, name)
 	} else { // name set
+		addCopyToClipboard = true
 		tooltip = fmt.Sprintf("%s\n%s", name, addressString) // set tool tip first, as we will change name
 		// limit name if necessary
 		if nameLimit > 0 && len(name) > nameLimit {


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c3c3511</samp>

This pull request adds support for displaying ENS names for eth1 and execution addresses and transactions in the explorer. It queries the ENS database and formats the addresses with ENS names if available, using new fields, functions, and CSS classes. It also improves the code style and the usability of QR code and clipboard functions. It affects the files `db/bigtable_eth1.go`, `db/ens.go`, `handlers/eth1Account.go`, `static/css/layout.css`, `templates/eth1tx.html`, `templates/execution/address.html`, `types/templates.go`, and `utils/eth1.go`.
