### PR TITLE
(BIDS-2360) fix notification center validator amount

### DIFF
--- a/handlers/user.go
+++ b/handlers/user.go
@@ -564,7 +564,7 @@ func UserNotificationsCenter(w http.ResponseWriter, r *http.Request) {
 
 	watchlist := []watchlistValidators{}
 	err = db.WriterDb.Select(&watchlist, `
-	SELECT 
+	SELECT DISTINCT ON (index)
 		validators.validatorindex as index,
 		ENCODE(validators.pubkey, 'hex') as pubkey,
 		eth1_deposits.from_address


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4163abb</samp>

Fixed a bug that caused duplicate notifications for some validators by changing the SQL query in `handlers/user.go`. This was part of a pull request that improved user notifications.

Correcting the validator count on the dashboard by removing duplicated entries from the underlying query. Afaics there should be no other side effects.

Could only test on Sepolia, check validator 379984 on prater for example as an extreme example.