### PR TITLE
(NOBIDS) fix db.GetLatestFinalizedEpoch, return erro if table is empty

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -516,7 +516,7 @@ func GetAllEpochs() ([]uint64, error) {
 func GetLatestFinalizedEpoch() (uint64, error) {
 	var latestFinalized uint64
 	err := WriterDb.Get(&latestFinalized, "SELECT finalized_epoch FROM chain_head")
-	if err != nil && err != sql.ErrNoRows {
+	if err != nil {
 		utils.LogError(err, "error retrieving latest exported finalized epoch from the database: %v", 0)
 	}
 

--- a/db/db.go
+++ b/db/db.go
@@ -518,6 +518,7 @@ func GetLatestFinalizedEpoch() (uint64, error) {
 	err := WriterDb.Get(&latestFinalized, "SELECT finalized_epoch FROM chain_head")
 	if err != nil {
 		utils.LogError(err, "error retrieving latest exported finalized epoch from the database: %v", 0)
+		return 0, err
 	}
 
 	return latestFinalized, nil

--- a/db/db.go
+++ b/db/db.go
@@ -517,7 +517,7 @@ func GetLatestFinalizedEpoch() (uint64, error) {
 	var latestFinalized uint64
 	err := WriterDb.Get(&latestFinalized, "SELECT finalized_epoch FROM chain_head")
 	if err != nil {
-		utils.LogError(err, "error retrieving latest exported finalized epoch from the database: %v", 0)
+		utils.LogError(err, "error retrieving latest exported finalized epoch from the database", 0)
 		return 0, err
 	}
 


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 00044d4</samp>

Simplify error handling in `db/db.go` by removing redundant check for `sql.ErrNoRows` in `GetLatestFinalizedEpoch` function.
