### PR TITLE
(NOBIDS) account for multiple attester duties included in a single slot

### DIFF
--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -266,14 +266,16 @@ func Start(client rpc.Client) error {
 		}
 
 		attDuties := make(map[types.Slot]map[types.ValidatorIndex][]types.Slot)
-		for validator, attestedSlot := range block.AttestationDuties {
-			if attDuties[types.Slot(attestedSlot)] == nil {
-				attDuties[types.Slot(attestedSlot)] = make(map[types.ValidatorIndex][]types.Slot)
+		for validator, attestedSlots := range block.AttestationDuties {
+			for _, attestedSlot := range attestedSlots {
+				if attDuties[types.Slot(attestedSlot)] == nil {
+					attDuties[types.Slot(attestedSlot)] = make(map[types.ValidatorIndex][]types.Slot)
+				}
+				if attDuties[types.Slot(attestedSlot)][types.ValidatorIndex(validator)] == nil {
+					attDuties[types.Slot(attestedSlot)][types.ValidatorIndex(validator)] = []types.Slot{}
+				}
+				attDuties[types.Slot(attestedSlot)][types.ValidatorIndex(validator)] = append(attDuties[types.Slot(attestedSlot)][types.ValidatorIndex(validator)], types.Slot(block.Slot))
 			}
-			if attDuties[types.Slot(attestedSlot)][types.ValidatorIndex(validator)] == nil {
-				attDuties[types.Slot(attestedSlot)][types.ValidatorIndex(validator)] = []types.Slot{}
-			}
-			attDuties[types.Slot(attestedSlot)][types.ValidatorIndex(validator)] = append(attDuties[types.Slot(attestedSlot)][types.ValidatorIndex(validator)], types.Slot(block.Slot))
 		}
 
 		err := db.BigtableClient.SaveAttestationDuties(attDuties)

--- a/handlers/validator.go
+++ b/handlers/validator.go
@@ -1988,7 +1988,6 @@ func ValidatorSync(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		// spew.Dump(syncDuties[validatorIndex])
 		// Search for the missed slots (status = 2), to see if it was only our validator that missed the slot or if the block was missed
 		slotsRange := slots[endIndex : startIndex+1]
 

--- a/rpc/lighthouse.go
+++ b/rpc/lighthouse.go
@@ -433,14 +433,17 @@ func (lc *LighthouseClient) GetEpochData(epoch uint64, skipHistoricBalances bool
 				for validator, duty := range block.SyncDuties {
 					data.SyncDuties[types.Slot(block.Slot)][types.ValidatorIndex(validator)] = duty
 				}
-				for validator, attestedSlot := range block.AttestationDuties {
-					if data.AttestationDuties[types.Slot(attestedSlot)] == nil {
-						data.AttestationDuties[types.Slot(attestedSlot)] = make(map[types.ValidatorIndex][]types.Slot)
+				for validator, attestedSlots := range block.AttestationDuties {
+
+					for _, attestedSlot := range attestedSlots {
+						if data.AttestationDuties[types.Slot(attestedSlot)] == nil {
+							data.AttestationDuties[types.Slot(attestedSlot)] = make(map[types.ValidatorIndex][]types.Slot)
+						}
+						if data.AttestationDuties[types.Slot(attestedSlot)][types.ValidatorIndex(validator)] == nil {
+							data.AttestationDuties[types.Slot(attestedSlot)][types.ValidatorIndex(validator)] = make([]types.Slot, 0, 10)
+						}
+						data.AttestationDuties[types.Slot(attestedSlot)][types.ValidatorIndex(validator)] = append(data.AttestationDuties[types.Slot(attestedSlot)][types.ValidatorIndex(validator)], types.Slot(block.Slot))
 					}
-					if data.AttestationDuties[types.Slot(attestedSlot)][types.ValidatorIndex(validator)] == nil {
-						data.AttestationDuties[types.Slot(attestedSlot)][types.ValidatorIndex(validator)] = make([]types.Slot, 0, 10)
-					}
-					data.AttestationDuties[types.Slot(attestedSlot)][types.ValidatorIndex(validator)] = append(data.AttestationDuties[types.Slot(attestedSlot)][types.ValidatorIndex(validator)], types.Slot(block.Slot))
 				}
 				mux.Unlock()
 			}
@@ -472,9 +475,11 @@ func (lc *LighthouseClient) GetEpochData(epoch uint64, skipHistoricBalances bool
 				data.FutureBlocks[block.Slot][fmt.Sprintf("%x", block.BlockRoot)] = block
 
 				// fill out performed attestation duties
-				for validator, attestedSlot := range block.AttestationDuties {
-					if attestedSlot < types.Slot((epoch+1)*utils.Config.Chain.ClConfig.SlotsPerEpoch) {
-						data.AttestationDuties[types.Slot(attestedSlot)][types.ValidatorIndex(validator)] = append(data.AttestationDuties[types.Slot(attestedSlot)][types.ValidatorIndex(validator)], types.Slot(block.Slot))
+				for validator, attestedSlots := range block.AttestationDuties {
+					for _, attestedSlot := range attestedSlots {
+						if attestedSlot < types.Slot((epoch+1)*utils.Config.Chain.ClConfig.SlotsPerEpoch) {
+							data.AttestationDuties[types.Slot(attestedSlot)][types.ValidatorIndex(validator)] = append(data.AttestationDuties[types.Slot(attestedSlot)][types.ValidatorIndex(validator)], types.Slot(block.Slot))
+						}
 					}
 				}
 				mux.Unlock()
@@ -723,7 +728,7 @@ func (lc *LighthouseClient) blockFromResponse(parsedHeaders *StandardBeaconHeade
 		SignedBLSToExecutionChange: make([]*types.SignedBLSToExecutionChange, len(parsedBlock.Message.Body.SignedBLSToExecutionChange)),
 		BlobKZGCommitments:         make([][]byte, len(parsedBlock.Message.Body.BlobKZGCommitments)),
 		BlobKZGProofs:              make([][]byte, len(parsedBlock.Message.Body.BlobKZGCommitments)),
-		AttestationDuties:          make(map[types.ValidatorIndex]types.Slot),
+		AttestationDuties:          make(map[types.ValidatorIndex][]types.Slot),
 		SyncDuties:                 make(map[types.ValidatorIndex]bool),
 	}
 
@@ -944,7 +949,12 @@ func (lc *LighthouseClient) blockFromResponse(parsedHeaders *StandardBeaconHeade
 				}
 				a.Attesters = append(a.Attesters, validator)
 
-				block.AttestationDuties[types.ValidatorIndex(validator)] = types.Slot(a.Data.Slot)
+				if block.AttestationDuties[types.ValidatorIndex(validator)] == nil {
+					block.AttestationDuties[types.ValidatorIndex(validator)] = []types.Slot{types.Slot(a.Data.Slot)}
+				} else {
+					block.AttestationDuties[types.ValidatorIndex(validator)] = append(block.AttestationDuties[types.ValidatorIndex(validator)], types.Slot(a.Data.Slot))
+				}
+
 			}
 		}
 

--- a/types/exporter.go
+++ b/types/exporter.go
@@ -142,7 +142,7 @@ type Block struct {
 	ExcessBlobGas              uint64
 	BlobKZGCommitments         [][]byte
 	BlobKZGProofs              [][]byte
-	AttestationDuties          map[ValidatorIndex]Slot
+	AttestationDuties          map[ValidatorIndex][]Slot
 	SyncDuties                 map[ValidatorIndex]bool
 }
 


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c1e2fe6</samp>

This pull request updates the code to support multiple attestation duties for validators in the Altair fork of the beacon chain. It changes the data structures and functions in `rpc/lighthouse.go`, `exporter/exporter.go`, and `types/exporter.go` to use slices of slots instead of single slots for attestation duties. It also removes a debugging statement from `handlers/validator.go`.
