### PR TITLE
(BIDS-2400) don't switch tab on new url

### DIFF
--- a/static/js/layout.js
+++ b/static/js/layout.js
@@ -195,7 +195,7 @@ function activateTabbarSwitcher(tabContainerId, tabBar, defaultTab) {
 
   if (window.navigation) {
     window.navigation.addEventListener("navigate", (event) => {
-      if (!event.destination?.url) {
+      if (!event.destination?.url || event.destination.url.split("#")[0] != event.srcElement?.currentEntry?.url?.split("#")[0]) {
         return
       }
       handleTabChange(event.destination?.url)


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7847e8e</samp>

Prevent tabbar switcher from activating on anchor links. Fix a bug in `layout.js` where the wrong tab would be shown when navigating within the same page using hashes.
