### PR TITLE
(BIDS-2440) fix query for filtered bls-changes-count on withdrawals-page

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -2965,7 +2965,7 @@ func GetBLSChangesCountForQuery(query string) (uint64, error) {
 		if decErr != nil {
 			return 0, decErr
 		}
-		err = ReaderDb.Select(&count, fmt.Sprintf(blsQuery, searchQuery, BlsChangeQueryLimit),
+		err = ReaderDb.Get(&count, fmt.Sprintf(blsQuery, searchQuery, BlsChangeQueryLimit),
 			pubkey)
 	} else if uiQuery, parseErr := strconv.ParseUint(query, 10, 64); parseErr == nil {
 		// Check whether the query can be used for a validator, slot or epoch search

--- a/db/statistics.go
+++ b/db/statistics.go
@@ -988,7 +988,7 @@ func WriteValidatorSyncDutiesForDay(validators []uint64, day uint64, tx *sqlx.Tx
 	if startEpoch < utils.Config.Chain.Config.AltairForkEpoch && endEpoch > utils.Config.Chain.Config.AltairForkEpoch {
 		startEpoch = utils.Config.Chain.Config.AltairForkEpoch
 	} else if endEpoch < utils.Config.Chain.Config.AltairForkEpoch {
-		logger.Infof("day %v is pre-altair, skipping sync committee export")
+		logger.Infof("day %v is pre-altair, skipping sync committee export", day)
 		return nil
 	}
 


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b838c5e</samp>

Fixed a bug in `db/db.go` that affected the BLS key change search feature. Used a more efficient database query to fetch the count of BLS key changes for a given query.
