### PR TITLE
(BIDS-2183) manually trigger shown event

### DIFF
--- a/static/js/layout.js
+++ b/static/js/layout.js
@@ -181,7 +181,6 @@ function activateTabbarSwitcher(tabContainerId, tabBar, defaultTab) {
     }
 
     new bootstrap.Tab(someTabTriggerEl[0]).show()
-    $(`[href='#${selectedTab}']`).trigger("shown")
   }
   const handleTabChangeClick = (event) => {
     var href = event.currentTarget.href

--- a/static/js/layout.js
+++ b/static/js/layout.js
@@ -181,6 +181,7 @@ function activateTabbarSwitcher(tabContainerId, tabBar, defaultTab) {
     }
 
     new bootstrap.Tab(someTabTriggerEl[0]).show()
+    $(`[href='#${selectedTab}']`).trigger("shown")
   }
   const handleTabChangeClick = (event) => {
     var href = event.currentTarget.href

--- a/templates/slot/slot.html
+++ b/templates/slot/slot.html
@@ -289,7 +289,13 @@
       var attestations_tab_loaded = false
       let atab = $('#attestations-tab')
       if(atab.length > 0) {
-        atab.on('shown.bs.tab', function (event) { if(!attestations_tab_loaded) { setupInfiniteScrollAttestations(); }; attestations_tab_loaded = true; });
+        var activateAttestations = ()=>{
+          if(!attestations_tab_loaded) { setupInfiniteScrollAttestations(); }; attestations_tab_loaded = true;
+        }
+        atab.on('shown.bs.tab', activateAttestations);
+        if (atab.hasClass("active")){
+          activateAttestations()
+        }
       } else {
         console.error('error getting #attestations-tab')
         const att = document.getElementById('attestationsTabPanel');


### PR DESCRIPTION
It seems like chromium-based browsers don't trigger `.on("shown.bs.tab"` on reload if page loading is takes too long for some reason, so I suggest calling those events manually. It should be made sure that there are no further side effects (as the `shown` event might gets executed twice for some tabs now).

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 610872c</samp>

Trigger custom event on tab switch to update components. The change adds a `shown` event to the tab link in `layout.js` and uses it to update the deposits chart in `charts.js` when the deposits tab is shown.
