### PR TITLE
(NOBIDS) Handle case where there are no att on a good block

### DIFF
--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -267,7 +267,7 @@ func Start(client rpc.Client) error {
 			logrus.Errorf("error exporting sync committee duties to bigtable for block %v: %v", block.Slot, err)
 		}
 
-		err = db.SaveBlock(block)
+		err = db.SaveBlock(block, false)
 		if err != nil {
 			logger.Errorf("error saving block: %v", err)
 		}


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8a96e79</samp>

This pull request adds a feature to update the block status and attestations in the database when the node has more or different data than the database. It modifies the `SaveBlock` and `saveBlocks` functions in `db/db.go` to accept a `forceSlotUpdate` parameter, and uses it in the `updateAggregationBits` function in `cmd/misc/main.go`. It also preserves the original behavior of the `exporter` package.
