### PR TITLE
(BIDS-2445) Increase turboThreshold for income charts

### DIFF
--- a/static/js/dashboard.js
+++ b/static/js/dashboard.js
@@ -1422,6 +1422,9 @@ function createIncomeChart(income, executionIncomeHistory) {
         },
         pointInterval: 24 * 3600 * 1000,
       },
+      series: {
+        turboThreshold: 10000,
+      },
     },
     xAxis: {
       type: "datetime",

--- a/templates/validator/charts.html
+++ b/templates/validator/charts.html
@@ -203,7 +203,10 @@
                   enabled: false
                 },
                 pointInterval: 24 * 3600 * 1000,
-              }
+              },
+              series: {
+                turboThreshold: 10000,
+              },
             },
             xAxis: {
               type: 'datetime',


### PR DESCRIPTION
With this PR, the income chart on the validator page and the dashboard works again even if any of both series shown (execution and consensus) has more than 1000 entries.
It was broken because of Highchart's `turboThreshold` parameter defaulting to `1000` and Mainnet now reached 1004 entries.