### PR TITLE
(BIDS-2457) remove previous odao members

### DIFF
--- a/exporter/rocketpool.go
+++ b/exporter/rocketpool.go
@@ -21,6 +21,7 @@ import (
 	_ "github.com/jackc/pgx/v4/stdlib"
 	"github.com/jmoiron/sqlx"
 	"github.com/klauspost/compress/zstd"
+	"github.com/lib/pq"
 	rpDAO "github.com/rocket-pool/rocketpool-go/dao"
 	rpDAOTrustedNode "github.com/rocket-pool/rocketpool-go/dao/trustednode"
 	"github.com/rocket-pool/rocketpool-go/minipool"

--- a/exporter/rocketpool.go
+++ b/exporter/rocketpool.go
@@ -1160,7 +1160,7 @@ func (rp *RocketpoolExporter) SaveDAOMembers() error {
 
 		_, err = tx.Exec(`
 			DELETE FROM rocketpool_dao_members
-			WHERE NOT address = ANY($1)`, addresses)
+			WHERE NOT address = ANY($1)`, pq.ByteaArray(addresses))
 		if err != nil {
 			return fmt.Errorf("error deleting from rocketpool_dao_members: %w", err)
 		}


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 200ecef</samp>

This pull request improves the integration of RocketPool DAO data in the `exporter/rocketpool.go` file. It adds logic to manage the DAO members in the database and avoid stale data.
