### PR TITLE
(BIDS-2452) limit ens name size to 2KB

### DIFF
--- a/db/ens.go
+++ b/db/ens.go
@@ -311,7 +311,7 @@ func (bigtable *Bigtable) TransformEnsNameRegistered(blk *types.Eth1Block, cache
 func verifyName(name string) error {
 	// limited by max capacity of db (caused by btrees of indexes); tests showed maximum of 2684 (added buffer)
 	if len(name) > 2048 {
-		return fmt.Errorf("name too long")
+		return fmt.Errorf("name too long: %v", name)
 	}
 	return nil
 }

--- a/db/ens.go
+++ b/db/ens.go
@@ -308,10 +308,9 @@ func (bigtable *Bigtable) TransformEnsNameRegistered(blk *types.Eth1Block, cache
 	return bulkData, bulkMetadataUpdates, nil
 }
 
-// Ens names are only supported to a length of 40
-// Source: https://github.com/wealdtech/go-ens/blob/5b323a4ef0472f06c515723b060b166843b9db08/resolver.go#L190
 func verifyName(name string) error {
-	if (strings.HasPrefix(name, "0x") && len(name) > 42) || (!strings.HasPrefix(name, "0x") && len(name) > 40) {
+	// limited by max capacity of db (caused by btrees of indexes); tests showed maximum of 2684 (added buffer)
+	if len(name) > 2048 {
 		return fmt.Errorf("name too long")
 	}
 	return nil


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a16cd40</samp>

Removed ENS name validation and added length check for validator names in `db/ens.go`. This enabled users to set custom names for validators in the explorer.
