### PR TITLE
(BIDS-2371) Use update instead of upsert for rank7d

### DIFF
--- a/db/migrations/TBD_add_not_null_constraint_to_cl_proposer_performance_total.sql
+++ b/db/migrations/TBD_add_not_null_constraint_to_cl_proposer_performance_total.sql
@@ -1,0 +1,12 @@
+-- +goose NO TRANSACTION
+-- +goose Up
+SELECT 'up SQL query - add not null constraint to column cl_proposer_performance_total in validator_performance';
+-- +goose StatementBegin
+ALTER TABLE validator_performance ALTER COLUMN cl_proposer_performance_total SET NOT NULL;
+-- +goose StatementEnd
+
+-- +goose Down
+SELECT 'up SQL query - drop not null constraint to column cl_proposer_performance_total in validator_performance';
+-- +goose StatementBegin
+ALTER TABLE validator_performance ALTER COLUMN cl_proposer_performance_total DROP NOT NULL;
+-- +goose StatementEnd


### PR DESCRIPTION
With this PR, `rank7d` in `validator_performance` is updated via `UPDATE` and not via an "upsert". This will not cause any `violates not-null constraint` errors. It is also cleaner.