### PR TITLE
(BIDS-2183) fixed wrong element selector

### DIFF
--- a/templates/slot/slot.html
+++ b/templates/slot/slot.html
@@ -121,7 +121,7 @@
     }
 
     async function setupInfiniteScrollAttestations() {
-      const infLoading = document.getElementById('attestations');
+      const infLoading = document.getElementById('attestationsTabPanel');
       if(infLoading) {
         try {
           const slot = {{ .Slot }} || 0;
@@ -292,7 +292,7 @@
         atab.on('shown.bs.tab', function (event) { if(!attestations_tab_loaded) { setupInfiniteScrollAttestations(); }; attestations_tab_loaded = true; });
       } else {
         console.error('error getting #attestations-tab')
-        const att = document.getElementById('attestations');
+        const att = document.getElementById('attestationsTabPanel');
         if(att) {
           att.appendChild(getInfoElementAttestations('Error loading attestations...', 'red'));
         }


### PR DESCRIPTION
copilot:summary

Fixed wrong selector id which stops attestation list from loading. It's related to changes: https://github.com/gobitfly/eth2-beaconchain-explorer/commit/b23f38357c85645f7641f47316abeb062b18843a#diff-e98fbd7d0e7546a403f9da39a8fc65da216d234dfbc5e582c51374f54561e16cL432-R433