### PR TITLE
(BIDS-2432) Remove text-primary style from 0x in FormatAddressLong

### DIFF
--- a/utils/eth1.go
+++ b/utils/eth1.go
@@ -240,9 +240,9 @@ func FormatHashLong(hash common.Hash) template.HTML {
 	if len(address) > 4 {
 		htmlFormat := `
 		<div class="d-flex text-monospace">
-			<span class="">%s</span>
+			%s
 			<span class="flex-shrink-1 text-truncate">%s</span>
-			<span class="">%s</span>
+			%s
 		</div>`
 
 		return template.HTML(fmt.Sprintf(htmlFormat, address[:4], address[4:len(address)-4], address[len(address)-4:]))

--- a/utils/eth1.go
+++ b/utils/eth1.go
@@ -256,9 +256,9 @@ func FormatAddressLong(address string) template.HTML {
 	}
 	address = FixAddressCasing(address)
 	test := `
-	<span class="text-monospace mw-100"><span class="text-primary">%s</span><span class="text-truncate">%s</span><span class="text-primary">%s</span></span>`
+	<span class="text-monospace mw-100"><span class="text-truncate">%s</span><span class="text-primary">%s</span><span class="text-truncate">%s</span><span class="text-primary">%s</span></span>`
 	if len(address) > 4 {
-		return template.HTML(fmt.Sprintf(test, address[:6], address[6:len(address)-4], address[len(address)-4:]))
+		return template.HTML(fmt.Sprintf(test, address[:2], address[2:6], address[6:len(address)-4], address[len(address)-4:]))
 	}
 
 	return template.HTML(address)

--- a/utils/eth1.go
+++ b/utils/eth1.go
@@ -237,14 +237,15 @@ func FormatAddressAsTokenLink(token, address []byte, name string, verified bool,
 
 func FormatHashLong(hash common.Hash) template.HTML {
 	address := hash.String()
-	test := `
-	<div class="d-flex text-monospace">
-		<span class="">%s</span>
-		<span class="flex-shrink-1 text-truncate">%s</span>
-		<span class="">%s</span>
-	</div>`
 	if len(address) > 4 {
-		return template.HTML(fmt.Sprintf(test, address[:4], address[4:len(address)-4], address[len(address)-4:]))
+		htmlFormat := `
+		<div class="d-flex text-monospace">
+			<span class="">%s</span>
+			<span class="flex-shrink-1 text-truncate">%s</span>
+			<span class="">%s</span>
+		</div>`
+
+		return template.HTML(fmt.Sprintf(htmlFormat, address[:4], address[4:len(address)-4], address[len(address)-4:]))
 	}
 
 	return template.HTML(address)
@@ -255,10 +256,11 @@ func FormatAddressLong(address string) template.HTML {
 		return template.HTML(address)
 	}
 	address = FixAddressCasing(address)
-	test := `
-	<span class="text-monospace mw-100"><span class="text-truncate">%s</span><span class="text-primary">%s</span><span class="text-truncate">%s</span><span class="text-primary">%s</span></span>`
 	if len(address) > 4 {
-		return template.HTML(fmt.Sprintf(test, address[:2], address[2:6], address[6:len(address)-4], address[len(address)-4:]))
+		htmlFormat := `
+		<span class="text-monospace mw-100">%s<span class="text-primary">%s</span>%s<span class="text-primary">%s</span></span>`
+
+		return template.HTML(fmt.Sprintf(htmlFormat, address[:2], address[2:6], address[6:len(address)-4], address[len(address)-4:]))
 	}
 
 	return template.HTML(address)


### PR DESCRIPTION
This PR causes the `0x` prefix of address not to be color orange anymore.

Current example: https://prater.beaconcha.in/address/0xe6a651e0a30fda0dc7f8b709287f5b76e0109202
![image](https://github.com/gobitfly/eth2-beaconchain-explorer/assets/114066135/916b3cf0-455d-47d3-bac3-0527b181d8e5)

This PR replaces https://github.com/gobitfly/eth2-beaconchain-explorer/pull/2522.