### PR TITLE
(BIDS-2398) Fix eth client subscription error handling

### DIFF
--- a/handlers/user.go
+++ b/handlers/user.go
@@ -2170,20 +2170,20 @@ func UserNotificationsUnsubscribe(w http.ResponseWriter, r *http.Request) {
 }
 
 func isValidSubscriptionFilter(eventName types.EventName, filter string) bool {
+	ethClients := []string{"geth", "nethermind", "besu", "erigon", "teku", "prysm", "nimbus", "lighthouse", "lodestar", "rocketpool", "mev-boost"}
+
 	isPkey := searchPubkeyExactRE.MatchString(filter)
+
+	isClientName := false
+	for _, str := range ethClients {
+		if str == filter {
+			isClientName = true
+			break
+		}
+	}
+
 	isClient := false
-	if eventName == types.EthClientUpdateEventName &&
-		(filter == "geth" ||
-			filter == "nethermind" ||
-			filter == "besu" ||
-			filter == "erigon" ||
-			filter == "teku" ||
-			filter == "prysm" ||
-			filter == "nimbus" ||
-			filter == "lighthouse" ||
-			filter == "lodestar" ||
-			filter == "rocketpool" ||
-			filter == "mev-boost") {
+	if eventName == types.EthClientUpdateEventName && isClientName {
 		isClient = true
 	}
 

--- a/handlers/user.go
+++ b/handlers/user.go
@@ -1846,11 +1846,26 @@ func internUserNotificationsSubscribe(event, filter string, threshold float64, w
 		return false
 	}
 
-	isPkey := searchPubkeyExactRE.MatchString(filter)
 	filterLen := len(filter)
+	isPkey := searchPubkeyExactRE.MatchString(filter)
+	isClient := false
+	if eventName == types.EthClientUpdateEventName &&
+		(filter == "geth" ||
+			filter == "nethermind" ||
+			filter == "besu" ||
+			filter == "erigon" ||
+			filter == "teku" ||
+			filter == "prysm" ||
+			filter == "nimbus" ||
+			filter == "lighthouse" ||
+			filter == "lodestar" ||
+			filter == "rocketpool" ||
+			filter == "mev-boost") {
+		isClient = true
+	}
 
-	if filterLen != 0 && !isPkey {
-		errMsg := fmt.Errorf("error invalid pubkey characters or length")
+	if filterLen != 0 && !isPkey && !isClient {
+		errMsg := fmt.Errorf("error invalid filter, not pubkey or client")
 		errFields := map[string]interface{}{
 			"filter":     filter,
 			"filter_len": len(filter)}
@@ -2025,11 +2040,26 @@ func internUserNotificationsUnsubscribe(event, filter string, w http.ResponseWri
 		return false
 	}
 
-	isPkey := searchPubkeyExactRE.MatchString(filter)
 	filterLen := len(filter)
+	isPkey := searchPubkeyExactRE.MatchString(filter)
+	isClient := false
+	if eventName == types.EthClientUpdateEventName &&
+		(filter == "geth" ||
+			filter == "nethermind" ||
+			filter == "besu" ||
+			filter == "erigon" ||
+			filter == "teku" ||
+			filter == "prysm" ||
+			filter == "nimbus" ||
+			filter == "lighthouse" ||
+			filter == "lodestar" ||
+			filter == "rocketpool" ||
+			filter == "mev-boost") {
+		isClient = true
+	}
 
-	if filterLen != 0 && !isPkey {
-		errMsg := fmt.Errorf("error invalid pubkey characters or length")
+	if filterLen != 0 && !isPkey && !isClient {
+		errMsg := fmt.Errorf("error invalid filter, not pubkey or client")
 		errFields := map[string]interface{}{
 			"filter":     filter,
 			"filter_len": len(filter)}
@@ -2113,11 +2143,26 @@ func UserNotificationsUnsubscribe(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	isPkey := searchPubkeyExactRE.MatchString(filter)
 	filterLen := len(filter)
+	isPkey := searchPubkeyExactRE.MatchString(filter)
+	isClient := false
+	if eventName == types.EthClientUpdateEventName &&
+		(filter == "geth" ||
+			filter == "nethermind" ||
+			filter == "besu" ||
+			filter == "erigon" ||
+			filter == "teku" ||
+			filter == "prysm" ||
+			filter == "nimbus" ||
+			filter == "lighthouse" ||
+			filter == "lodestar" ||
+			filter == "rocketpool" ||
+			filter == "mev-boost") {
+		isClient = true
+	}
 
-	if filterLen != 0 && !isPkey {
-		errMsg := fmt.Errorf("error invalid pubkey characters or length")
+	if filterLen != 0 && !isPkey && !isClient {
+		errMsg := fmt.Errorf("error invalid filter, not pubkey or client")
 		errFields := map[string]interface{}{
 			"filter":     filter,
 			"filter_len": len(filter)}

--- a/handlers/user.go
+++ b/handlers/user.go
@@ -1846,25 +1846,7 @@ func internUserNotificationsSubscribe(event, filter string, threshold float64, w
 		return false
 	}
 
-	filterLen := len(filter)
-	isPkey := searchPubkeyExactRE.MatchString(filter)
-	isClient := false
-	if eventName == types.EthClientUpdateEventName &&
-		(filter == "geth" ||
-			filter == "nethermind" ||
-			filter == "besu" ||
-			filter == "erigon" ||
-			filter == "teku" ||
-			filter == "prysm" ||
-			filter == "nimbus" ||
-			filter == "lighthouse" ||
-			filter == "lodestar" ||
-			filter == "rocketpool" ||
-			filter == "mev-boost") {
-		isClient = true
-	}
-
-	if filterLen != 0 && !isPkey && !isClient {
+	if !isValidSubscriptionFilter(eventName, filter) {
 		errMsg := fmt.Errorf("error invalid filter, not pubkey or client")
 		errFields := map[string]interface{}{
 			"filter":     filter,
@@ -1896,6 +1878,7 @@ func internUserNotificationsSubscribe(event, filter string, threshold float64, w
 		// rocketpool thresholds are free
 	}
 
+	filterLen := len(filter)
 	if filterLen == 0 && !strings.HasPrefix(string(eventName), "monitoring_") && !strings.HasPrefix(string(eventName), "rocketpool_") { // no filter = add all my watched validators
 		myValidators, err2 := db.GetTaggedValidators(filterWatchlist)
 		if err2 != nil {
@@ -2040,25 +2023,7 @@ func internUserNotificationsUnsubscribe(event, filter string, w http.ResponseWri
 		return false
 	}
 
-	filterLen := len(filter)
-	isPkey := searchPubkeyExactRE.MatchString(filter)
-	isClient := false
-	if eventName == types.EthClientUpdateEventName &&
-		(filter == "geth" ||
-			filter == "nethermind" ||
-			filter == "besu" ||
-			filter == "erigon" ||
-			filter == "teku" ||
-			filter == "prysm" ||
-			filter == "nimbus" ||
-			filter == "lighthouse" ||
-			filter == "lodestar" ||
-			filter == "rocketpool" ||
-			filter == "mev-boost") {
-		isClient = true
-	}
-
-	if filterLen != 0 && !isPkey && !isClient {
+	if !isValidSubscriptionFilter(eventName, filter) {
 		errMsg := fmt.Errorf("error invalid filter, not pubkey or client")
 		errFields := map[string]interface{}{
 			"filter":     filter,
@@ -2076,6 +2041,7 @@ func internUserNotificationsUnsubscribe(event, filter string, w http.ResponseWri
 		Network:        utils.GetNetwork(),
 	}
 
+	filterLen := len(filter)
 	if filterLen == 0 && !strings.HasPrefix(string(eventName), "monitoring_") && !strings.HasPrefix(string(eventName), "rocketpool_") { // no filter = add all my watched validators
 
 		myValidators, err2 := db.GetTaggedValidators(filterWatchlist)
@@ -2143,25 +2109,7 @@ func UserNotificationsUnsubscribe(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	filterLen := len(filter)
-	isPkey := searchPubkeyExactRE.MatchString(filter)
-	isClient := false
-	if eventName == types.EthClientUpdateEventName &&
-		(filter == "geth" ||
-			filter == "nethermind" ||
-			filter == "besu" ||
-			filter == "erigon" ||
-			filter == "teku" ||
-			filter == "prysm" ||
-			filter == "nimbus" ||
-			filter == "lighthouse" ||
-			filter == "lodestar" ||
-			filter == "rocketpool" ||
-			filter == "mev-boost") {
-		isClient = true
-	}
-
-	if filterLen != 0 && !isPkey && !isClient {
+	if !isValidSubscriptionFilter(eventName, filter) {
 		errMsg := fmt.Errorf("error invalid filter, not pubkey or client")
 		errFields := map[string]interface{}{
 			"filter":     filter,
@@ -2172,6 +2120,7 @@ func UserNotificationsUnsubscribe(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	filterLen := len(filter)
 	if filterLen == 0 && !types.IsUserIndexed(eventName) { // no filter = add all my watched validators
 
 		filter := db.WatchlistFilter{
@@ -2218,6 +2167,27 @@ func UserNotificationsUnsubscribe(w http.ResponseWriter, r *http.Request) {
 	}
 
 	OKResponse(w, r)
+}
+
+func isValidSubscriptionFilter(eventName types.EventName, filter string) bool {
+	isPkey := searchPubkeyExactRE.MatchString(filter)
+	isClient := false
+	if eventName == types.EthClientUpdateEventName &&
+		(filter == "geth" ||
+			filter == "nethermind" ||
+			filter == "besu" ||
+			filter == "erigon" ||
+			filter == "teku" ||
+			filter == "prysm" ||
+			filter == "nimbus" ||
+			filter == "lighthouse" ||
+			filter == "lodestar" ||
+			filter == "rocketpool" ||
+			filter == "mev-boost") {
+		isClient = true
+	}
+
+	return len(filter) == 0 || isPkey || isClient
 }
 
 func UserNotificationsUnsubscribeByHash(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 57f3830</samp>

Added client-specific notification preferences for users. Users can now choose which Eth2 clients they want to receive updates for in the `EthClientUpdateEventName` event.
