### PR TITLE
Updates on p2p.org saas info

### DIFF
--- a/templates/stakingServices.html
+++ b/templates/stakingServices.html
@@ -534,14 +534,14 @@
                     </td>
                   </tr>
                   <tr>
-                    <td data-column="Service"><a href="https://ethereum-staking.p2p.org">P2P.org</a></td>
-                    <td data-column="No Supermajority client" style="text-align: center;">❌</td>
+                    <td data-column="Service"><a href="https://p2p.org/networks/ethereum">P2P.org</a></td>
+                    <td data-column="No Supermajority client" style="text-align: center;">✅</td>
                     <td data-column="Validator key owner">Service</td>
                     <td data-column="Withdrawal key owner">User</td>
                     <td data-column="Pool token">No</td>
                     <td data-column="3rd Party Software">No</td>
                     <td data-column="Min. Stake">32 ETH</td>
-                    <td data-column="Fee">10% of rewards</td>
+                    <td data-column="Fee">5% of rewards</td>
                     <td data-column="Open Source">No</td>
                     <td data-column="Social">
                       <i class="fab fa-discord ml-1 mr-1"></i><a href="https://twitter.com/P2Pvalidator" target="_blank"><i class="fab fa-twitter ml-1 mr-1"></i></a><a href="https://t.me/P2Pstaking" target="_blank"><i class="fab fa-telegram ml-1 mr-1"></i></a><a href="mailto:letsgo@p2p.org" target="_blank"><i class="fa fa-mail-bulk ml-1 mr-1"></i></a>


### PR DESCRIPTION
1. Service link is now https://p2p.org/networks/ethereum
2. Fee is changed from 10% to 5%
3. p2p.org used 50% Besu and 50% Geth, so there's no supermajority client issue in EL (if you need any proofs — please, let me know)