### PR TITLE
(BIDS-2469) Handle sql.ErrNoRows for missed attestations

### DIFF
--- a/handlers/validator.go
+++ b/handlers/validator.go
@@ -376,7 +376,7 @@ func Validator(w http.ResponseWriter, r *http.Request) {
 
 		incomeHistoryChartData, err := db.GetValidatorIncomeHistoryChart([]uint64{index}, currency, lastFinalizedEpoch, lowerBoundDay)
 		if err != nil {
-			return fmt.Errorf("error calling db.GetValidatorIncomeHistoryChart: %v", err)
+			return fmt.Errorf("error calling db.GetValidatorIncomeHistoryChart: %w", err)
 		}
 
 		validatorPageData.IncomeHistoryChartData = incomeHistoryChartData
@@ -391,7 +391,7 @@ func Validator(w http.ResponseWriter, r *http.Request) {
 
 		executionIncomeHistoryData, err := getExecutionChartData([]uint64{index}, currency, lowerBoundDay)
 		if err != nil {
-			return fmt.Errorf("error calling getExecutionChartData: %v", err)
+			return fmt.Errorf("error calling getExecutionChartData: %w", err)
 		}
 
 		validatorPageData.ExecutionIncomeHistoryData = executionIncomeHistoryData
@@ -406,7 +406,7 @@ func Validator(w http.ResponseWriter, r *http.Request) {
 		}()
 		earnings, balances, err := GetValidatorEarnings([]uint64{index}, GetCurrency(r))
 		if err != nil {
-			return fmt.Errorf("error retrieving validator earnings: %v", err)
+			return fmt.Errorf("error retrieving validator earnings: %w", err)
 		}
 		// each income and apr variable is a struct of 3 fields: cl, el and total
 		validatorPageData.Income1d = earnings.Income1d
@@ -441,13 +441,13 @@ func Validator(w http.ResponseWriter, r *http.Request) {
 			// get validator withdrawals
 			withdrawalsCount, lastWithdrawalsEpoch, err := db.GetValidatorWithdrawalsCount(validatorPageData.Index)
 			if err != nil {
-				return fmt.Errorf("error getting validator withdrawals count from db: %v", err)
+				return fmt.Errorf("error getting validator withdrawals count from db: %w", err)
 			}
 			validatorPageData.WithdrawalCount = withdrawalsCount
 
 			blsChange, err := db.GetValidatorBLSChange(validatorPageData.Index)
 			if err != nil {
-				return fmt.Errorf("error getting validator bls change from db: %v", err)
+				return fmt.Errorf("error getting validator bls change from db: %w", err)
 			}
 			validatorPageData.BLSChange = blsChange
 
@@ -462,7 +462,7 @@ func Validator(w http.ResponseWriter, r *http.Request) {
 			if stats != nil && stats.LatestValidatorWithdrawalIndex != nil && stats.TotalValidatorCount != nil && validatorPageData.IsWithdrawableAddress && (isFullWithdrawal || isPartialWithdrawal) {
 				distance, err := GetWithdrawableCountFromCursor(validatorPageData.Epoch, validatorPageData.Index, *stats.LatestValidatorWithdrawalIndex)
 				if err != nil {
-					return fmt.Errorf("error getting withdrawable validator count from cursor: %v", err)
+					return fmt.Errorf("error getting withdrawable validator count from cursor: %w", err)
 				}
 
 				timeToWithdrawal := utils.GetTimeToNextWithdrawal(distance)
@@ -520,7 +520,7 @@ func Validator(w http.ResponseWriter, r *http.Request) {
 
 		watchlist, err := db.GetTaggedValidators(filter)
 		if err != nil {
-			return fmt.Errorf("error getting tagged validators from db: %v", err)
+			return fmt.Errorf("error getting tagged validators from db: %w", err)
 		}
 
 		validatorPageData.Watchlist = watchlist
@@ -534,7 +534,7 @@ func Validator(w http.ResponseWriter, r *http.Request) {
 		}()
 		deposits, err := db.GetValidatorDeposits(validatorPageData.PublicKey)
 		if err != nil {
-			return fmt.Errorf("error getting validator-deposits from db: %v", err)
+			return fmt.Errorf("error getting validator-deposits from db: %w", err)
 		}
 		validatorPageData.Deposits = deposits
 		validatorPageData.DepositsCount = uint64(len(deposits.Eth1Deposits))
@@ -556,7 +556,7 @@ func Validator(w http.ResponseWriter, r *http.Request) {
 		if validatorPageData.ActivationEpoch > 100_000_000 && validatorPageData.ActivationEligibilityEpoch < 100_000_000 {
 			queueAhead, err := db.GetQueueAheadOfValidator(validatorPageData.Index)
 			if err != nil {
-				return fmt.Errorf("failed to retrieve queue ahead of validator %v: %v", validatorPageData.ValidatorIndex, err)
+				return fmt.Errorf("failed to retrieve queue ahead of validator %v: %w", validatorPageData.ValidatorIndex, err)
 			}
 			validatorPageData.QueuePosition = queueAhead + 1
 			epochsToWait := queueAhead / *churnRate
@@ -592,7 +592,7 @@ func Validator(w http.ResponseWriter, r *http.Request) {
 				// logger.Infof("retrieving attestations not yet in stats, lookback is %v", lookback)
 				missedAttestations, err := db.BigtableClient.GetValidatorMissedAttestationHistory([]uint64{index}, lastFinalizedEpoch-uint64(lookback), lastFinalizedEpoch)
 				if err != nil {
-					return fmt.Errorf("error retrieving validator attestations not in stats from bigtable: %v", err)
+					return fmt.Errorf("error retrieving validator attestations not in stats from bigtable: %w", err)
 				}
 				attestationStats.MissedAttestations += uint64(len(missedAttestations[index]))
 			}
@@ -623,7 +623,7 @@ func Validator(w http.ResponseWriter, r *http.Request) {
 				limit 1`,
 				index)
 			if err != nil {
-				return fmt.Errorf("error retrieving validator slashing info: %v", err)
+				return fmt.Errorf("error retrieving validator slashing info: %w", err)
 			}
 			validatorPageData.SlashedBy = slashingInfo.Slasher
 			validatorPageData.SlashedAt = slashingInfo.Slot
@@ -632,7 +632,7 @@ func Validator(w http.ResponseWriter, r *http.Request) {
 
 		err = db.ReaderDb.Get(&validatorPageData.SlashingsCount, `select COALESCE(sum(attesterslashingscount) + sum(proposerslashingscount), 0) from blocks where blocks.proposer = $1 and blocks.status = '1'`, index)
 		if err != nil {
-			return fmt.Errorf("error retrieving slashings-count: %v", err)
+			return fmt.Errorf("error retrieving slashings-count: %w", err)
 		}
 		return nil
 	})
@@ -640,7 +640,7 @@ func Validator(w http.ResponseWriter, r *http.Request) {
 	g.Go(func() error {
 		eff, err := db.BigtableClient.GetValidatorEffectiveness([]uint64{index}, validatorPageData.Epoch-1)
 		if err != nil {
-			return fmt.Errorf("error retrieving validator effectiveness: %v", err)
+			return fmt.Errorf("error retrieving validator effectiveness: %w", err)
 		}
 		if len(eff) > 1 {
 			return fmt.Errorf("error retrieving validator effectiveness: invalid length %v", len(eff))
@@ -670,7 +670,7 @@ func Validator(w http.ResponseWriter, r *http.Request) {
 		WHERE validatorindex = $2
 		ORDER BY period desc`, utils.Config.Chain.Config.EpochsPerSyncCommitteePeriod, index)
 		if err != nil {
-			return fmt.Errorf("error getting sync participation count data of sync-assignments: %v", err)
+			return fmt.Errorf("error getting sync participation count data of sync-assignments: %w", err)
 		}
 
 		if len(allSyncPeriods) > 0 && allSyncPeriods[0].LastEpoch > latestEpoch {
@@ -697,7 +697,7 @@ func Validator(w http.ResponseWriter, r *http.Request) {
 					FROM validator_stats
 					WHERE validatorindex = $1`, index)
 				if err != nil {
-					return fmt.Errorf("error retrieving validator syncStats: %v", err)
+					return fmt.Errorf("error retrieving validator syncStats: %w", err)
 				}
 			}
 
@@ -707,7 +707,7 @@ func Validator(w http.ResponseWriter, r *http.Request) {
 			if lastSyncPeriod.LastEpoch > lastExportedEpoch {
 				res, err := db.BigtableClient.GetValidatorSyncDutiesHistory([]uint64{index}, lastExportedEpoch+1, latestEpoch)
 				if err != nil {
-					return fmt.Errorf("error retrieving validator sync participations data from bigtable: %v", err)
+					return fmt.Errorf("error retrieving validator sync participations data from bigtable: %w", err)
 				}
 				syncStatsBt := utils.AddSyncStats([]uint64{index}, res, nil)
 				// if last sync period is the current one, add remaining scheduled slots
@@ -734,7 +734,7 @@ func Validator(w http.ResponseWriter, r *http.Request) {
 			maxPeriod := allSyncPeriods[0].Period
 			expectedSyncCount, err := getExpectedSyncCommitteeSlots([]uint64{index}, latestEpoch)
 			if err != nil {
-				return fmt.Errorf("error retrieving expected sync committee slots: %v", err)
+				return fmt.Errorf("error retrieving expected sync committee slots: %w", err)
 			}
 			if expectedSyncCount != 0 {
 				validatorPageData.SyncLuck = float64(validatorPageData.ParticipatedSyncCountSlots+validatorPageData.MissedSyncCountSlots) / float64(expectedSyncCount)
@@ -785,7 +785,7 @@ func Validator(w http.ResponseWriter, r *http.Request) {
 				validatorPageData.Rocketpool.RocketscanUrl = "prater.rocketscan.io"
 			}
 		} else if err != nil && err != sql.ErrNoRows {
-			return fmt.Errorf("error getting rocketpool-data for validator for %v route: %v", r.URL.String(), err)
+			return fmt.Errorf("error getting rocketpool-data for validator for %v route: %w", r.URL.String(), err)
 		}
 		return nil
 	})

--- a/handlers/validator.go
+++ b/handlers/validator.go
@@ -374,12 +374,12 @@ func Validator(w http.ResponseWriter, r *http.Request) {
 			timings.Charts = time.Since(start)
 		}()
 
-		var err error
-		validatorPageData.IncomeHistoryChartData, err = db.GetValidatorIncomeHistoryChart([]uint64{index}, currency, lastFinalizedEpoch, lowerBoundDay)
-
+		incomeHistoryChartData, err := db.GetValidatorIncomeHistoryChart([]uint64{index}, currency, lastFinalizedEpoch, lowerBoundDay)
 		if err != nil {
 			return fmt.Errorf("error calling db.GetValidatorIncomeHistoryChart: %v", err)
 		}
+
+		validatorPageData.IncomeHistoryChartData = incomeHistoryChartData
 		return nil
 	})
 
@@ -389,12 +389,12 @@ func Validator(w http.ResponseWriter, r *http.Request) {
 			timings.Charts = time.Since(start)
 		}()
 
-		var err error
-		validatorPageData.ExecutionIncomeHistoryData, err = getExecutionChartData([]uint64{index}, currency, lowerBoundDay)
-
+		executionIncomeHistoryData, err := getExecutionChartData([]uint64{index}, currency, lowerBoundDay)
 		if err != nil {
 			return fmt.Errorf("error calling getExecutionChartData: %v", err)
 		}
+
+		validatorPageData.ExecutionIncomeHistoryData = executionIncomeHistoryData
 		return nil
 	})
 


### PR DESCRIPTION
This PR handles young validators that have no entry in the stats table properly on the validator page.
Problems where introduced here: https://github.com/gobitfly/eth2-beaconchain-explorer/commit/68902dc0f9532fec52c3e0ba616e507ed5d72e60

It also fixes concurrency issues with the `err` variable.