### PR TITLE
(BIDS-2183) Move attestation load to the end of the script

### DIFF
--- a/templates/slot/slot.html
+++ b/templates/slot/slot.html
@@ -4,20 +4,6 @@
   <script type="text/javascript" src="/js/datatable_input.js"></script>
 
   <script>
-    {
-      var attestations_tab_loaded = false
-      let atab = $('#attestations-tab')
-      if(atab.length > 0) {
-        atab.on('shown.bs.tab', function (event) { if(!attestations_tab_loaded) { setupInfiniteScrollAttestations(); }; attestations_tab_loaded = true; });
-      } else {
-        console.error('error getting #attestations-tab')
-        const att = document.getElementById('attestations');
-        if(att) {
-          att.appendChild(getInfoElementAttestations('Error loading attestations...', 'red'));
-        }
-      }
-    }
-
     function getInfoElementAttestations (text, color) {
       const att_card = document.createElement('div'); {
         att_card.classList.add('card', 'my-2');
@@ -298,6 +284,20 @@
 
         $("#block_blsChange").DataTable(blsChangeOpts)
     })
+
+    {
+      var attestations_tab_loaded = false
+      let atab = $('#attestations-tab')
+      if(atab.length > 0) {
+        atab.on('shown.bs.tab', function (event) { if(!attestations_tab_loaded) { setupInfiniteScrollAttestations(); }; attestations_tab_loaded = true; });
+      } else {
+        console.error('error getting #attestations-tab')
+        const att = document.getElementById('attestations');
+        if(att) {
+          att.appendChild(getInfoElementAttestations('Error loading attestations...', 'red'));
+        }
+      }
+    }
   </script>
 
   <script>


### PR DESCRIPTION
While it is relatively easy to reproduce for Sepolia/Prater/Main (~10-20%) in Chrome I could never reproduce it in Firefox or when starting the explorer locally.

The implemented attempted fix can therefore only be tested after it is merged on Sepolia.

The issue is that https://github.com/gobitfly/eth2-beaconchain-explorer/blob/5016ae03304f813c3441226174187d3fe1212687/templates/slot/slot.html#L292 gets set up correctly but you then never enter the function `setupInfiniteScrollAttestations`.
Moving this to the end of the script after the `$(document).ready(function () {...}` might help.