### PR TITLE
(NOBIDS) limit resultset of validators and withdrawals to 10000 for p…

### DIFF
--- a/handlers/validators.go
+++ b/handlers/validators.go
@@ -192,6 +192,10 @@ func parseValidatorsDataQueryParams(r *http.Request) (*ValidatorsDataQueryParams
 		logger.Errorf("error converting datatables start parameter from string to int: %v", err)
 		return nil, err
 	}
+	if start > 10000 {
+		// limit offset to 10000, otherwise the query will be too slow
+		start = 10000
+	}
 
 	length, err := strconv.ParseInt(q.Get("length"), 10, 64)
 	if err != nil {
@@ -362,6 +366,13 @@ func ValidatorsData(w http.ResponseWriter, r *http.Request) {
 		}
 	} else {
 		countFiltered = countTotal
+	}
+
+	if countTotal > 10000 {
+		countTotal = 10000
+	}
+	if countFiltered > 10000 {
+		countFiltered = 10000
 	}
 
 	data := &types.DataTableResponse{

--- a/handlers/withdrawals.go
+++ b/handlers/withdrawals.go
@@ -70,6 +70,9 @@ func WithdrawalsData(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Internal server error", http.StatusServiceUnavailable)
 		return
 	}
+	if start > 10000 {
+		start = 10000
+	}
 	length, err := strconv.ParseUint(q.Get("length"), 10, 64)
 	if err != nil {
 		logger.Errorf("error converting datatables length parameter from string to int: %v", err)
@@ -194,6 +197,13 @@ func WithdrawalsTableData(draw uint64, search string, length, start uint64, orde
 		}
 	}
 
+	if filteredCount > 10000 {
+		filteredCount = 10000
+	}
+	if withdrawalCount > 10000 {
+		withdrawalCount = 10000
+	}
+
 	data := &types.DataTableResponse{
 		Draw:            draw,
 		RecordsTotal:    withdrawalCount,
@@ -223,6 +233,10 @@ func BLSChangeData(w http.ResponseWriter, r *http.Request) {
 		logger.Errorf("error converting datatables start parameter from string to int: %v", err)
 		http.Error(w, "Internal server error", http.StatusServiceUnavailable)
 		return
+	}
+	if start > 10000 {
+		// limit offset to 10000, otherwise the query will be too slow
+		start = 10000
 	}
 	length, err := strconv.ParseUint(q.Get("length"), 10, 64)
 	if err != nil {
@@ -336,6 +350,13 @@ func BLSTableData(draw uint64, search string, length, start uint64, orderBy, ord
 			template.HTML(fmt.Sprintf("%v", utils.FormatHashWithCopy(bls.BlsPubkey))),
 			template.HTML(fmt.Sprintf("%v", utils.FormatAddress(bls.Address, nil, "", false, false, true))),
 		}
+	}
+
+	if totalCount > 10000 {
+		totalCount = 10000
+	}
+	if filteredCount > 10000 {
+		filteredCount = 10000
 	}
 
 	data := &types.DataTableResponse{

--- a/templates/validators.html
+++ b/templates/validators.html
@@ -331,6 +331,7 @@
           </nav>
         </div>
       </div>
+      <h6 class="my-2">This table only shows the first 10000 validators of the resultset for the given sorting and filters.</h6>
       <div class="card">
         <div class="card-body px-0 py-2">
           <div class="table-responsive pt-2">

--- a/templates/withdrawals.html
+++ b/templates/withdrawals.html
@@ -213,7 +213,7 @@
       {{ template "withdrawalChart" . }}
     </div>
     <div class="my-3">
-      <h6 class="my-2">This table displays partial and full withdrawals.</h6>
+      <h6 class="my-2">This table displays partial and full withdrawals. Only the first 10000 entries of the resultset are shown.</h6>
       <div class="card">
         <div class="card-body px-0 py-2">
           <div class="table-responsive pt-2">
@@ -239,7 +239,7 @@
       <span class="nav-text">Address Changes (BLS)</span>
     </h2>
     <div class="my-3">
-      <h6 class="my-2">This table displays the BLS address changes from <span class="monospace">0x00</span> credentials to <span class="monospace">0x01</span>.</h6>
+      <h6 class="my-2">This table displays the BLS address changes from <span class="monospace">0x00</span> credentials to <span class="monospace">0x01</span>. Only the first 10000 entries of the resultset are shown.</h6>
       <div class="card">
         <div class="card-body px-0 py-2">
           <div class="table-responsive pt-2">


### PR DESCRIPTION
…erformance-reasons

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b21c458</samp>

This pull request improves the performance and reliability of the data queries and displays for validators, withdrawals, and BLS changes. It adds limits to the query parameters and disclaimers to the frontend tables, to prevent slow and inconsistent database operations and user experience. It affects the files `handlers/validators.go`, `handlers/withdrawals.go`, `templates/withdrawals.html`, and `templates/validators.html`.
