### PR TITLE
(BIDS-1690) lighthouse - listen to stream errors to reconnect

### DIFF
--- a/rpc/lighthouse.go
+++ b/rpc/lighthouse.go
@@ -33,8 +33,6 @@ type LighthouseClient struct {
 	assignmentsCache    *lru.Cache
 	assignmentsCacheMux *sync.Mutex
 	signer              gtypes.Signer
-	lastBlockSeen       time.Time
-	lastBlockSeenMux    *sync.Mutex
 }
 
 // NewLighthouseClient is used to create a new Lighthouse client
@@ -44,7 +42,6 @@ func NewLighthouseClient(endpoint string, chainID *big.Int) (*LighthouseClient, 
 		endpoint:            endpoint,
 		assignmentsCacheMux: &sync.Mutex{},
 		signer:              signer,
-		lastBlockSeenMux:    &sync.Mutex{},
 	}
 	client.assignmentsCache, _ = lru.New(10)
 
@@ -52,22 +49,6 @@ func NewLighthouseClient(endpoint string, chainID *big.Int) (*LighthouseClient, 
 }
 
 func (lc *LighthouseClient) GetNewBlockChan() chan *types.Block {
-	// setup health check & exit if the new block chan does no longer receive new blocks
-	lc.lastBlockSeenMux.Lock()
-	lc.lastBlockSeen = time.Now()
-	lc.lastBlockSeenMux.Unlock()
-	go func() {
-		for ; ; time.Sleep(time.Second) {
-			lc.lastBlockSeenMux.Lock()
-			if time.Since(lc.lastBlockSeen) > time.Minute*2 {
-				lc.lastBlockSeenMux.Unlock()
-				// fatal if no new block was received for more than two minutes
-				logger.Fatalf("lighthouse client error, no new block retrieved since %v (%v ago)", lc.lastBlockSeen, time.Since(lc.lastBlockSeen))
-			}
-			lc.lastBlockSeenMux.Unlock()
-		}
-	}()
-
 	blkCh := make(chan *types.Block, 10)
 	go func() {
 		stream, err := eventsource.Subscribe(fmt.Sprintf("%s/eth/v1/events?topics=head", lc.endpoint), "")
@@ -76,6 +57,14 @@ func (lc *LighthouseClient) GetNewBlockChan() chan *types.Block {
 			utils.LogFatal(err, "getting eventsource stream error", 0)
 		}
 		defer stream.Close()
+
+		go func() {
+			for {
+				// It is important to register to Errors, otherwise the stream does not reconnect if the connection was lost
+				err := <-stream.Errors
+				utils.LogError(err, "Lighthouse connection error (will automaticaly retry to connect)", 0)
+			}
+		}()
 
 		for {
 			e := <-stream.Events
@@ -98,9 +87,6 @@ func (lc *LighthouseClient) GetNewBlockChan() chan *types.Block {
 				// logger.Infof("pushing block %v", blk.Slot)
 				blkCh <- blk
 			}
-			lc.lastBlockSeenMux.Lock()
-			lc.lastBlockSeen = time.Now()
-			lc.lastBlockSeenMux.Unlock()
 		}
 	}()
 	return blkCh


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 22e6f9e</samp>

Refactored `LighthouseClient` to simplify health check and handle stream errors. Removed unused code from `rpc/lighthouse.go`.
