### PR TITLE
(BIDS-2340) Fix performance xd columns (remove them from DB)

### DIFF
--- a/db/migrations/20230814224221_fix_performance_xd.sql
+++ b/db/migrations/20230814224221_fix_performance_xd.sql
@@ -1,0 +1,17 @@
+-- +goose Up
+-- +goose StatementBegin
+SELECT 'delete all unneeded performance xd columns';
+ALTER TABLE validator_performance DROP COLUMN IF EXISTS performance1d;
+ALTER TABLE validator_performance DROP COLUMN IF EXISTS performance7d;
+ALTER TABLE validator_performance DROP COLUMN IF EXISTS performance31d;
+ALTER TABLE validator_performance DROP COLUMN IF EXISTS performance365d;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+SELECT 'add all unneeded performance xd columns';
+ALTER TABLE validator_stats ADD COLUMN IF NOT EXISTS performance1d BIGINT NOT NULL;
+ALTER TABLE validator_stats ADD COLUMN IF NOT EXISTS performance7d BIGINT NOT NULL;
+ALTER TABLE validator_stats ADD COLUMN IF NOT EXISTS performance31d BIGINT NOT NULL;
+ALTER TABLE validator_stats ADD COLUMN IF NOT EXISTS performance365d BIGINT NOT NULL;
+-- +goose StatementEnd


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8cd8012</samp>

This change fixes a performance issue by moving the `performance xd` columns from the `validator_performance` table to the `validator_stats` table. This restores the correct schema for storing and querying the validator's balance change over time.
