### PR TITLE
(BIDS-2440) improve performance of withrdawals-page

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -2297,16 +2297,7 @@ func GetWithdrawalsCountForQuery(query string) (uint64, error) {
 	var err error = nil
 
 	trimmedQuery := strings.ToLower(strings.TrimPrefix(query, "0x"))
-	// Check whether the query can be used for a validator, slot or epoch search
-	if uiQuery, parseErr := strconv.ParseUint(query, 10, 64); parseErr == nil {
-		searchQuery := `
-			WHERE w.validatorindex = $1
-				OR block_slot = $1
-				OR block_slot BETWEEN $1*$2 AND ($1+1)*$2-1`
-		err = ReaderDb.Get(&count, fmt.Sprintf(withdrawalsQuery, searchQuery),
-			uiQuery, utils.Config.Chain.Config.SlotsPerEpoch)
-
-	} else if addressRE.MatchString(query) {
+	if addressRE.MatchString(query) {
 		searchQuery := `WHERE address = $1`
 		addr, decErr := hex.DecodeString(trimmedQuery)
 		if err != nil {
@@ -2314,6 +2305,14 @@ func GetWithdrawalsCountForQuery(query string) (uint64, error) {
 		}
 		err = ReaderDb.Get(&count, fmt.Sprintf(withdrawalsQuery, searchQuery),
 			addr)
+	} else if uiQuery, parseErr := strconv.ParseUint(query, 10, 64); parseErr == nil {
+		// Check whether the query can be used for a validator, slot or epoch search
+		searchQuery := `
+			WHERE w.validatorindex = $1
+				OR block_slot = $1
+				OR block_slot BETWEEN $1*$2 AND ($1+1)*$2-1`
+		err = ReaderDb.Get(&count, fmt.Sprintf(withdrawalsQuery, searchQuery),
+			uiQuery, utils.Config.Chain.Config.SlotsPerEpoch)
 	}
 
 	if err != nil {
@@ -2363,15 +2362,7 @@ func GetWithdrawals(query string, length, start uint64, orderBy, orderDir string
 
 	trimmedQuery := strings.ToLower(strings.TrimPrefix(query, "0x"))
 	if trimmedQuery != "" {
-		// Check whether the query can be used for a validator, slot or epoch search
-		if uiQuery, parseErr := strconv.ParseUint(query, 10, 64); parseErr == nil {
-			searchQuery := `
-				WHERE w.validatorindex = $3
-					OR w.block_slot = $3
-					OR w.block_slot BETWEEN $3*$4 AND ($3+1)*$4-1`
-			err = ReaderDb.Select(&withdrawals, fmt.Sprintf(withdrawalsQuery, searchQuery, orderBy, orderDir),
-				length, start, uiQuery, utils.Config.Chain.Config.SlotsPerEpoch)
-		} else if addressRE.MatchString(query) {
+		if addressRE.MatchString(query) {
 			searchQuery := `WHERE address = $3`
 			addr, decErr := hex.DecodeString(trimmedQuery)
 			if decErr != nil {
@@ -2379,6 +2370,14 @@ func GetWithdrawals(query string, length, start uint64, orderBy, orderDir string
 			}
 			err = ReaderDb.Select(&withdrawals, fmt.Sprintf(withdrawalsQuery, searchQuery, orderBy, orderDir),
 				length, start, addr)
+		} else if uiQuery, parseErr := strconv.ParseUint(query, 10, 64); parseErr == nil {
+			// Check whether the query can be used for a validator, slot or epoch search
+			searchQuery := `
+				WHERE w.validatorindex = $3
+					OR w.block_slot = $3
+					OR w.block_slot BETWEEN $3*$4 AND ($3+1)*$4-1`
+			err = ReaderDb.Select(&withdrawals, fmt.Sprintf(withdrawalsQuery, searchQuery, orderBy, orderDir),
+				length, start, uiQuery, utils.Config.Chain.Config.SlotsPerEpoch)
 		}
 	} else {
 		err = ReaderDb.Select(&withdrawals, fmt.Sprintf(withdrawalsQuery, "", orderBy, orderDir), length, start)
@@ -2958,15 +2957,7 @@ func GetBLSChangesCountForQuery(query string) (uint64, error) {
 	trimmedQuery := strings.ToLower(strings.TrimPrefix(query, "0x"))
 	var err error = nil
 
-	// Check whether the query can be used for a validator, slot or epoch search
-	if uiQuery, parseErr := strconv.ParseUint(query, 10, 64); parseErr == nil {
-		searchQuery := `
-			WHERE bls.validatorindex = $1			
-				OR block_slot = $1
-				OR block_slot BETWEEN $1*$2 AND ($1+1)*$2-1`
-		err = ReaderDb.Get(&count, fmt.Sprintf(blsQuery, searchQuery),
-			uiQuery, utils.Config.Chain.Config.SlotsPerEpoch)
-	} else if blsRE.MatchString(query) {
+	if blsRE.MatchString(query) {
 		searchQuery := `WHERE pubkey = $1`
 		pubkey, decErr := hex.DecodeString(trimmedQuery)
 		if decErr != nil {
@@ -2974,6 +2965,14 @@ func GetBLSChangesCountForQuery(query string) (uint64, error) {
 		}
 		err = ReaderDb.Select(&count, fmt.Sprintf(blsQuery, searchQuery),
 			pubkey)
+	} else if uiQuery, parseErr := strconv.ParseUint(query, 10, 64); parseErr == nil {
+		// Check whether the query can be used for a validator, slot or epoch search
+		searchQuery := `
+			WHERE bls.validatorindex = $1			
+				OR block_slot = $1
+				OR block_slot BETWEEN $1*$2 AND ($1+1)*$2-1`
+		err = ReaderDb.Get(&count, fmt.Sprintf(blsQuery, searchQuery),
+			uiQuery, utils.Config.Chain.Config.SlotsPerEpoch)
 	}
 	if err != nil {
 		return 0, err
@@ -3018,15 +3017,7 @@ func GetBLSChanges(query string, length, start uint64, orderBy, orderDir string)
 	var err error = nil
 
 	if trimmedQuery != "" {
-		// Check whether the query can be used for a validator, slot or epoch search
-		if uiQuery, parseErr := strconv.ParseUint(query, 10, 64); parseErr == nil {
-			searchQuery := `
-				WHERE bls.validatorindex = $3			
-					OR block_slot = $3
-					OR block_slot BETWEEN $3*$4 AND ($3+1)*$4-1`
-			err = ReaderDb.Select(&blsChange, fmt.Sprintf(blsQuery, searchQuery, orderBy, orderDir),
-				length, start, uiQuery, utils.Config.Chain.Config.SlotsPerEpoch)
-		} else if blsRE.MatchString(query) {
+		if blsRE.MatchString(query) {
 			searchQuery := `WHERE pubkey = $3`
 			pubkey, decErr := hex.DecodeString(trimmedQuery)
 			if decErr != nil {
@@ -3034,6 +3025,14 @@ func GetBLSChanges(query string, length, start uint64, orderBy, orderDir string)
 			}
 			err = ReaderDb.Select(&blsChange, fmt.Sprintf(blsQuery, searchQuery, orderBy, orderDir),
 				length, start, pubkey)
+		} else if uiQuery, parseErr := strconv.ParseUint(query, 10, 64); parseErr == nil {
+			// Check whether the query can be used for a validator, slot or epoch search
+			searchQuery := `
+				WHERE bls.validatorindex = $3			
+					OR block_slot = $3
+					OR block_slot BETWEEN $3*$4 AND ($3+1)*$4-1`
+			err = ReaderDb.Select(&blsChange, fmt.Sprintf(blsQuery, searchQuery, orderBy, orderDir),
+				length, start, uiQuery, utils.Config.Chain.Config.SlotsPerEpoch)
 		}
 		if err != nil {
 			return nil, err

--- a/db/db.go
+++ b/db/db.go
@@ -2298,7 +2298,7 @@ func GetWithdrawalsCountForQuery(query string) (uint64, error) {
 
 	trimmedQuery := strings.ToLower(strings.TrimPrefix(query, "0x"))
 	if addressRE.MatchString(query) {
-		searchQuery := `WHERE address = $1`
+		searchQuery := `WHERE w.address = $1`
 		addr, decErr := hex.DecodeString(trimmedQuery)
 		if err != nil {
 			return 0, decErr
@@ -2309,8 +2309,8 @@ func GetWithdrawalsCountForQuery(query string) (uint64, error) {
 		// Check whether the query can be used for a validator, slot or epoch search
 		searchQuery := `
 			WHERE w.validatorindex = $1
-				OR block_slot = $1
-				OR block_slot BETWEEN $1*$2 AND ($1+1)*$2-1`
+				OR w.block_slot = $1
+				OR w.block_slot BETWEEN $1*$2 AND ($1+1)*$2-1`
 		err = ReaderDb.Get(&count, fmt.Sprintf(withdrawalsQuery, searchQuery),
 			uiQuery, utils.Config.Chain.Config.SlotsPerEpoch)
 	}
@@ -2363,7 +2363,7 @@ func GetWithdrawals(query string, length, start uint64, orderBy, orderDir string
 	trimmedQuery := strings.ToLower(strings.TrimPrefix(query, "0x"))
 	if trimmedQuery != "" {
 		if addressRE.MatchString(query) {
-			searchQuery := `WHERE address = $3`
+			searchQuery := `WHERE w.address = $3`
 			addr, decErr := hex.DecodeString(trimmedQuery)
 			if decErr != nil {
 				return nil, decErr
@@ -2958,7 +2958,7 @@ func GetBLSChangesCountForQuery(query string) (uint64, error) {
 	var err error = nil
 
 	if blsRE.MatchString(query) {
-		searchQuery := `WHERE pubkey = $1`
+		searchQuery := `WHERE bls.pubkey = $1`
 		pubkey, decErr := hex.DecodeString(trimmedQuery)
 		if decErr != nil {
 			return 0, decErr
@@ -2969,8 +2969,8 @@ func GetBLSChangesCountForQuery(query string) (uint64, error) {
 		// Check whether the query can be used for a validator, slot or epoch search
 		searchQuery := `
 			WHERE bls.validatorindex = $1			
-				OR block_slot = $1
-				OR block_slot BETWEEN $1*$2 AND ($1+1)*$2-1`
+				OR bls.block_slot = $1
+				OR bls.block_slot BETWEEN $1*$2 AND ($1+1)*$2-1`
 		err = ReaderDb.Get(&count, fmt.Sprintf(blsQuery, searchQuery),
 			uiQuery, utils.Config.Chain.Config.SlotsPerEpoch)
 	}
@@ -3018,7 +3018,7 @@ func GetBLSChanges(query string, length, start uint64, orderBy, orderDir string)
 
 	if trimmedQuery != "" {
 		if blsRE.MatchString(query) {
-			searchQuery := `WHERE pubkey = $3`
+			searchQuery := `WHERE bls.pubkey = $3`
 			pubkey, decErr := hex.DecodeString(trimmedQuery)
 			if decErr != nil {
 				return nil, decErr
@@ -3029,8 +3029,8 @@ func GetBLSChanges(query string, length, start uint64, orderBy, orderDir string)
 			// Check whether the query can be used for a validator, slot or epoch search
 			searchQuery := `
 				WHERE bls.validatorindex = $3			
-					OR block_slot = $3
-					OR block_slot BETWEEN $3*$4 AND ($3+1)*$4-1`
+					OR bls.block_slot = $3
+					OR bls.block_slot BETWEEN $3*$4 AND ($3+1)*$4-1`
 			err = ReaderDb.Select(&blsChange, fmt.Sprintf(blsQuery, searchQuery, orderBy, orderDir),
 				length, start, uiQuery, utils.Config.Chain.Config.SlotsPerEpoch)
 		}

--- a/db/db.go
+++ b/db/db.go
@@ -2349,24 +2349,15 @@ func GetWithdrawals(query string, length, start uint64, orderBy, orderDir string
 
 	withdrawalsQuery := `
 		SELECT 
-			a.block_slot as slot, 
-			a.withdrawalindex as index, 
-			a.validatorindex,
-			a.address,
-			a.amount
-		FROM (
-			SELECT 
-				w.block_root,
-				w.block_slot,
-				w.withdrawalindex,
-				w.validatorindex,
-				w.address,
-				w.amount
-			FROM blocks_withdrawals w
-			%s 
-			ORDER BY %s %s
-		) a
-		INNER JOIN blocks b ON a.block_root = b.blockroot AND b.status = '1'
+			w.block_slot as slot,
+			w.withdrawalindex as index,
+			w.validatorindex,
+			w.address,
+			w.amount
+		FROM blocks_withdrawals w
+		INNER JOIN blocks b ON w.block_root = b.blockroot AND b.status = '1'
+		%s 
+		ORDER BY %s %s
 		LIMIT $1
 		OFFSET $2`
 

--- a/db/db.go
+++ b/db/db.go
@@ -2308,9 +2308,9 @@ func GetWithdrawalsCountForQuery(query string) (uint64, error) {
 
 	} else if addressRE.MatchString(query) {
 		searchQuery := `WHERE address = $1`
-		addr, err := hex.DecodeString(trimmedQuery)
+		addr, decErr := hex.DecodeString(trimmedQuery)
 		if err != nil {
-			return 0, err
+			return 0, decErr
 		}
 		err = ReaderDb.Get(&count, fmt.Sprintf(withdrawalsQuery, searchQuery),
 			addr)
@@ -2373,9 +2373,9 @@ func GetWithdrawals(query string, length, start uint64, orderBy, orderDir string
 				length, start, uiQuery, utils.Config.Chain.Config.SlotsPerEpoch)
 		} else if addressRE.MatchString(query) {
 			searchQuery := `WHERE address = $3`
-			addr, err := hex.DecodeString(trimmedQuery)
-			if err != nil {
-				return nil, err
+			addr, decErr := hex.DecodeString(trimmedQuery)
+			if decErr != nil {
+				return nil, decErr
 			}
 			err = ReaderDb.Select(&withdrawals, fmt.Sprintf(withdrawalsQuery, searchQuery, orderBy, orderDir),
 				length, start, addr)
@@ -2968,9 +2968,9 @@ func GetBLSChangesCountForQuery(query string) (uint64, error) {
 			uiQuery, utils.Config.Chain.Config.SlotsPerEpoch)
 	} else if blsRE.MatchString(query) {
 		searchQuery := `WHERE pubkey = $1`
-		pubkey, err := hex.DecodeString(trimmedQuery)
-		if err != nil {
-			return 0, err
+		pubkey, decErr := hex.DecodeString(trimmedQuery)
+		if decErr != nil {
+			return 0, decErr
 		}
 		err = ReaderDb.Select(&count, fmt.Sprintf(blsQuery, searchQuery),
 			pubkey)
@@ -3028,9 +3028,9 @@ func GetBLSChanges(query string, length, start uint64, orderBy, orderDir string)
 				length, start, uiQuery, utils.Config.Chain.Config.SlotsPerEpoch)
 		} else if blsRE.MatchString(query) {
 			searchQuery := `WHERE pubkey = $3`
-			pubkey, err := hex.DecodeString(trimmedQuery)
-			if err != nil {
-				return nil, err
+			pubkey, decErr := hex.DecodeString(trimmedQuery)
+			if decErr != nil {
+				return nil, decErr
 			}
 			err = ReaderDb.Select(&blsChange, fmt.Sprintf(blsQuery, searchQuery, orderBy, orderDir),
 				length, start, pubkey)

--- a/db/migrations/20230830144100_improve_blocks_bls_change_pubkey_text_idx.sql
+++ b/db/migrations/20230830144100_improve_blocks_bls_change_pubkey_text_idx.sql
@@ -1,24 +1,40 @@
+-- +goose NO TRANSACTION
+
 -- +goose Up
 
 -- +goose StatementBegin
-DROP INDEX IF EXISTS idx_blocks_bls_change_pubkey_text;
+DROP INDEX CONCURRENTLY IF EXISTS idx_blocks_bls_change_pubkey_text;
+-- +goose StatementEnd
+-- +goose StatementBegin
 ALTER TABLE blocks_bls_change DROP COLUMN IF EXISTS pubkey_text;
-
-DROP INDEX IF EXISTS idx_blocks_withdrawals_search;
-DROP INDEX IF EXISTS idx_blocks_withdrawals_address_text;
+-- +goose StatementEnd
+-- +goose StatementBegin
+DROP INDEX CONCURRENTLY IF EXISTS idx_blocks_withdrawals_search;
+-- +goose StatementEnd
+-- +goose StatementBegin
+DROP INDEX CONCURRENTLY IF EXISTS idx_blocks_withdrawals_address_text;
+-- +goose StatementEnd
+-- +goose StatementBegin
 ALTER TABLE blocks_withdrawals DROP COLUMN IF EXISTS address_text;
-
-CREATE INDEX IF NOT EXISTS idx_blocks_withdrawals_address ON blocks_withdrawals (address);
+-- +goose StatementEnd
+-- +goose StatementBegin
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_blocks_withdrawals_address ON blocks_withdrawals (address);
 -- +goose StatementEnd
 
 -- +goose Down
 
 -- +goose StatementBegin
 ALTER TABLE blocks_withdrawals ADD COLUMN IF NOT EXISTS address_text TEXT NOT NULL DEFAULT '';
-CREATE INDEX IF NOT EXISTS idx_blocks_withdrawals_address_text ON blocks_withdrawals USING gin (address_text gin_trgm_ops);
-
+-- +goose StatementEnd
+-- +goose StatementBegin
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_blocks_withdrawals_address_text ON blocks_withdrawals USING gin (address_text gin_trgm_ops);
+-- +goose StatementEnd
+-- +goose StatementBegin
 ALTER TABLE blocks_bls_change ADD COLUMN IF NOT EXISTS pubkey_text TEXT NOT NULL DEFAULT '';
-CREATE INDEX IF NOT EXISTS idx_blocks_bls_change_pubkey_text ON blocks_bls_change USING gin (pubkey_text gin_trgm_ops);
-
-CREATE INDEX IF NOT EXISTS idx_blocks_bls_change_search ON blocks_bls_change (validatorindex, block_slot, pubkey_text);
+-- +goose StatementEnd
+-- +goose StatementBegin
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_blocks_bls_change_pubkey_text ON blocks_bls_change USING gin (pubkey_text gin_trgm_ops);
+-- +goose StatementEnd
+-- +goose StatementBegin
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_blocks_bls_change_search ON blocks_bls_change (validatorindex, block_slot, pubkey_text);
 -- +goose StatementEnd

--- a/db/migrations/20230830144100_improve_blocks_bls_change_pubkey_text_idx.sql
+++ b/db/migrations/20230830144100_improve_blocks_bls_change_pubkey_text_idx.sql
@@ -1,0 +1,31 @@
+-- +goose NO TRANSACTION
+
+-- +goose Up
+
+-- +goose StatementBegin
+DROP INDEX CONCURRENTLY IF EXISTS idx_blocks_bls_change_pubkey_text;
+-- +goose StatementEnd
+-- +goose StatementBegin
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_blocks_bls_change_pubkey_text ON blocks_bls_change USING gin (pubkey_text gin_trgm_ops);
+-- +goose StatementEnd
+-- +goose StatementBegin
+DROP INDEX CONCURRENTLY IF EXISTS idx_blocks_withdrawals_address_text;
+-- +goose StatementEnd
+-- +goose StatementBegin
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_blocks_withdrawals_address_text ON blocks_withdrawals USING gin (address_text gin_trgm_ops);
+-- +goose StatementEnd
+
+-- +goose Down
+
+-- +goose StatementBegin
+DROP INDEX CONCURRENTLY IF EXISTS idx_blocks_bls_change_pubkey_text;
+-- +goose StatementEnd
+-- +goose StatementBegin
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_blocks_bls_change_pubkey_text ON blocks_bls_change (pubkey_text);
+-- +goose StatementEnd
+-- +goose StatementBegin
+DROP INDEX CONCURRENTLY IF EXISTS idx_blocks_withdrawals_address_text;
+-- +goose StatementEnd
+-- +goose StatementBegin
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_blocks_withdrawals_search ON blocks_withdrawals (validatorindex, block_slot, address_text);
+-- +goose StatementEnd

--- a/db/migrations/20230830144100_improve_blocks_bls_change_pubkey_text_idx.sql
+++ b/db/migrations/20230830144100_improve_blocks_bls_change_pubkey_text_idx.sql
@@ -1,37 +1,24 @@
--- +goose NO TRANSACTION
-
 -- +goose Up
 
 -- +goose StatementBegin
-DROP INDEX CONCURRENTLY IF EXISTS idx_blocks_bls_change_pubkey_text;
--- +goose StatementEnd
--- +goose StatementBegin
-CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_blocks_bls_change_pubkey_text ON blocks_bls_change USING gin (pubkey_text gin_trgm_ops);
--- +goose StatementEnd
--- +goose StatementBegin
-DROP INDEX CONCURRENTLY IF EXISTS idx_blocks_withdrawals_address_text;
--- +goose StatementEnd
--- +goose StatementBegin
-CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_blocks_withdrawals_address_text ON blocks_withdrawals USING gin (address_text gin_trgm_ops);
--- +goose StatementEnd
--- +goose StatementBegin
-CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_blocks_withdrawals_address ON blocks_withdrawals (address);
+DROP INDEX IF EXISTS idx_blocks_bls_change_pubkey_text;
+ALTER TABLE blocks_bls_change DROP COLUMN IF EXISTS pubkey_text;
+
+DROP INDEX IF EXISTS idx_blocks_withdrawals_search;
+DROP INDEX IF EXISTS idx_blocks_withdrawals_address_text;
+ALTER TABLE blocks_withdrawals DROP COLUMN IF EXISTS address_text;
+
+CREATE INDEX IF NOT EXISTS idx_blocks_withdrawals_address ON blocks_withdrawals (address);
 -- +goose StatementEnd
 
 -- +goose Down
 
 -- +goose StatementBegin
-DROP INDEX CONCURRENTLY IF EXISTS idx_blocks_bls_change_pubkey_text;
--- +goose StatementEnd
--- +goose StatementBegin
-CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_blocks_bls_change_pubkey_text ON blocks_bls_change (pubkey_text);
--- +goose StatementEnd
--- +goose StatementBegin
-DROP INDEX CONCURRENTLY IF EXISTS idx_blocks_withdrawals_address_text;
--- +goose StatementEnd
--- +goose StatementBegin
-CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_blocks_withdrawals_search ON blocks_withdrawals (validatorindex, block_slot, address_text);
--- +goose StatementEnd
--- +goose StatementBegin
-DROP INDEX CONCURRENTLY IF EXISTS idx_blocks_withdrawals_address;
+ALTER TABLE blocks_withdrawals ADD COLUMN IF NOT EXISTS address_text TEXT NOT NULL DEFAULT '';
+CREATE INDEX IF NOT EXISTS idx_blocks_withdrawals_address_text ON blocks_withdrawals USING gin (address_text gin_trgm_ops);
+
+ALTER TABLE blocks_bls_change ADD COLUMN IF NOT EXISTS pubkey_text TEXT NOT NULL DEFAULT '';
+CREATE INDEX IF NOT EXISTS idx_blocks_bls_change_pubkey_text ON blocks_bls_change USING gin (pubkey_text gin_trgm_ops);
+
+CREATE INDEX IF NOT EXISTS idx_blocks_bls_change_search ON blocks_bls_change (validatorindex, block_slot, pubkey_text);
 -- +goose StatementEnd

--- a/db/migrations/20230830144100_improve_blocks_bls_change_pubkey_text_idx.sql
+++ b/db/migrations/20230830144100_improve_blocks_bls_change_pubkey_text_idx.sql
@@ -14,6 +14,9 @@ DROP INDEX CONCURRENTLY IF EXISTS idx_blocks_withdrawals_address_text;
 -- +goose StatementBegin
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_blocks_withdrawals_address_text ON blocks_withdrawals USING gin (address_text gin_trgm_ops);
 -- +goose StatementEnd
+-- +goose StatementBegin
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_blocks_withdrawals_address ON blocks_withdrawals (address);
+-- +goose StatementEnd
 
 -- +goose Down
 
@@ -28,4 +31,7 @@ DROP INDEX CONCURRENTLY IF EXISTS idx_blocks_withdrawals_address_text;
 -- +goose StatementEnd
 -- +goose StatementBegin
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_blocks_withdrawals_search ON blocks_withdrawals (validatorindex, block_slot, address_text);
+-- +goose StatementEnd
+-- +goose StatementBegin
+DROP INDEX CONCURRENTLY IF EXISTS idx_blocks_withdrawals_address;
 -- +goose StatementEnd

--- a/handlers/withdrawals.go
+++ b/handlers/withdrawals.go
@@ -184,6 +184,16 @@ func WithdrawalsTableData(draw uint64, search string, length, start uint64, orde
 		formatCurrency = "Ether"
 	}
 
+	var err error
+	names := make(map[string]string)
+	for _, v := range withdrawals {
+		names[string(v.Address)] = ""
+	}
+	names, _, err = db.BigtableClient.GetAddressesNamesArMetadata(&names, nil)
+	if err != nil {
+		return nil, err
+	}
+
 	tableData := make([][]interface{}, len(withdrawals))
 	for i, w := range withdrawals {
 		tableData[i] = []interface{}{
@@ -192,7 +202,7 @@ func WithdrawalsTableData(draw uint64, search string, length, start uint64, orde
 			template.HTML(fmt.Sprintf("%v", w.Index)),
 			template.HTML(fmt.Sprintf("%v", utils.FormatValidator(w.ValidatorIndex))),
 			template.HTML(fmt.Sprintf("%v", utils.FormatTimestamp(utils.SlotToTime(w.Slot).Unix()))),
-			template.HTML(fmt.Sprintf("%v", utils.FormatAddress(w.Address, nil, "", false, false, true))),
+			template.HTML(fmt.Sprintf("%v", utils.FormatAddressWithLimits(w.Address, names[string(w.Address)], false, "address", visibleDigitsForHash+5, 18, true))),
 			template.HTML(fmt.Sprintf("%v", utils.FormatAmount(new(big.Int).Mul(new(big.Int).SetUint64(w.Amount), big.NewInt(1e9)), formatCurrency, 6))),
 		}
 	}
@@ -340,6 +350,16 @@ func BLSTableData(draw uint64, search string, length, start uint64, orderBy, ord
 		filteredCount = totalCount
 	}
 
+	var err error
+	names := make(map[string]string)
+	for _, v := range blsChange {
+		names[string(v.Address)] = ""
+	}
+	names, _, err = db.BigtableClient.GetAddressesNamesArMetadata(&names, nil)
+	if err != nil {
+		return nil, err
+	}
+
 	tableData := make([][]interface{}, len(blsChange))
 	for i, bls := range blsChange {
 		tableData[i] = []interface{}{
@@ -348,7 +368,7 @@ func BLSTableData(draw uint64, search string, length, start uint64, orderBy, ord
 			template.HTML(fmt.Sprintf("%v", utils.FormatValidator(bls.Validatorindex))),
 			template.HTML(fmt.Sprintf("%v", utils.FormatHashWithCopy(bls.Signature))),
 			template.HTML(fmt.Sprintf("%v", utils.FormatHashWithCopy(bls.BlsPubkey))),
-			template.HTML(fmt.Sprintf("%v", utils.FormatAddress(bls.Address, nil, "", false, false, true))),
+			template.HTML(fmt.Sprintf("%v", utils.FormatAddressWithLimits(bls.Address, names[string(bls.Address)], false, "address", visibleDigitsForHash+5, 18, true))),
 		}
 	}
 


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at cce4b89</samp>

This pull request improves the database and web interface for withdrawals and BLS public key changes in the eth2 beacon chain explorer. It uses binary fields and indexes for faster and more accurate queries, displays address names and metadata, and truncates and links long addresses. It also adds a new SQL migration file to alter the indexes on the `blocks_bls_change` and `blocks_withdrawals` tables.
