### PR TITLE
(BIDS-2253) Implement reexport for eth store database

### DIFF
--- a/cmd/ethstore-exporter/main.go
+++ b/cmd/ethstore-exporter/main.go
@@ -8,6 +8,8 @@ import (
 	"eth2-exporter/version"
 	"flag"
 	"fmt"
+	"strconv"
+	"strings"
 
 	_ "github.com/jackc/pgx/v4/stdlib"
 	"github.com/sirupsen/logrus"
@@ -21,6 +23,8 @@ func main() {
 	errorInterval := flag.Duration("error-intv", 0, "Error interval")
 	sleepInterval := flag.Duration("sleep-intv", 0, "Sleep interval")
 	versionFlag := flag.Bool("version", false, "Show version and exit")
+	dayToReexport := flag.Int64("day", -1, "Day to reexport")
+	daysToReexport := flag.String("days", "", "Days to reexport")
 	flag.Parse()
 
 	if *versionFlag {
@@ -56,6 +60,27 @@ func main() {
 	defer db.ReaderDb.Close()
 	defer db.WriterDb.Close()
 
-	exporter.StartEthStoreExporter(*bnAddress, *enAddress, *updateInterval, *errorInterval, *sleepInterval)
+	var startDayReexport int64 = -1
+	var endDayReexport int64 = -1
+
+	if *daysToReexport != "" {
+		s := strings.Split(*daysToReexport, "-")
+		if len(s) < 2 {
+			logrus.Fatalf("invalid arg")
+		}
+		startDayReexport, err = strconv.ParseInt(s[0], 10, 64)
+		if err != nil {
+			utils.LogFatal(err, "error parsing first day of daysToExport flag to int", 0)
+		}
+		endDayReexport, err = strconv.ParseInt(s[1], 10, 64)
+		if err != nil {
+			utils.LogFatal(err, "error parsing last day of daysToExport flag to int", 0)
+		}
+	} else if *dayToReexport >= 0 {
+		startDayReexport = *dayToReexport
+		endDayReexport = *dayToReexport
+	}
+
+	exporter.StartEthStoreExporter(*bnAddress, *enAddress, *updateInterval, *errorInterval, *sleepInterval, startDayReexport, endDayReexport)
 	logrus.Println("exiting...")
 }

--- a/cmd/ethstore-exporter/main.go
+++ b/cmd/ethstore-exporter/main.go
@@ -66,7 +66,7 @@ func main() {
 	if *daysToReexport != "" {
 		s := strings.Split(*daysToReexport, "-")
 		if len(s) < 2 {
-			logrus.Fatalf("invalid arg")
+			utils.LogFatal(nil, fmt.Sprintf("invalid 'days' flag: %s, expected something of the form 'startDay-endDay'", *daysToReexport), 0)
 		}
 		startDayReexport, err = strconv.ParseInt(s[0], 10, 64)
 		if err != nil {

--- a/exporter/ethstore.go
+++ b/exporter/ethstore.go
@@ -57,6 +57,7 @@ func StartEthStoreExporter(bnAddress string, enAddress string, updateInterval, e
 				return
 			}
 		}
+		return
 	}
 
 	ese.Run()
@@ -203,10 +204,8 @@ func (ese *EthStoreExporter) prepareExportDayTx(tx *sqlx.Tx, day string) error {
 			total_rewards_wei           = excluded.total_rewards_wei,
 			apr                         = excluded.apr`,
 		ethStoreDay.Day)
-	if err != nil {
-		return err
-	}
-	return tx.Commit()
+
+	return err
 }
 
 func (ese *EthStoreExporter) getStoreDay(day string) (*ethstore.Day, map[uint64]*ethstore.Day, error) {


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4ad8da3</samp>

This pull request enhances the `ethstore-exporter` tool to allow reexporting eth.store data for specific days. It adds new flags to the command and updates the `exporter` package to handle the reexport logic. This feature can help users update or fix their eth.store data in the database.
