### PR TITLE
New total supply endpoint

### DIFF
--- a/cmd/explorer/main.go
+++ b/cmd/explorer/main.go
@@ -373,6 +373,9 @@ func main() {
 		apiV1AuthRouter.Use(utils.CORSMiddleware)
 		apiV1AuthRouter.Use(utils.AuthorizedAPIMiddleware)
 
+		apiV2Router := router.PathPrefix("/api/v2").Subrouter()
+		apiV2Router.HandleFunc("/totalsupply", handlers.Supply).Methods("GET")
+
 		router.HandleFunc("/api/healthz", handlers.ApiHealthz).Methods("GET", "HEAD")
 		router.HandleFunc("/api/healthz-loadbalancer", handlers.ApiHealthzLoadbalancer).Methods("GET", "HEAD")
 

--- a/handlers/network.go
+++ b/handlers/network.go
@@ -1,0 +1,75 @@
+package handlers
+
+import (
+	"encoding/json"
+	"eth2-exporter/db"
+	"eth2-exporter/rpc"
+	"eth2-exporter/services"
+	"eth2-exporter/types"
+	"eth2-exporter/utils"
+	"github.com/ethereum/go-ethereum/params"
+	"math/big"
+	"net/http"
+)
+
+const (
+	GWei = 1e9
+)
+
+// Supply godoc
+// @Summary Get total supply of all native network tokens in existence
+// @Tags Misc
+// @Description Returns information about total supply of all native network tokens in existence (in wei).
+// @Produce  json
+// @Success 200 {object} types.ApiResponse{data=types.SupplyResponse} "Success"
+// @Failure 400 {object} types.ApiResponse "Failure"
+// @Failure 500 {object} types.ApiResponse "Server Error"
+// @Router /api/v2/totalsupply [get]
+func Supply(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	genesisTotalSupply := utils.Config.Chain.GenesisTotalSupply
+
+	totalAmountWithdrawn, _, err := db.GetTotalAmountWithdrawn()
+	if err != nil {
+		logger.WithError(err).Error("error getting total amount withdrawn from db")
+	}
+
+	latestFinalizedEpoch := services.LatestFinalizedEpoch()
+	if err != nil {
+		logger.WithError(err).Error("error getting latest finalized epoch")
+	}
+
+	chainIDBig := new(big.Int).SetUint64(utils.Config.Chain.Config.DepositChainID)
+	rpcClient, err := rpc.NewLighthouseClient("http://"+utils.Config.Indexer.Node.Host+":"+utils.Config.Indexer.Node.Port, chainIDBig)
+	if err != nil {
+		logger.WithError(err).Error("new total supply Lighthouse client in monitor error")
+	}
+
+	// Get the total staked gwei that was active (i.e., able to vote) during the latestFinalizedEpoch epoch
+	validatorParticipation, err := rpcClient.GetValidatorParticipation(latestFinalizedEpoch)
+	if err != nil {
+		logger.WithError(err).Error("error getting validators participation data")
+	}
+
+	totalSupply := genesisTotalSupply + totalAmountWithdrawn + validatorParticipation.EligibleEther
+
+	amount := new(big.Int).Mul(new(big.Int).SetUint64(totalSupply), big.NewInt(params.GWei))
+
+	data := types.SupplyResponse{
+		TotalSupply: amount.String(),
+	}
+
+	response := &types.ApiResponse{
+		Status: "OK",
+		Data:   data,
+	}
+
+	err = json.NewEncoder(w).Encode(response)
+	if err != nil {
+		logger.WithError(err).WithField("route", r.URL.String()).Error("error encoding json response")
+		http.Error(w, "Internal server error", http.StatusServiceUnavailable)
+		return
+	}
+
+}

--- a/types/api.go
+++ b/types/api.go
@@ -722,3 +722,7 @@ type ApiProposalLuckResponse struct {
 	NextProposalEstimateTs  *int64   `json:"next_proposal_estimate_ts"` // The estimated timestamp of the next proposal
 	TimeFrameName           *string  `json:"time_frame_name"`           // The timeframe for which the luck is calculated
 }
+
+type SupplyResponse struct {
+	TotalSupply string `json:"total_supply"`
+}

--- a/types/config.go
+++ b/types/config.go
@@ -33,6 +33,7 @@ type Config struct {
 		Name                       string `yaml:"name" envconfig:"CHAIN_NAME"`
 		GenesisTimestamp           uint64 `yaml:"genesisTimestamp" envconfig:"CHAIN_GENESIS_TIMESTAMP"`
 		GenesisValidatorsRoot      string `yaml:"genesisValidatorsRoot" envconfig:"CHAIN_GENESIS_VALIDATORS_ROOT"`
+		GenesisTotalSupply         uint64 `yaml:"genesisTotalSupply" envconfig:"CHAIN_GENESIS_TOTAL_SUPPLY"`
 		DomainBLSToExecutionChange string `yaml:"domainBLSToExecutionChange" envconfig:"CHAIN_DOMAIN_BLS_TO_EXECUTION_CHANGE"`
 		DomainVoluntaryExit        string `yaml:"domainVoluntaryExit" envconfig:"CHAIN_DOMAIN_VOLUNTARY_EXIT"`
 		ConfigPath                 string `yaml:"configPath" envconfig:"CHAIN_CONFIG_PATH"`

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -472,6 +472,15 @@ func ReadConfig(cfg *types.Config, path string) error {
 		}
 	}
 
+	if cfg.Chain.GenesisTotalSupply == 0 {
+		switch cfg.Chain.Name {
+		case "lukso":
+			cfg.Chain.GenesisTotalSupply = 42000000000000000
+		default:
+			return fmt.Errorf("tried to set known genesisTotalSupply, but unknown chain-name")
+		}
+	}
+
 	if cfg.Chain.DomainBLSToExecutionChange == "" {
 		cfg.Chain.DomainBLSToExecutionChange = "0x0A000000"
 	}


### PR DESCRIPTION
This PR adds new `Beaconcha.in` explorer API endpoint to integrate with 3rd party markets and exchanges (`CoinGecko`, `Coinmarketcap`, they need to know the `TotalSupply` for native tokens like `LYX` is for example). 

There was an official foundation founds allocation made in chain config under `alloc`: https://github.com/lukso-network/network-configs/blob/e3a2e914d76db0c5e93d93ade6caafef9936a6d9/mainnet/shared/genesis.json#L34 (and supply was announced and explained in https://medium.com/lukso/its-happening-the-genesis-validators-are-coming-ce5e07935df6 blog post for example).

State:
- It's placed under `Misc` API category and documented (Swagger)
- It's based on `genesis.json` allocation (for foundation, allocated in chain config)
- It makes calculation of sum of `genesis.json` (alloc) supply, total withdrawn amount and current consensus validator balances (current balances based on https://lighthouse-book.sigmaprime.io/validator-inclusion.html#global)