### PR TITLE
(NOBIDS) Mention slot instead of block number on slots page

### DIFF
--- a/templates/slots.html
+++ b/templates/slots.html
@@ -55,7 +55,7 @@
         pageLength: 50,
         pagingType: "input",
         language: {
-          searchPlaceholder: "Block Number / Graffiti / Proposer Name",
+          searchPlaceholder: "Slot / Graffiti / Proposer Name",
           search: "",
           paginate: {
             previous: '<i class="fas fa-chevron-left"></i>',


### PR DESCRIPTION
This PR writes `Slot` instead of `Block Number` as search placeholder on the `/slots` page.