### PR TITLE
(NOBIDS) fix orphaned attestation view

### DIFF
--- a/db/bigtable.go
+++ b/db/bigtable.go
@@ -1130,7 +1130,7 @@ func (bigtable *Bigtable) GetValidatorAttestationHistory(validators []uint64, st
 	res := make(map[uint64][]*types.ValidatorAttestation, len(validators))
 	resMux := &sync.Mutex{}
 
-	filter := gcp_bigtable.LatestNFilter(1)
+	filter := gcp_bigtable.LatestNFilter(32)
 
 	g, gCtx := errgroup.WithContext(ctx)
 	g.SetLimit(concurrency)

--- a/db/bigtable.go
+++ b/db/bigtable.go
@@ -1421,7 +1421,7 @@ func (bigtable *Bigtable) GetValidatorMissedAttestationHistory(validators []uint
 
 	resMux := &sync.Mutex{}
 
-	filter := gcp_bigtable.LatestNFilter(1)
+	filter := gcp_bigtable.LatestNFilter(32)
 
 	g, gCtx := errgroup.WithContext(ctx)
 	g.SetLimit(concurrency)


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d43fb68</samp>

Changed the Bigtable query filter to fetch more attestation data for validators. This enables showing the attestation history for the last 32 epochs on the explorer website.
