### PR TITLE
(BIDS-2403) make it lower to get higher

### DIFF
--- a/handlers/search.go
+++ b/handlers/search.go
@@ -231,7 +231,7 @@ func SearchAhead(w http.ResponseWriter, r *http.Request) {
 		if !utils.IsValidEnsDomain(search) && !utils.IsEth1Address(search) {
 			break
 		}
-		result, err = FindValidatorIndicesByEth1Address(search)
+		result, err = FindValidatorIndicesByEth1Address(strings.ToLower(search))
 	case "count_indexed_validators_by_eth1_address":
 		var ensData *types.EnsDomainResponse
 		if utils.IsValidEnsDomain(search) {


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 45910a9</samp>

Fixed a case-sensitive search bug for eth1 addresses in `handlers/search.go`. Lowercased the search parameter before calling `FindValidatorIndicesByEth1Address`.
