### PR TITLE
(NOBIDS) dont use transactions in from_address_text sql up

### DIFF
--- a/db/migrations/20230814124202_add_from_address_to_text_eth1_deposits.sql
+++ b/db/migrations/20230814124202_add_from_address_to_text_eth1_deposits.sql
@@ -1,11 +1,16 @@
+-- +goose NO TRANSACTION
 -- +goose Up
 -- +goose StatementBegin
 SELECT 'up SQL query - add column eth1_deposits for from_address_text';
 ALTER TABLE eth1_deposits ADD COLUMN from_address_text TEXT NOT NULL DEFAULT '';
+-- +goose StatementEnd
 
+-- +goose StatementBegin
 SELECT 'create new eth1_deposits index for from_address_text'; 
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_eth1_deposits_from_address_text ON eth1_deposits (from_address_text);
+-- +goose StatementEnd
 
+-- +goose StatementBegin
 SELECT 'populate new eth1_deposits column from_address_text, 1000 at a time'; 
 DO
 $do$
@@ -29,14 +34,15 @@ LOOP
 END LOOP;
 END;
 $do$;
-
 -- +goose StatementEnd
 
 -- +goose Down
 -- +goose StatementBegin
 SELECT 'down SQL query - drop from_address_text index from eth1_deposits '; 
 DROP INDEX IF EXISTS idx_eth1_deposits_from_address_text;
+-- +goose StatementEnd
 
+-- +goose StatementBegin
 SELECT 'drop column from_address_text from eth1_deposits';
 ALTER TABLE eth1_deposits DROP COLUMN from_address_text;
 -- +goose StatementEnd


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d39b907</samp>

Improved the migration file for adding `from_address` to `text_eth1_deposits` table. Used separate transactions and concurrent index creation to speed up and avoid locking the database.
