### PR TITLE
Fix grammar

### DIFF
--- a/templates/validator/overview.html
+++ b/templates/validator/overview.html
@@ -115,7 +115,7 @@
           {{ else if lt .EstimatedActivationEpoch 100_000_000 }}
             It is estimated to be activated on <span class="font-weight-bolder" title="{{ .EstimatedActivationTs }}" data-toggle="tooltip" aria-ethereum-date="{{ .EstimatedActivationTs.Unix }}">{{ .EstimatedActivationTs }}</span> during epoch <span class="font-weight-bolder">{{ .EstimatedActivationEpoch }}</span>.
           {{ end }}
-          Make sure your nodes and your client is up and running <em>before</em> the countdown reaches zero.
+          Make sure your nodes and your client are up and running <em>before</em> the countdown reaches zero.
         </div>
         {{ if gt .QueuePosition 0 }}
           <div class="d-flex justify-content-center">


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at eb674d0</samp>

Fixed a grammatical inconsistency in `templates/validator/overview.html`. The message now uses the plural form of "client" when referring to multiple nodes.
