### PR TITLE
Nobids/improve exporter performance

### DIFF
--- a/cmd/statistics/main.go
+++ b/cmd/statistics/main.go
@@ -57,10 +57,10 @@ func main() {
 	utils.Config = cfg
 
 	if utils.Config.Chain.Config.SlotsPerEpoch == 0 || utils.Config.Chain.Config.SecondsPerSlot == 0 {
-		utils.LogFatal(fmt.Errorf("error ether SlotsPerEpoch [%v] or SecondsPerSlot [%v] are not set", utils.Config.Chain.Config.SlotsPerEpoch, utils.Config.Chain.Config.SecondsPerSlot), "", 0)
+		utils.LogFatal(fmt.Errorf("error either SlotsPerEpoch [%v] or SecondsPerSlot [%v] are not set", utils.Config.Chain.Config.SlotsPerEpoch, utils.Config.Chain.Config.SecondsPerSlot), "", 0)
 		return
 	} else {
-		logrus.Infof("Writing statistic with: SlotsPerEpoch [%v] or SecondsPerSlot [%v]", utils.Config.Chain.Config.SlotsPerEpoch, utils.Config.Chain.Config.SecondsPerSlot)
+		logrus.Infof("writing statistic with: SlotsPerEpoch [%v] and SecondsPerSlot [%v]", utils.Config.Chain.Config.SlotsPerEpoch, utils.Config.Chain.Config.SecondsPerSlot)
 	}
 
 	db.MustInitDB(&types.DatabaseConfig{

--- a/db/bigtable.go
+++ b/db/bigtable.go
@@ -135,7 +135,7 @@ func (bigtable *Bigtable) gcWriteCache() {
 	for ; ; time.Sleep(time.Minute) {
 		logger.Infof("cleaning up write cache")
 		bigtable.epochWriteCacheMux.Lock()
-		for len(bigtable.epochWriteCache) > 9 {
+		for len(bigtable.epochWriteCache) > 5 {
 			minEpoch := types.Epoch(math.MaxUint64)
 
 			for epoch := range bigtable.epochWriteCache {

--- a/db/bigtable.go
+++ b/db/bigtable.go
@@ -68,6 +68,9 @@ type Bigtable struct {
 	lastAttestationCache    map[uint64]uint64
 	lastAttestationCacheMux *sync.Mutex
 
+	epochWriteCache    map[types.Epoch]map[types.ValidatorIndex]*types.EpochWriteCacheEntry
+	epochWriteCacheMux *sync.RWMutex
+
 	chainId string
 }
 
@@ -118,10 +121,114 @@ func InitBigtable(project, instance, chainId, redisAddress string) (*Bigtable, e
 		chainId:                 chainId,
 		redisCache:              rdc,
 		lastAttestationCacheMux: &sync.Mutex{},
+		epochWriteCache:         make(map[types.Epoch]map[types.ValidatorIndex]*types.EpochWriteCacheEntry),
+		epochWriteCacheMux:      &sync.RWMutex{},
 	}
+
+	go bt.gcWriteCache()
 
 	BigtableClient = bt
 	return bt, nil
+}
+
+func (bigtable *Bigtable) gcWriteCache() {
+	for ; ; time.Sleep(time.Minute) {
+		logger.Infof("cleaning up write cache")
+		bigtable.epochWriteCacheMux.Lock()
+		for len(bigtable.epochWriteCache) > 9 {
+			minEpoch := types.Epoch(math.MaxUint64)
+
+			for epoch := range bigtable.epochWriteCache {
+				if epoch < types.Epoch(minEpoch) {
+					minEpoch = epoch
+				}
+			}
+			logrus.Infof("purging epoch %v from write cache", minEpoch)
+			delete(bigtable.epochWriteCache, minEpoch)
+		}
+		bigtable.epochWriteCacheMux.Unlock()
+
+	}
+}
+
+func (bigtable *Bigtable) clearEpochfromWriteCache(epoch types.Epoch) {
+	bigtable.epochWriteCacheMux.Lock()
+	defer bigtable.epochWriteCacheMux.Unlock()
+
+	delete(bigtable.epochWriteCache, epoch)
+}
+
+func (bigtable *Bigtable) setBalanceWritten(epoch types.Epoch, validator types.ValidatorIndex, effectiveBalance uint64, balance uint64) {
+	bigtable.epochWriteCacheMux.Lock()
+	defer bigtable.epochWriteCacheMux.Unlock()
+
+	_, ok := bigtable.epochWriteCache[epoch]
+	if !ok {
+		bigtable.epochWriteCache[epoch] = make(map[types.ValidatorIndex]*types.EpochWriteCacheEntry)
+	}
+
+	_, ok = bigtable.epochWriteCache[epoch][validator]
+	if !ok {
+		bigtable.epochWriteCache[epoch][validator] = &types.EpochWriteCacheEntry{
+			Attestations: make(map[types.Slot]types.Slot),
+		}
+	}
+
+	bigtable.epochWriteCache[epoch][validator].EffectiveBalance = effectiveBalance
+	bigtable.epochWriteCache[epoch][validator].Balance = balance
+}
+
+func (bigtable *Bigtable) getBalanceWritten(epoch types.Epoch, validator types.ValidatorIndex, effectiveBalance uint64, balance uint64) bool {
+	bigtable.epochWriteCacheMux.RLock()
+	defer bigtable.epochWriteCacheMux.RUnlock()
+
+	_, ok := bigtable.epochWriteCache[epoch]
+	if !ok {
+		return false
+	}
+
+	_, ok = bigtable.epochWriteCache[epoch][validator]
+	if !ok {
+		return false
+	}
+
+	return bigtable.epochWriteCache[epoch][validator].Balance == balance && bigtable.epochWriteCache[epoch][validator].EffectiveBalance == effectiveBalance
+}
+
+func (bigtable *Bigtable) setAttestationWritten(epoch types.Epoch, validator types.ValidatorIndex, inclusionSlot, targetSlot types.Slot) {
+	bigtable.epochWriteCacheMux.Lock()
+	defer bigtable.epochWriteCacheMux.Unlock()
+
+	_, ok := bigtable.epochWriteCache[epoch]
+	if !ok {
+		bigtable.epochWriteCache[epoch] = make(map[types.ValidatorIndex]*types.EpochWriteCacheEntry)
+	}
+
+	_, ok = bigtable.epochWriteCache[epoch][validator]
+	if !ok {
+		bigtable.epochWriteCache[epoch][validator] = &types.EpochWriteCacheEntry{
+			Attestations: make(map[types.Slot]types.Slot),
+		}
+	}
+
+	bigtable.epochWriteCache[epoch][validator].Attestations[inclusionSlot] = targetSlot
+}
+
+func (bigtable *Bigtable) getAttestationWritten(epoch types.Epoch, validator types.ValidatorIndex, inclusionSlot, targetSlot types.Slot) bool {
+	bigtable.epochWriteCacheMux.RLock()
+	defer bigtable.epochWriteCacheMux.RUnlock()
+
+	_, ok := bigtable.epochWriteCache[epoch]
+	if !ok {
+		return false
+	}
+
+	_, ok = bigtable.epochWriteCache[epoch][validator]
+	if !ok {
+		return false
+	}
+
+	return bigtable.epochWriteCache[epoch][validator].Attestations[inclusionSlot] == targetSlot
 }
 
 func (bigtable *Bigtable) Close() {
@@ -484,11 +591,21 @@ func (bigtable *Bigtable) SaveValidatorBalances(epoch uint64, validators []*type
 
 	highestActiveIndex := uint64(0)
 	epochKey := bigtable.reversedPaddedEpoch(epoch)
+
+	skipped := 0
+
 	for _, validator := range validators {
 
 		if validator.Balance > 0 && validator.Index > highestActiveIndex {
 			highestActiveIndex = validator.Index
 		}
+
+		if bigtable.getBalanceWritten(types.Epoch(epoch), types.ValidatorIndex(validator.Index), validator.EffectiveBalance, validator.Balance) {
+			// logrus.Infof("balance %v already written for validator %v in epoch %v", validator.Balance, validator.Index, epoch)
+			skipped++
+			continue
+		}
+		bigtable.setBalanceWritten(types.Epoch(epoch), types.ValidatorIndex(validator.Index), validator.EffectiveBalance, validator.Balance)
 
 		balanceEncoded := make([]byte, 8)
 		binary.LittleEndian.PutUint64(balanceEncoded, validator.Balance)
@@ -508,10 +625,12 @@ func (bigtable *Bigtable) SaveValidatorBalances(epoch uint64, validators []*type
 			errs, err := bigtable.tableValidatorsHistory.ApplyBulk(ctx, keys, muts)
 
 			if err != nil {
+				bigtable.clearEpochfromWriteCache(types.Epoch(epoch))
 				return err
 			}
 
 			for _, err := range errs {
+				bigtable.clearEpochfromWriteCache(types.Epoch(epoch))
 				return err
 			}
 			muts = make([]*gcp_bigtable.Mutation, 0, MAX_BATCH_MUTATIONS)
@@ -523,10 +642,12 @@ func (bigtable *Bigtable) SaveValidatorBalances(epoch uint64, validators []*type
 		errs, err := bigtable.tableValidatorsHistory.ApplyBulk(ctx, keys, muts)
 
 		if err != nil {
+			bigtable.clearEpochfromWriteCache(types.Epoch(epoch))
 			return err
 		}
 
 		for _, err := range errs {
+			bigtable.clearEpochfromWriteCache(types.Epoch(epoch))
 			return err
 		}
 	}
@@ -540,10 +661,11 @@ func (bigtable *Bigtable) SaveValidatorBalances(epoch uint64, validators []*type
 	key := fmt.Sprintf("%s:%s:%s", bigtable.chainId, VALIDATOR_HIGHEST_ACTIVE_INDEX_FAMILY, epochKey)
 	err := bigtable.tableValidatorsHistory.Apply(ctx, key, mut)
 	if err != nil {
+		bigtable.clearEpochfromWriteCache(types.Epoch(epoch))
 		return err
 	}
 
-	// logger.Infof("exported validator balances to bigtable in %v", time.Since(start))
+	logger.Infof("skipped %v writes while writing balance entries", skipped)
 	return nil
 }
 
@@ -600,6 +722,8 @@ func (bigtable *Bigtable) SaveProposalAssignments(epoch uint64, assignments map[
 
 func (bigtable *Bigtable) SaveAttestationDuties(duties map[types.Slot]map[types.ValidatorIndex][]types.Slot) error {
 
+	skipped := 0
+
 	// Initialize in memory last attestation cache lazily
 	bigtable.lastAttestationCacheMux.Lock()
 	if bigtable.lastAttestationCache == nil {
@@ -638,6 +762,14 @@ func (bigtable *Bigtable) SaveAttestationDuties(duties map[types.Slot]map[types.
 				inclusions = append(inclusions, MAX_CL_BLOCK_NUMBER)
 			}
 			for _, inclusionSlot := range inclusions {
+
+				if bigtable.getAttestationWritten(types.Epoch(epoch), types.ValidatorIndex(validator), inclusionSlot, attestedSlot) {
+					// logrus.Infof("attestation %d-%d already written for validator %v in epoch %v", inclusionSlot, attestedSlot, validator, epoch)
+					skipped++
+					continue
+				}
+				bigtable.setAttestationWritten(types.Epoch(epoch), types.ValidatorIndex(validator), inclusionSlot, attestedSlot)
+
 				key := fmt.Sprintf("%s:%s:%s:%s", bigtable.chainId, bigtable.validatorIndexToKey(uint64(validator)), ATTESTATIONS_FAMILY, bigtable.reversedPaddedEpoch(epoch))
 
 				mutInclusionSlot := gcp_bigtable.NewMutation()
@@ -706,7 +838,7 @@ func (bigtable *Bigtable) SaveAttestationDuties(duties map[types.Slot]map[types.
 		}
 	}
 
-	logger.Infof("exported %v attestations to bigtable in %v", writes, time.Since(start))
+	logger.Infof("exported %v attestations to bigtable in %v (skipped %v writes)", writes, time.Since(start), skipped)
 	return nil
 }
 

--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -194,7 +194,7 @@ func Start(client rpc.Client) error {
 			}
 		}
 
-		logger.Printf("exporting %v epochs.", len(epochsToExport))
+		logger.Printf("exporting %v epochs. (%v)", len(epochsToExport), epochsToExport)
 
 		keys := make([]uint64, 0)
 		for k := range epochsToExport {
@@ -393,9 +393,11 @@ func doFullCheck(client rpc.Client, lookback uint64) {
 	// Add not yet exported epochs to the export set (for example during the initial sync)
 	if len(epochs) > 0 && epochs[len(epochs)-1] < head.HeadEpoch {
 		for i := epochs[len(epochs)-1]; i <= head.HeadEpoch; i++ {
+			logrus.Infof("queuing epoch %v for export as it has not yet been exported", i)
 			epochsToExport[i] = true
 		}
 	} else if len(epochs) > 0 && epochs[0] != 0 { // Export the genesis epoch if not yet present in the db
+		logrus.Info("queuing genesis epoch 0 for export")
 		epochsToExport[0] = true
 	} else if len(epochs) == 0 { // No epochs are present int the db
 		for i := uint64(0); i <= head.HeadEpoch; i++ {
@@ -417,7 +419,7 @@ func doFullCheck(client rpc.Client, lookback uint64) {
 		}
 	}
 
-	logger.Printf("exporting %v epochs.", len(epochsToExport))
+	logger.Printf("exporting %v epochs. (%v)", len(epochsToExport), epochsToExport)
 
 	keys := make([]uint64, 0)
 	for k := range epochsToExport {

--- a/types/exporter.go
+++ b/types/exporter.go
@@ -46,7 +46,14 @@ type FinalityCheckpoints struct {
 }
 
 type Slot uint64
+type Epoch uint64
 type ValidatorIndex uint64
+
+type EpochWriteCacheEntry struct {
+	Balance          uint64
+	EffectiveBalance uint64
+	Attestations     map[Slot]Slot
+}
 
 // EpochData is a struct to hold epoch data
 type EpochData struct {


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5448adb</samp>

This pull request adds a cache mechanism to improve the performance of writing validator data to Bigtable, enhances the logging of the exporter module, and fixes a typo and a log level in the statistics command. It also introduces new types for epochs and cache entries. The affected files are `db/bigtable.go`, `exporter/exporter.go`, `cmd/statistics/main.go`, and `types/exporter.go`.
