### PR TITLE
(BIDS-2462) shortened long ENS names

### DIFF
--- a/static/js/layout.js
+++ b/static/js/layout.js
@@ -825,6 +825,41 @@ function getIncomeChartValueString(value, currency) {
   return `${trimCurrency(value)} ${currency}`
 }
 
+$("[data-truncate-middle]").each(function (item) {
+  truncateMiddle(this)
+  addEventListener("resize", (event) => {
+    truncateMiddle(this)
+  })
+  addEventListener("copy", (event) => {
+    copyDots(event, this)
+  })
+})
+
+// function for trimming an placing ellipsis in the middle when text is overflowing
+function truncateMiddle(element) {
+  element.innerHTML = element.getAttribute("data-truncate-middle")
+  const parent = element.parentElement
+  // get ratio of visible width to full width
+  const ratio = parent.offsetWidth / parent.scrollWidth
+  if (ratio < 1) {
+    const removeCount = Math.ceil((parent.innerText.length * (1 - ratio)) / 2) + 1
+    const originalText = element.getAttribute("data-truncate-middle")
+    element.innerHTML = originalText.substr(0, originalText.length / 2 - removeCount) + "…" + originalText.substr(originalText.length / 2 + removeCount)
+  }
+}
+
+// function for inserting correct text into clipboard when copying ellipsis of text truncated with 'truncateMiddle()'
+function copyDots(event, element) {
+  const selection = document.getSelection()
+  if (selection.toString().includes("…")) {
+    const originalText = element.getAttribute("data-truncate-middle")
+    const diff = originalText.length - (element.innerText.length - 1)
+    const replaceText = selection.toString().replace("…", originalText.substr(originalText.length / 2 - diff / 2, diff))
+    event.clipboardData.setData("text/plain", replaceText)
+    event.preventDefault()
+  }
+}
+
 $("[data-tooltip-date=true]").each(function (item) {
   let titleObject = $($.parseHTML($(this).attr("title")))
   titleObject.find("[aria-ethereum-date]").each(function () {

--- a/templates/ensSearch.html
+++ b/templates/ensSearch.html
@@ -7,7 +7,7 @@
 {{ define "content" }}
   <div class="container mt-2">
     <div class="d-md-flex py-2 my-3 justify-content-md-between">
-      <h1 class="h4 mb-1 mb-md-0 text-nowrap"><i class="fas fa-search mr-2 position-relative"></i>Ens Search for: {{ formatAddressLong .Data.Search }}</h1>
+      <h1 class="h4 mb-1 mb-md-0 text-nowrap"><i class="fas fa-search mr-2 position-relative"></i>ENS Search for: {{ formatAddressLong .Data.Search }}</h1>
     </div>
     <div class="card mt-3">
       {{ if gt (len .Data.Error) 0 }}

--- a/templates/ensSearch.html
+++ b/templates/ensSearch.html
@@ -6,7 +6,7 @@
 
 {{ define "content" }}
   <div class="container mt-2">
-    <div class="d-md-flex py-2 my-3 justify-content-md-between">
+    <div class="py-2 my-3 justify-content-md-between">
       <h1 class="h4 mb-1 mb-md-0 text-nowrap"><i class="fas fa-search mr-2 position-relative"></i>ENS Search for: {{ formatAddressLong .Data.Search }}</h1>
     </div>
     <div class="card mt-3">

--- a/templates/ensSearch.html
+++ b/templates/ensSearch.html
@@ -7,7 +7,7 @@
 {{ define "content" }}
   <div class="container mt-2">
     <div class="d-md-flex py-2 my-3 justify-content-md-between">
-      <h1 class="h4 mb-1 mb-md-0"><i class="fas fa-search mr-2 position-relative"></i>Ens Search for: {{ formatAddressLong .Data.Search }}</h1>
+      <h1 class="h4 mb-1 mb-md-0 text-nowrap"><i class="fas fa-search mr-2 position-relative"></i>Ens Search for: {{ formatAddressLong .Data.Search }}</h1>
     </div>
     <div class="card mt-3">
       {{ if gt (len .Data.Error) 0 }}

--- a/utils/eth1.go
+++ b/utils/eth1.go
@@ -253,10 +253,7 @@ func FormatHashLong(hash common.Hash) template.HTML {
 
 func FormatAddressLong(address string) template.HTML {
 	if IsValidEnsDomain(address) {
-		if len(address) > 59 {
-			return template.HTML(fmt.Sprintf("%s…%s", address[:9], address[len(address)-50:]))
-		}
-		return template.HTML(address)
+		return template.HTML(fmt.Sprintf(`<span data-truncate-middle="%s"></span>.eth`, strings.TrimSuffix(address, ".eth")))
 	}
 	address = FixAddressCasing(address)
 	if len(address) > 4 {

--- a/utils/eth1.go
+++ b/utils/eth1.go
@@ -253,6 +253,9 @@ func FormatHashLong(hash common.Hash) template.HTML {
 
 func FormatAddressLong(address string) template.HTML {
 	if IsValidEnsDomain(address) {
+		if len(address) > 59 {
+			return template.HTML(fmt.Sprintf("%s…%s", address[:9], address[len(address)-50:]))
+		}
 		return template.HTML(address)
 	}
 	address = FixAddressCasing(address)


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c06db5f</samp>

Truncate very long addresses in `FormatAddressLong` function. This improves the address display on the web interface and avoids layout issues.
