### PR TITLE
(BIDS-2361) make the ValidatorSync function prettier

### DIFF
--- a/db/bigtable.go
+++ b/db/bigtable.go
@@ -1070,19 +1070,6 @@ func (bigtable *Bigtable) GetValidatorMissedAttestationHistory(validators []uint
 	return res, nil
 }
 
-func (bigtable *Bigtable) GetValidatorSyncDutiesHistoryOrdered(validators []uint64, startEpoch uint64, endEpoch uint64, reverseOrdering bool) (map[uint64][]*types.ValidatorSyncParticipation, error) {
-	res, err := bigtable.GetValidatorSyncDutiesHistory(validators, startEpoch, endEpoch)
-	if err != nil {
-		return nil, err
-	}
-	if reverseOrdering {
-		for _, duties := range res {
-			utils.ReverseSlice(duties)
-		}
-	}
-	return res, nil
-}
-
 func (bigtable *Bigtable) GetValidatorSyncDutiesHistory(validators []uint64, startEpoch uint64, endEpoch uint64) (map[uint64][]*types.ValidatorSyncParticipation, error) {
 	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(time.Minute*5))
 	defer cancel()

--- a/handlers/validator.go
+++ b/handlers/validator.go
@@ -1910,7 +1910,7 @@ func ValidatorSync(w http.ResponseWriter, r *http.Request) {
 		length = uint64(len(pageSlots)) // Last page might be shorter
 		epochs := []uint64{}
 		last := uint64(0)
-		// we gether all epochs for that page (the table currently displays 10 items per page, so it displays max 2 epoches. But we want to be future proof, so we support bigger page sizes)
+		// we gather all epochs for that page (the table currently displays 10 items per page, so it displays max 2 epoches. But we want to be future proof, so we support bigger page sizes)
 		for _, slot := range pageSlots {
 			epoch := slot / utils.Config.Chain.Config.SlotsPerEpoch
 			if len(epochs) == 0 || epoch != last {
@@ -1963,7 +1963,7 @@ func ValidatorSync(w http.ResponseWriter, r *http.Request) {
 							pageSlot.Participation++
 						}
 
-						// Get the status if the dutiy belongs to our validator
+						// Get the status if the duty belongs to our validator
 						if validator == validatorIndex {
 							slotTime := utils.SlotToTime(duty.Slot)
 							if duty.Status == 0 && time.Since(slotTime) <= time.Minute {


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 851a319</samp>

Refactor `ValidatorSync` handler to use maps, contexts, and errgroups for sync committee duties, and remove unused function `GetValidatorSyncDutiesHistoryOrdered` from `db` package.
