### PR TITLE
(BIDS-2340) split validator stats total accumulation

### DIFF
--- a/db/migrations/tbd_add_validator_stats_total_accumulation_column copy.sql
+++ b/db/migrations/tbd_add_validator_stats_total_accumulation_column copy.sql
@@ -1,0 +1,18 @@
+-- +goose Up
+-- +goose StatementBegin
+SELECT 'up SQL query with new column total_accumulation_exported for validator_stats_status';
+ALTER TABLE validator_stats_status ADD COLUMN IF NOT EXISTS total_accumulation_exported BOOLEAN NOT NULL DEFAULT FALSE;
+
+SELECT 'setting new validator_stats_status columns to true for already exported days'; 
+UPDATE validator_stats_status
+SET 
+    total_accumulation_exported = true
+WHERE total_performance_exported=true;
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+SELECT 'down SQL query column total_accumulation_exported for validator_stats_status';
+ALTER TABLE validator_stats_status DROP COLUMN IF EXISTS total_accumulation_exported;
+-- +goose StatementEnd

--- a/db/migrations/tbd_add_validator_stats_total_accumulation_column copy.sql
+++ b/db/migrations/tbd_add_validator_stats_total_accumulation_column copy.sql
@@ -7,7 +7,7 @@ SELECT 'setting new validator_stats_status columns to true for already exported 
 UPDATE validator_stats_status
 SET 
     total_accumulation_exported = true
-WHERE total_performance_exported=true;
+WHERE total_performance_exported = true;
 
 -- +goose StatementEnd
 

--- a/db/statistics.go
+++ b/db/statistics.go
@@ -364,11 +364,6 @@ func WriteValidatorTotalPerformance(day uint64, concurrency uint64) error {
 			_, err = WriterDb.Exec(`insert into validator_performance (
 				validatorindex,
 				balance,
-				performance1d,
-				performance7d,
-				performance31d,
-				performance365d,
-
 				rank7d,
 
 				cl_performance_1d,
@@ -392,11 +387,7 @@ func WriteValidatorTotalPerformance(day uint64, concurrency uint64) error {
 				) (
 					select 
 					vs_now.validatorindex, 
-						COALESCE(vs_now.end_balance, 0) as balance, 
-						0 as performance1d, 
-						0 as performance7d, 
-						0 as performance31d, 
-						0 as performance365d, 
+						COALESCE(vs_now.end_balance, 0) as balance,
 						0 as rank7d,
 
 						coalesce(vs_now.cl_rewards_gwei_total, 0) - coalesce(vs_1d.cl_rewards_gwei_total, 0) as cl_performance_1d, 
@@ -425,12 +416,7 @@ func WriteValidatorTotalPerformance(day uint64, concurrency uint64) error {
 					where vs_now.day = $1 AND vs_now.validatorindex >= $6 AND vs_now.validatorindex < $7
 				) 
 				on conflict (validatorindex) do update set 
-					balance = excluded.balance, 
-					performance1d=excluded.performance1d,
-					performance7d=excluded.performance7d,
-					performance31d=excluded.performance31d,
-					performance365d=excluded.performance365d,
-
+					balance = excluded.balance,
 					rank7d=excluded.rank7d,
 
 					cl_performance_1d=excluded.cl_performance_1d,
@@ -468,14 +454,10 @@ func WriteValidatorTotalPerformance(day uint64, concurrency uint64) error {
 	_, err = WriterDb.Exec(`
 		insert into validator_performance (                                                                                                 
 			validatorindex,          
-			balance,             
-			performance1d,
-			performance7d,
-			performance31d,  
-			performance365d,                                                                                             
+			balance,
 			rank7d
 		) (
-			select validatorindex, 0, 0, 0, 0, 0, row_number() over(order by validator_performance.cl_performance_7d desc) as rank7d from validator_performance
+			select validatorindex, 0, row_number() over(order by validator_performance.cl_performance_7d desc) as rank7d from validator_performance
 		) 
 			on conflict (validatorindex) do update set 
 				rank7d=excluded.rank7d

--- a/db/statistics.go
+++ b/db/statistics.go
@@ -48,7 +48,7 @@ func WriteValidatorStatisticsForDay(day uint64, concurrencyTotal uint64, concurr
 		ElRewards           bool `db:"el_rewards_exported"`
 		TotalPerformance    bool `db:"total_performance_exported"`
 		BlockStats          bool `db:"block_stats_exported"`
-		TotalAccumation     bool `db:"total_accumulation_exported"`
+		TotalAccumulation   bool `db:"total_accumulation_exported"`
 	}
 	exported := Exported{}
 
@@ -73,7 +73,7 @@ func WriteValidatorStatisticsForDay(day uint64, concurrencyTotal uint64, concurr
 	}
 	logger.Infof("getting exported state took %v", time.Since(start))
 
-	if exported.FailedAttestations && exported.SyncDuties && exported.WithdrawalsDeposits && exported.Balance && exported.ClRewards && exported.ElRewards && exported.TotalPerformance && exported.BlockStats && exported.Status {
+	if exported.FailedAttestations && exported.SyncDuties && exported.WithdrawalsDeposits && exported.Balance && exported.ClRewards && exported.ElRewards && exported.TotalAccumulation && exported.TotalPerformance && exported.BlockStats && exported.Status {
 		logger.Infof("Skipping day %v as it is already exported", day)
 		return nil
 	}
@@ -120,7 +120,7 @@ func WriteValidatorStatisticsForDay(day uint64, concurrencyTotal uint64, concurr
 		return err
 	}
 
-	if exported.TotalAccumation {
+	if exported.TotalAccumulation {
 		logger.Infof("Skipping total accumulation")
 	} else if err := WriteValidatorTotalAccumulation(day, concurrencyTotal); err != nil {
 		return err


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0c576ef</samp>

This pull request adds a new column `total_accumulation_exported` to the `validator_stats_status` table to track the export status of the total accumulation statistics for validators. It also updates the `db` package functions and adds a SQL migration script to handle the new column. The goal is to improve the efficiency and accuracy of exporting the total accumulation statistics, which are a new feature of the eth2-beaconchain-explorer.
