### PR TITLE
(NOBIDS) Added workflow for dencun-devnet-8 docker

### DIFF
--- a/.github/workflows/publish-dencun-devnet-8-images.yml
+++ b/.github/workflows/publish-dencun-devnet-8-images.yml
@@ -1,0 +1,21 @@
+name: Publish Docker dencun-devnet-8 images
+
+on:
+  # Trigger the workflow on push or pull request,
+  # but only for the dencun-devnet-8 branch
+  push:
+    branches:
+      - dencun-devnet-8
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Publish to Dockerhub Registry
+        uses: elgohr/Publish-Docker-Github-Action@master
+        with:
+          name: gobitfly/eth2-beaconchain-explorer
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          tags: "dencun-devnet-8"


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a03a59d</samp>

Add a new workflow file to build and publish a Docker image of the application for the dencun-devnet-8 branch. This enables automated deployment of the new feature to a Dockerhub repository.
