### PR TITLE
(BIDS-2335) use config for bt setup on eth1indexer, signatures

### DIFF
--- a/cmd/eth1indexer/main.go
+++ b/cmd/eth1indexer/main.go
@@ -60,9 +60,6 @@ func main() {
 	tokenPriceExportList := flag.String("token.price.list", "", "Tokenlist path to use for the token price export")
 	tokenPriceExportFrequency := flag.Duration("token.price.frequency", time.Hour, "Token price export interval")
 
-	bigtableProject := flag.String("bigtable.project", "", "Bigtable project")
-	bigtableInstance := flag.String("bigtable.instance", "", "Bigtable instance")
-
 	versionFlag := flag.Bool("version", false, "Print version and exit")
 
 	configPath := flag.String("config", "", "Path to the config file, if empty string defaults will be used")
@@ -135,7 +132,7 @@ func main() {
 		logrus.Fatalf("node chain id mismatch, wanted %v got %v", chainId, nodeChainId.String())
 	}
 
-	bt, err := db.InitBigtable(*bigtableProject, *bigtableInstance, chainId, utils.Config.RedisCacheEndpoint)
+	bt, err := db.InitBigtable(utils.Config.Bigtable.Project, utils.Config.Bigtable.Instance, chainId, utils.Config.RedisCacheEndpoint)
 	if err != nil {
 		logrus.Fatalf("error connecting to bigtable: %v", err)
 	}

--- a/cmd/signatures/main.go
+++ b/cmd/signatures/main.go
@@ -25,8 +25,6 @@ import (
 * so that we can label the transction function calls instead of the "id"
 **/
 func main() {
-	bigtableProject := flag.String("bigtable.project", "", "Bigtable project")
-	bigtableInstance := flag.String("bigtable.instance", "", "Bigtable instance")
 	configPath := flag.String("config", "", "Path to the config file, if empty string defaults will be used")
 	metricsAddr := flag.String("metrics.address", "localhost:9090", "serve metrics on that addr")
 	metricsEnabled := flag.Bool("metrics.enabled", false, "enable serving metrics")
@@ -76,7 +74,7 @@ func main() {
 		}()
 	}
 
-	bt, err := db.InitBigtable(*bigtableProject, *bigtableInstance, "1", utils.Config.RedisCacheEndpoint)
+	bt, err := db.InitBigtable(utils.Config.Bigtable.Project, utils.Config.Bigtable.Instance, "1", utils.Config.RedisCacheEndpoint)
 	if err != nil {
 		logrus.Errorf("error initializing bigtable: %v", err)
 		return


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a579c97</samp>

Refactored the bigtable configuration and usage for eth1indexer and signatures commands. This simplifies the code and enhances the data handling.
