### PR TITLE
(BIDS-2334) Add configurable api key to monitoring

### DIFF
--- a/services/monitoring.go
+++ b/services/monitoring.go
@@ -173,24 +173,28 @@ func startApiMonitoringService() {
 		Timeout: time.Second * 10,
 	}
 
+	url := "https://" + utils.Config.Frontend.SiteDomain + "/api/v1/epoch/latest"
+	// add apikey (if any) to url but don't log the api key when errors occur
+	errFields := map[string]interface{}{
+		"url": url}
+	url += "?apikey=" + utils.Config.Monitoring.ApiKey
+
 	for {
 		if !firstRun {
 			time.Sleep(time.Minute)
 		}
 		firstRun = false
 
-		url := "https://" + utils.Config.Frontend.SiteDomain + "/api/v1/epoch/latest"
 		resp, err := client.Get(url)
-
 		if err != nil {
-			utils.LogError(err, "getting client error", 0)
+			utils.LogError(err, "getting client error", 0, errFields)
 			ReportStatus(name, err.Error(), nil)
 			continue
 		}
 
 		if resp.StatusCode != 200 {
 			errorMsg := fmt.Errorf("error: api epoch / latest endpoint returned a non 200 status: %v", resp.StatusCode)
-			utils.LogError(nil, errorMsg, 0)
+			utils.LogError(nil, errorMsg, 0, errFields)
 			ReportStatus(name, errorMsg.Error(), nil)
 			continue
 		}
@@ -208,24 +212,28 @@ func startAppMonitoringService() {
 		Timeout: time.Second * 10,
 	}
 
+	url := "https://" + utils.Config.Frontend.SiteDomain + "/api/v1/app/dashboard"
+	// add apikey (if any) to url but don't log the api key when errors occur
+	errFields := map[string]interface{}{
+		"url": url}
+	url += "?apikey=" + utils.Config.Monitoring.ApiKey
+
 	for {
 		if !firstRun {
 			time.Sleep(time.Minute)
 		}
 		firstRun = false
 
-		url := "https://" + utils.Config.Frontend.SiteDomain + "/api/v1/app/dashboard"
 		resp, err := client.Post(url, "application/json", strings.NewReader(`{"indicesOrPubkey": "1,2"}`))
-
 		if err != nil {
-			utils.LogError(err, "POST to dashboard URL error", 0)
+			utils.LogError(err, "POST to dashboard URL error", 0, errFields)
 			ReportStatus(name, err.Error(), nil)
 			continue
 		}
 
 		if resp.StatusCode != 200 {
 			errorMsg := fmt.Errorf("error: api app endpoint returned a non 200 status: %v", resp.StatusCode)
-			utils.LogError(nil, errorMsg, 0)
+			utils.LogError(nil, errorMsg, 0, errFields)
 			ReportStatus(name, errorMsg.Error(), nil)
 			continue
 		}
@@ -261,8 +269,8 @@ func startServicesMonitoringService() {
 		//"notification-sender", //exclude for now as the sender is only running on mainnet
 	}
 
-	if utils.Config.ServiceMonitoringConfigurations != nil {
-		for _, service := range utils.Config.ServiceMonitoringConfigurations {
+	if utils.Config.Monitoring.ServiceMonitoringConfigurations != nil {
+		for _, service := range utils.Config.Monitoring.ServiceMonitoringConfigurations {
 			if service.Duration == 0 {
 				delete(servicesToCheck, service.Name)
 				logger.Infof("Removing %v from monitoring service", service.Name)

--- a/types/config.go
+++ b/types/config.go
@@ -196,7 +196,10 @@ type Config struct {
 		ElEndpoint string `yaml:"elEndpoint" envconfig:"NODE_JOBS_PROCESSOR_EL_ENDPOINT"`
 		ClEndpoint string `yaml:"clEndpoint" envconfig:"NODE_JOBS_PROCESSOR_CL_ENDPOINT"`
 	} `yaml:"nodeJobsProcessor"`
-	ServiceMonitoringConfigurations []ServiceMonitoringConfiguration `yaml:"serviceMonitoringConfigurations" envconfig:"SERVICE_MONITORING_CONFIGURATIONS"`
+	Monitoring struct {
+		ApiKey                          string                           `yaml:"apiKey" envconfig:"MONITORING_API_KEY"`
+		ServiceMonitoringConfigurations []ServiceMonitoringConfiguration `yaml:"serviceMonitoringConfigurations" envconfig:"SERVICE_MONITORING_CONFIGURATIONS"`
+	} `yaml:"monitoring"`
 }
 
 type DatabaseConfig struct {


### PR DESCRIPTION
This PR adds a configurable api key to the monitoring. If set, it is used within `startApiMonitoringService` and `startAppMonitoringService`.
Error messages in both functions have also been improved slightly.