### PR TITLE
(BIDS-2342) quick fix for last validator sync page

### DIFF
--- a/handlers/validator.go
+++ b/handlers/validator.go
@@ -1965,6 +1965,11 @@ func ValidatorSync(w http.ResponseWriter, r *http.Request) {
 
 		// last epoch containing the duties shown on this page
 		lastShownEpoch := moveAway(firstShownEpoch, epochsDiff)
+		// handle overflow on last page
+		if !ascOrdering && lastShownEpoch > firstShownEpoch {
+			lastShownEpoch = 0
+			length = utils.Config.Chain.Config.SlotsPerEpoch - (start % utils.Config.Chain.Config.SlotsPerEpoch)
+		}
 		// amount of epochs fetched by bigtable
 		limit := diffValue(firstShownEpoch, lastShownEpoch) + 1
 

--- a/handlers/validator.go
+++ b/handlers/validator.go
@@ -1966,7 +1966,7 @@ func ValidatorSync(w http.ResponseWriter, r *http.Request) {
 
 		// last epoch containing the duties shown on this page
 		lastShownEpoch := moveAway(firstShownEpoch, epochsDiff)
-		// handle overflow on last page
+		// handle overflow on last page for validators that were part of the very first sync period starting during epoch 0
 		if !ascOrdering && lastShownEpoch > firstShownEpoch {
 			lastShownEpoch = 0
 			length = utils.Config.Chain.Config.SlotsPerEpoch - (start % utils.Config.Chain.Config.SlotsPerEpoch)

--- a/handlers/validator.go
+++ b/handlers/validator.go
@@ -2067,7 +2067,7 @@ func ValidatorSync(w http.ResponseWriter, r *http.Request) {
 		}
 
 		// sanity check for right amount of slots in response
-		if uint64(len(syncDuties))%utils.Config.Chain.Config.SlotsPerEpoch == 0 {
+		if uint64(len(syncDutiesValidator))%utils.Config.Chain.Config.SlotsPerEpoch == 0 {
 			// extract correct slots
 			tableData = make([][]interface{}, length)
 			for dataIndex, slotIndex := 0, start%utils.Config.Chain.Config.SlotsPerEpoch; slotIndex < protomath.MinU64((start%utils.Config.Chain.Config.SlotsPerEpoch)+length, uint64(len(syncDuties))); dataIndex, slotIndex = dataIndex+1, slotIndex+1 {


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7b0f364</samp>

Fix validator sync page sorting bug in `handlers/validator.go`. Handle epoch overflow on last page and adjust page length accordingly.
