### PR TITLE
(NOBIDS) insert from_address_text only if missing

### DIFF
--- a/db/migrations/20230814124202_add_from_address_to_text_eth1_deposits.sql
+++ b/db/migrations/20230814124202_add_from_address_to_text_eth1_deposits.sql
@@ -1,7 +1,7 @@
 -- +goose Up
 -- +goose StatementBegin
 SELECT 'up SQL query - add column eth1_deposits for from_address_text';
-ALTER TABLE eth1_deposits ADD COLUMN from_address_text TEXT NOT NULL DEFAULT '';
+ALTER TABLE eth1_deposits ADD COLUMN IF NOT EXISTS from_address_text TEXT NOT NULL DEFAULT '';
 
 SELECT 'create new eth1_deposits index for from_address_text'; 
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_eth1_deposits_from_address_text ON eth1_deposits (from_address_text);
@@ -38,5 +38,5 @@ SELECT 'down SQL query - drop from_address_text index from eth1_deposits ';
 DROP INDEX IF EXISTS idx_eth1_deposits_from_address_text;
 
 SELECT 'drop column from_address_text from eth1_deposits';
-ALTER TABLE eth1_deposits DROP COLUMN from_address_text;
+ALTER TABLE eth1_deposits DROP COLUMN IF EXISTS from_address_text;
 -- +goose StatementEnd


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at df685e7</samp>

This file adds a new column to store the sender address of each eth1 deposit in the `text_eth1_deposits` table. It also checks for and avoids potential column conflicts.
