### PR TITLE
feat: add reth to clients page

### DIFF
--- a/ethClients/ethClients.go
+++ b/ethClients/ethClients.go
@@ -63,6 +63,7 @@ type EthClientServicesPageData struct {
 	Nimbus              EthClients
 	Lighthouse          EthClients
 	Erigon              EthClients
+	Reth                EthClients
 	RocketpoolSmartnode EthClients
 	MevBoost            EthClients
 	Lodestar            EthClients
@@ -190,6 +191,8 @@ func updateEthClientNetShare() {
 			ethClients.Besu.NetworkShare = share
 		case "erigon":
 			ethClients.Erigon.NetworkShare = share
+		case "reth":
+			ethClients.Reth.NetworkShare = share
 		default:
 			continue
 		}
@@ -215,6 +218,7 @@ func updateEthClient() {
 	ethClients.Nethermind.ClientReleaseVersion, ethClients.Nethermind.ClientReleaseDate = prepareEthClientData("/NethermindEth/nethermind", "Nethermind", curTime)
 	ethClients.Besu.ClientReleaseVersion, ethClients.Besu.ClientReleaseDate = prepareEthClientData("/hyperledger/besu", "Besu", curTime)
 	ethClients.Erigon.ClientReleaseVersion, ethClients.Erigon.ClientReleaseDate = prepareEthClientData("/ledgerwatch/erigon", "Erigon", curTime)
+	ethClients.Reth.ClientReleaseVersion, ethClients.Reth.ClientReleaseDate = prepareEthClientData("/paradigmxyz/reth", "Reth", curTime)
 
 	ethClients.Teku.ClientReleaseVersion, ethClients.Teku.ClientReleaseDate = prepareEthClientData("/ConsenSys/teku", "Teku", curTime)
 	ethClients.Prysm.ClientReleaseVersion, ethClients.Prysm.ClientReleaseDate = prepareEthClientData("/prysmaticlabs/prysm", "Prysm", curTime)

--- a/handlers/ethClientsServices.go
+++ b/handlers/ethClientsServices.go
@@ -52,6 +52,8 @@ func EthClientsServices(w http.ResponseWriter, r *http.Request) {
 				pageData.Nimbus.IsUserSubscribed = true
 			case "erigon":
 				pageData.Erigon.IsUserSubscribed = true
+			case "reth":
+				pageData.Reth.IsUserSubscribed = true
 			case "rocketpool":
 				pageData.RocketpoolSmartnode.IsUserSubscribed = true
 			case "mev-boost":

--- a/templates/ethClientsServices.html
+++ b/templates/ethClientsServices.html
@@ -134,6 +134,19 @@
                       <td><input id="erigon-checkbox" type="checkbox" data-toggle="toggle" {{ if .Erigon.IsUserSubscribed }}checked{{ end }} onchange="updateUserSubscription('erigon-checkbox', 'eth_client_update', 'erigon')" /></td>
                     {{ end }}
                   </tr>
+                  <tr>
+                    <td data-column="Name"><a href="https://github.com/paradigmxyz/reth">Reth </a></td>
+                    <td data-column="Language">Rust</td>
+                    <td data-column="Network share"><a href="https://ethernodes.org">{{ if .Reth.NetworkShare }}{{ .Reth.NetworkShare }}{{ else }}N/a{{ end }}</a></td>
+                    <td data-column="Latest update"><a href="https://github.com/paradigmxyz/reth/releases">{{ .Reth.ClientReleaseVersion }}</a> - {{ .Reth.ClientReleaseDate }}</td>
+                    <td data-column="Social media">
+                      <a href="https://t.me/paradigm_reth" target="_blank"><i class="fab fa-telegram ml-1 mr-1"></i></a>
+                    </td>
+                    <td data-column="Support">N/A</td>
+                    {{ if $.User.Authenticated }}
+                      <td><input id="reth-checkbox" type="checkbox" data-toggle="toggle" {{ if .Reth.IsUserSubscribed }}checked{{ end }} onchange="updateUserSubscription('reth-checkbox', 'eth_client_update', 'reth')" /></td>
+                    {{ end }}
+                  </tr>
                 </tbody>
               </table>
             </div>


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3fb7bde</samp>

This pull request adds support for the Reth Ethereum client to the ethClients module and the Ethereum clients services page. It modifies the `ethClients/ethClients.go`, `handlers/ethClientsServices.go`, and `templates/ethClientsServices.html` files to include the Reth client information and subscription option.
