### PR TITLE
(BIDS-2424) stop search if ens name is valid but not registered

### DIFF
--- a/handlers/search.go
+++ b/handlers/search.go
@@ -235,12 +235,8 @@ func SearchAhead(w http.ResponseWriter, r *http.Request) {
 			LEFT JOIN validators ON validators.pubkey = eth1_deposits.publickey
 			WHERE validators.pubkey IS NULL AND ENCODE(eth1_deposits.publickey, 'hex') LIKE ($1 || '%')`, lowerStrippedSearch)
 	case "indexed_validators_by_eth1_addresses":
-		if !utils.IsValidEnsDomain(search) && !utils.IsEth1Address(search) {
-			break
-		}
 		search = ReplaceEnsNameWithAddress(search)
-		if utils.IsValidEnsDomain(search) {
-			// unregistered ENS name
+		if !utils.IsEth1Address(search) {
 			break
 		}
 		result, err = FindValidatorIndicesByEth1Address(strings.ToLower(search))

--- a/handlers/search.go
+++ b/handlers/search.go
@@ -238,6 +238,11 @@ func SearchAhead(w http.ResponseWriter, r *http.Request) {
 		if !utils.IsValidEnsDomain(search) && !utils.IsEth1Address(search) {
 			break
 		}
+		search = ReplaceEnsNameWithAddress(search)
+		if utils.IsValidEnsDomain(search) {
+			// unregistered ENS name
+			break
+		}
 		result, err = FindValidatorIndicesByEth1Address(strings.ToLower(search))
 	case "count_indexed_validators_by_eth1_address":
 		var ensData *types.EnsDomainResponse


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b25ee16</samp>

Improve search ahead functionality for ENS names. Handle unregistered ENS names in `handlers/search.go` by returning them as search queries.
