### PR TITLE
(BIDS-2408) Remove query limit for attestation history

### DIFF
--- a/db/bigtable.go
+++ b/db/bigtable.go
@@ -875,20 +875,17 @@ func (bigtable *Bigtable) GetValidatorAttestationHistory(validators []uint64, st
 	filter := gcp_bigtable.ChainFilters(
 		gcp_bigtable.FamilyFilter(ATTESTATIONS_FAMILY),
 		gcp_bigtable.InterleaveFilters(columnFilters...),
-		gcp_bigtable.LatestNFilter(1),
 	)
 
 	if len(columnFilters) == 1 { // special case to retrieve data for one validators
 		filter = gcp_bigtable.ChainFilters(
 			gcp_bigtable.FamilyFilter(ATTESTATIONS_FAMILY),
 			columnFilters[0],
-			gcp_bigtable.LatestNFilter(1),
 		)
 	}
 	if len(columnFilters) == 0 { // special case to retrieve data for all validators
 		filter = gcp_bigtable.ChainFilters(
 			gcp_bigtable.FamilyFilter(ATTESTATIONS_FAMILY),
-			gcp_bigtable.LatestNFilter(1),
 		)
 	}
 	err = bigtable.tableBeaconchain.ReadRows(ctx, ranges, func(r gcp_bigtable.Row) bool {
@@ -910,6 +907,8 @@ func (bigtable *Bigtable) GetValidatorAttestationHistory(validators []uint64, st
 			} else if orphanedSlotsMap[inclusionSlot] {
 				status = 0
 			}
+
+			logger.Infof("Row: %v, Col: %v, inclusionSlot: %v, ts: %v", ri.Row, ri.Column, inclusionSlot, ri.Timestamp)
 
 			validator, err := strconv.ParseUint(strings.TrimPrefix(ri.Column, ATTESTATIONS_FAMILY+":"), 10, 64)
 			if err != nil {
@@ -1038,20 +1037,17 @@ func (bigtable *Bigtable) GetValidatorMissedAttestationHistory(validators []uint
 	filter := gcp_bigtable.ChainFilters(
 		gcp_bigtable.FamilyFilter(ATTESTATIONS_FAMILY),
 		gcp_bigtable.InterleaveFilters(columnFilters...),
-		gcp_bigtable.LatestNFilter(1),
 	)
 
 	if len(columnFilters) == 1 { // special case to retrieve data for one validators
 		filter = gcp_bigtable.ChainFilters(
 			gcp_bigtable.FamilyFilter(ATTESTATIONS_FAMILY),
 			columnFilters[0],
-			gcp_bigtable.LatestNFilter(1),
 		)
 	}
 	if len(columnFilters) == 0 { // special case to retrieve data for all validators
 		filter = gcp_bigtable.ChainFilters(
 			gcp_bigtable.FamilyFilter(ATTESTATIONS_FAMILY),
-			gcp_bigtable.LatestNFilter(1),
 		)
 	}
 

--- a/db/bigtable.go
+++ b/db/bigtable.go
@@ -908,8 +908,6 @@ func (bigtable *Bigtable) GetValidatorAttestationHistory(validators []uint64, st
 				status = 0
 			}
 
-			logger.Infof("Row: %v, Col: %v, inclusionSlot: %v, ts: %v", ri.Row, ri.Column, inclusionSlot, ri.Timestamp)
-
 			validator, err := strconv.ParseUint(strings.TrimPrefix(ri.Column, ATTESTATIONS_FAMILY+":"), 10, 64)
 			if err != nil {
 				logger.Errorf("error parsing validator from column key %v: %v", ri.Column, err)


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at de2f8b8</samp>

Fix bugs in `bigtable.go` queries for attestation history. Remove unnecessary filters and add logging for debugging.
