### PR TITLE
(BIDS-2337) increase finality warning to > 5

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -125,7 +125,7 @@
               {{- end }}
             {{ end }}
             {{ if not .ShowSyncingMessage }}
-              {{ if gt .FinalizationDelay 3 }}
+              {{ if gt .FinalizationDelay 5 }}
                 <div data-toggle="tooltip" title="" data-original-title="Finality: the last finalized epoch was {{ .FinalizationDelay }} epochs ago" id="banner-fin" class="info-item d-flex mr-2 mr-lg-3">
                   <div class="info-item-header mr-1">
                     <span class="item-icon"><i class="fas fa-exclamation-triangle"></i></span>

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -126,7 +126,7 @@
             {{ end }}
             {{ if not .ShowSyncingMessage }}
               {{ if gt .FinalizationDelay 5 }}
-                <div data-toggle="tooltip" title="" data-original-title="Finality: the last finalized epoch was {{ .FinalizationDelay }} epochs ago" id="banner-fin" class="info-item d-flex mr-2 mr-lg-3">
+                <div data-toggle="tooltip" title="" data-original-title="Finality: The last finalized epoch was {{ .FinalizationDelay }} epochs ago" id="banner-fin" class="info-item d-flex mr-2 mr-lg-3">
                   <div class="info-item-header mr-1">
                     <span class="item-icon"><i class="fas fa-exclamation-triangle"></i></span>
                   </div>


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 55252bb</samp>

Reduced the threshold for showing the finality banner in `layout.html` from 3 to 5 epochs. This improves the user experience and matches the Prysm client's criteria for non-finality.
