### PR TITLE
Update stakingServices.html, Rocketpool min stake is 8 ETH

### DIFF
--- a/templates/stakingServices.html
+++ b/templates/stakingServices.html
@@ -583,7 +583,7 @@
                     <td data-column="Withdrawal key owner">Smart Contract</td>
                     <td data-column="Pool token">Yes</td>
                     <td data-column="3rd Party Software">No</td>
-                    <td data-column="Min. Stake">16 ETH</td>
+                    <td data-column="Min. Stake">8 ETH</td>
                     <td data-column="Fee">Free</td>
                     <td data-column="Open Source">Yes</td>
                     <td data-column="Social">


### PR DESCRIPTION
Update Rocketpool's min stake from 16 ETH to 8 ETH

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9b080f6</samp>

Updated the minimum stake for Rocket Pool on the staking services page. This change `templates/stakingServices.html` to show the correct information for users who want to compare different options for staking on eth2.
