### PR TITLE
(BIDS-2325) input length dependent search delay

### DIFF
--- a/static/js/dashboard.js
+++ b/static/js/dashboard.js
@@ -692,6 +692,24 @@ $(document).ready(function () {
   }
   create_validators_typeahead("input[aria-controls='validators']", "#validators")
 
+  var timeWait = 0
+  var debounce = function (context, func) {
+    var timeout, result
+
+    return function () {
+      var args = arguments,
+        later = function () {
+          timeout = null
+          result = func.apply(context, args)
+        }
+      clearTimeout(timeout)
+      timeout = setTimeout(later, timeWait)
+      if (!timeout) {
+        result = func.apply(context, args)
+      }
+      return result
+    }
+  }
   var bhValidators = new Bloodhound({
     datumTokenizer: Bloodhound.tokenizers.whitespace,
     queryTokenizer: Bloodhound.tokenizers.whitespace,
@@ -700,9 +718,19 @@ $(document).ready(function () {
     },
     remote: {
       url: "/search/indexed_validators/%QUERY",
-      wildcard: "%QUERY",
+      // use prepare hook to modify the rateLimitWait parameter on input changes
+      // NOTE: we only need to do this for the first function because testing showed that queries are executed/queued in order
+      // No need to update `timeWait` multiple times.
+      prepare: function (_, settings) {
+        var cur_query = $(".typeahead-dashboard").val()
+        timeWait = 4000 - Math.min(cur_query.length, 5) * 500
+        // "wildcard" can't be used anymore, need to set query wildcard ourselves now
+        settings.url = settings.url.replace("%QUERY", encodeURIComponent(cur_query))
+        return settings
+      },
     },
   })
+  bhValidators.remote.transport._get = debounce(bhValidators.remote.transport, bhValidators.remote.transport._get)
   var bhPubkey = new Bloodhound({
     datumTokenizer: Bloodhound.tokenizers.whitespace,
     queryTokenizer: Bloodhound.tokenizers.whitespace,
@@ -714,6 +742,7 @@ $(document).ready(function () {
       wildcard: "%QUERY",
     },
   })
+  bhPubkey.remote.transport._get = debounce(bhPubkey.remote.transport, bhPubkey.remote.transport._get)
   var bhEth1Addresses = new Bloodhound({
     datumTokenizer: Bloodhound.tokenizers.whitespace,
     queryTokenizer: Bloodhound.tokenizers.whitespace,
@@ -725,6 +754,7 @@ $(document).ready(function () {
       wildcard: "%QUERY",
     },
   })
+  bhEth1Addresses.remote.transport._get = debounce(bhEth1Addresses.remote.transport, bhEth1Addresses.remote.transport._get)
   var bhName = new Bloodhound({
     datumTokenizer: Bloodhound.tokenizers.whitespace,
     queryTokenizer: Bloodhound.tokenizers.whitespace,
@@ -736,6 +766,7 @@ $(document).ready(function () {
       wildcard: "%QUERY",
     },
   })
+  bhName.remote.transport._get = debounce(bhName.remote.transport, bhName.remote.transport._get)
   var bhGraffiti = new Bloodhound({
     datumTokenizer: Bloodhound.tokenizers.whitespace,
     queryTokenizer: Bloodhound.tokenizers.whitespace,
@@ -747,6 +778,7 @@ $(document).ready(function () {
       wildcard: "%QUERY",
     },
   })
+  bhGraffiti.remote.transport._get = debounce(bhGraffiti.remote.transport, bhGraffiti.remote.transport._get)
 
   $(".typeahead-dashboard").typeahead(
     {

--- a/static/js/layout.js
+++ b/static/js/layout.js
@@ -224,6 +224,29 @@ $(document).ready(function () {
   // set maxParallelRequests to number of datasets queried in each search
   // make sure this is set in every one bloodhound object
   let requestNum = 9
+  var timeWait = 0
+
+  // used to overwrite Bloodhounds "transport._get" function which handles the rateLimitWait parameter
+  // since we can't access the closure variable anymore (?)
+  // copied and adapted from typeahead.js source code (https://github.com/twitter/typeahead.js/blob/master/dist/typeahead.bundle.js#L106)
+  // -> so we have control via `timeWait` now
+  var debounce = function (context, func) {
+    var timeout, result
+
+    return function () {
+      var args = arguments,
+        later = function () {
+          timeout = null
+          result = func.apply(context, args)
+        }
+      clearTimeout(timeout)
+      timeout = setTimeout(later, timeWait)
+      if (!timeout) {
+        result = func.apply(context, args)
+      }
+      return result
+    }
+  }
 
   var bhValidators = new Bloodhound({
     datumTokenizer: Bloodhound.tokenizers.whitespace,
@@ -233,10 +256,20 @@ $(document).ready(function () {
     },
     remote: {
       url: "/search/validators/%QUERY",
-      wildcard: "%QUERY",
+      // use prepare hook to modify the rateLimitWait parameter on input changes
+      // NOTE: we only need to do this for the first function because testing showed that queries are executed/queued in order
+      // No need to update `timeWait` multiple times.
+      prepare: function (_, settings) {
+        var cur_query = $("input.typeahead.tt-input").val()
+        timeWait = 4000 - Math.min(cur_query.length, 5) * 500
+        // "wildcard" can't be used anymore, need to set query wildcard ourselves now
+        settings.url = settings.url.replace("%QUERY", encodeURIComponent(cur_query))
+        return settings
+      },
       maxPendingRequests: requestNum,
     },
   })
+  bhValidators.remote.transport._get = debounce(bhValidators.remote.transport, bhValidators.remote.transport._get)
 
   var bhEns = new Bloodhound({
     datumTokenizer: Bloodhound.tokenizers.whitespace,
@@ -253,6 +286,7 @@ $(document).ready(function () {
       },
     },
   })
+  bhEns.remote.transport._get = debounce(bhEns.remote.transport, bhEns.remote.transport._get)
 
   var bhSlots = new Bloodhound({
     datumTokenizer: Bloodhound.tokenizers.whitespace,
@@ -266,6 +300,7 @@ $(document).ready(function () {
       maxPendingRequests: requestNum,
     },
   })
+  bhSlots.remote.transport._get = debounce(bhSlots.remote.transport, bhSlots.remote.transport._get)
 
   var bhBlocks = new Bloodhound({
     datumTokenizer: Bloodhound.tokenizers.whitespace,
@@ -279,6 +314,7 @@ $(document).ready(function () {
       maxPendingRequests: requestNum,
     },
   })
+  bhBlocks.remote.transport._get = debounce(bhBlocks.remote.transport, bhBlocks.remote.transport._get)
 
   var bhTransactions = new Bloodhound({
     datumTokenizer: Bloodhound.tokenizers.whitespace,
@@ -292,6 +328,7 @@ $(document).ready(function () {
       maxPendingRequests: requestNum,
     },
   })
+  bhTransactions.remote.transport._get = debounce(bhTransactions.remote.transport, bhTransactions.remote.transport._get)
 
   var bhGraffiti = new Bloodhound({
     datumTokenizer: Bloodhound.tokenizers.whitespace,
@@ -305,6 +342,7 @@ $(document).ready(function () {
       maxPendingRequests: requestNum,
     },
   })
+  bhGraffiti.remote.transport._get = debounce(bhGraffiti.remote.transport, bhGraffiti.remote.transport._get)
 
   var bhEpochs = new Bloodhound({
     datumTokenizer: Bloodhound.tokenizers.whitespace,
@@ -318,6 +356,7 @@ $(document).ready(function () {
       maxPendingRequests: requestNum,
     },
   })
+  bhEpochs.remote.transport._get = debounce(bhEpochs.remote.transport, bhEpochs.remote.transport._get)
 
   var bhEth1Accounts = new Bloodhound({
     datumTokenizer: Bloodhound.tokenizers.whitespace,
@@ -331,6 +370,7 @@ $(document).ready(function () {
       maxPendingRequests: requestNum,
     },
   })
+  bhEth1Accounts.remote.transport._get = debounce(bhEth1Accounts.remote.transport, bhEth1Accounts.remote.transport._get)
 
   var bhValidatorsByAddress = new Bloodhound({
     datumTokenizer: Bloodhound.tokenizers.whitespace,
@@ -344,6 +384,7 @@ $(document).ready(function () {
       maxPendingRequests: requestNum,
     },
   })
+  bhValidatorsByAddress.remote.transport._get = debounce(bhValidatorsByAddress.remote.transport, bhValidatorsByAddress.remote.transport._get)
 
   // before adding datasets make sure requestNum is set to the correct value
   $(".typeahead").typeahead(

--- a/static/js/validatorRewards.js
+++ b/static/js/validatorRewards.js
@@ -7,6 +7,25 @@ var subsTable = null
 // let validators = []
 
 function create_typeahead(input_container) {
+  var timeWait = 0
+  var debounce = function (context, func) {
+    var timeout, result
+
+    return function () {
+      var args = arguments,
+        later = function () {
+          timeout = null
+          result = func.apply(context, args)
+        }
+      clearTimeout(timeout)
+      timeout = setTimeout(later, timeWait)
+      if (!timeout) {
+        result = func.apply(context, args)
+      }
+      return result
+    }
+  }
+
   var bhValidators = new Bloodhound({
     datumTokenizer: Bloodhound.tokenizers.whitespace,
     queryTokenizer: Bloodhound.tokenizers.whitespace,
@@ -15,9 +34,19 @@ function create_typeahead(input_container) {
     },
     remote: {
       url: "/search/indexed_validators/%QUERY",
-      wildcard: "%QUERY",
+      // use prepare hook to modify the rateLimitWait parameter on input changes
+      // NOTE: we only need to do this for the first function because testing showed that queries are executed/queued in order
+      // No need to update `timeWait` multiple times.
+      prepare: function (_, settings) {
+        var cur_query = $(input_container).val()
+        timeWait = 4000 - Math.min(cur_query.length, 5) * 500
+        // "wildcard" can't be used anymore, need to set query wildcard ourselves now
+        settings.url = settings.url.replace("%QUERY", encodeURIComponent(cur_query))
+        return settings
+      },
     },
   })
+  bhValidators.remote.transport._get = debounce(bhValidators.remote.transport, bhValidators.remote.transport._get)
   var bhEth1Addresses = new Bloodhound({
     datumTokenizer: Bloodhound.tokenizers.whitespace,
     queryTokenizer: Bloodhound.tokenizers.whitespace,
@@ -29,6 +58,7 @@ function create_typeahead(input_container) {
       wildcard: "%QUERY",
     },
   })
+  bhEth1Addresses.remote.transport._get = debounce(bhEth1Addresses.remote.transport, bhEth1Addresses.remote.transport._get)
   var bhName = new Bloodhound({
     datumTokenizer: Bloodhound.tokenizers.whitespace,
     queryTokenizer: Bloodhound.tokenizers.whitespace,
@@ -40,6 +70,7 @@ function create_typeahead(input_container) {
       wildcard: "%QUERY",
     },
   })
+  bhName.remote.transport._get = debounce(bhName.remote.transport, bhName.remote.transport._get)
   var bhGraffiti = new Bloodhound({
     datumTokenizer: Bloodhound.tokenizers.whitespace,
     queryTokenizer: Bloodhound.tokenizers.whitespace,
@@ -51,6 +82,7 @@ function create_typeahead(input_container) {
       wildcard: "%QUERY",
     },
   })
+  bhGraffiti.remote.transport._get = debounce(bhGraffiti.remote.transport, bhGraffiti.remote.transport._get)
 
   $(input_container).typeahead(
     {


### PR DESCRIPTION
Added an input length dependent time delay until searches get executed. Only applied to 4 main search bars which execute parallel requests.

1 character start search after 3.5s
2 characters start search after 3s
...
5 or more characters start search after 1.5s 

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 23152e4</samp>

This pull request improves the search features in various pages of the eth2-beaconchain-explorer by adding a `debounce` function that limits and delays the number of requests sent to the server. The `debounce` function is applied to the `transport._get` functions of several Bloodhound instances that provide search suggestions. The goal is to enhance the performance and user experience of the search features by reducing the request frequency and the response time. The files affected are `static/js/dashboard.js`, `static/js/layout.js`, `static/js/notificationsCenter.js`, and `static/js/validatorRewards.js`.
