### PR TITLE
Nobids/improve stats process performance

### DIFF
--- a/db/bigtable.go
+++ b/db/bigtable.go
@@ -1516,7 +1516,7 @@ func (bigtable *Bigtable) GetValidatorSyncDutiesHistory(validators []uint64, sta
 	batchSize := 1000
 	concurrency := 10
 
-	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(time.Minute*5))
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(time.Minute*20))
 	defer cancel()
 
 	res := make(map[uint64]map[uint64]*types.ValidatorSyncParticipation, len(validators))
@@ -1529,6 +1529,7 @@ func (bigtable *Bigtable) GetValidatorSyncDutiesHistory(validators []uint64, sta
 
 	for i := 0; i < len(validators); i += batchSize {
 
+		i := i
 		upperBound := i + batchSize
 		if len(validators) < upperBound {
 			upperBound = len(validators)
@@ -1543,6 +1544,7 @@ func (bigtable *Bigtable) GetValidatorSyncDutiesHistory(validators []uint64, sta
 			}
 			ranges := bigtable.getValidatorSlotRanges(vals, SYNC_COMMITTEES_FAMILY, startSlot, endSlot)
 
+			logger.Infof("processing GetValidatorSyncDutiesHistory validators batch %v", i)
 			err := bigtable.tableValidatorsHistory.ReadRows(ctx, ranges, func(r gcp_bigtable.Row) bool {
 				keySplit := strings.Split(r.Key(), ":")
 

--- a/db/statistics.go
+++ b/db/statistics.go
@@ -148,6 +148,8 @@ func WriteValidatorStatisticsForDay(day uint64) error {
 		return err
 	}
 
+	logger.Infof("statistics data collection for day %v completed", day)
+
 	// calculate cl income data & update totals
 	for index, data := range validatorData {
 
@@ -610,7 +612,7 @@ func gatherValidatorElIcome(day uint64, data []*types.ValidatorStatsTableDbRow, 
 	}
 	mux.Unlock()
 
-	logger.Infof("gathering el rewards statistics completed, took %v", time.Since(exportStart))
+	logger.Infof("gathering mev & el rewards statistics completed, took %v", time.Since(exportStart))
 	return nil
 }
 
@@ -671,7 +673,7 @@ func gatherValidatorDepositWithdrawals(day uint64, data []*types.ValidatorStatsT
 		"lastSlot":  lastSlot,
 	})
 
-	logger.Infof("gathering withdrawals + deposits")
+	logger.Infof("gathering deposits + withdrawals")
 
 	type resRowDeposits struct {
 		ValidatorIndex uint64 `db:"validatorindex"`
@@ -810,6 +812,15 @@ func gatherValidatorFailedAttestationsStatisticsForDay(validators []uint64, day 
 }
 
 func gatherStatisticsForDay(day int64) ([]*types.ValidatorStatsTableDbRow, error) {
+
+	logger := logger.WithFields(logrus.Fields{
+		"day": day,
+	})
+
+	start := time.Now()
+
+	logger.Infof("gathering statistics for day %v", day)
+
 	ret := make([]*types.ValidatorStatsTableDbRow, 0)
 
 	err := WriterDb.Select(&ret, `SELECT 
@@ -854,6 +865,7 @@ func gatherStatisticsForDay(day int64) ([]*types.ValidatorStatsTableDbRow, error
 		return nil, fmt.Errorf("error statistics for day %v data: %w", day, err)
 	}
 
+	logrus.Infof("gathering statistics completed, took %v", time.Since(start))
 	return ret, nil
 }
 

--- a/types/exporter.go
+++ b/types/exporter.go
@@ -48,6 +48,8 @@ type FinalityCheckpoints struct {
 type Slot uint64
 type Epoch uint64
 type ValidatorIndex uint64
+type SyncCommitteePeriod uint64
+type CommitteeIndex uint64
 
 type EpochWriteCacheEntry struct {
 	Balance          uint64

--- a/types/exporter.go
+++ b/types/exporter.go
@@ -696,9 +696,24 @@ type ValidatorStatsTableDbRow struct {
 	ClRewardsGWei      int64 `db:"cl_rewards_gwei"`
 	ClRewardsGWeiTotal int64 `db:"cl_rewards_gwei_total"`
 
+	ClPerformance1d   int64 `db:"-"`
+	ClPerformance7d   int64 `db:"-"`
+	ClPerformance31d  int64 `db:"-"`
+	ClPerformance365d int64 `db:"-"`
+
 	ElRewardsWei      decimal.Decimal `db:"el_rewards_wei"`
 	ElRewardsWeiTotal decimal.Decimal `db:"el_rewards_wei_total"`
 
+	ElPerformance1d   decimal.Decimal `db:"-"`
+	ElPerformance7d   decimal.Decimal `db:"-"`
+	ElPerformance31d  decimal.Decimal `db:"-"`
+	ElPerformance365d decimal.Decimal `db:"-"`
+
 	MEVRewardsWei      decimal.Decimal `db:"mev_rewards_wei"`
 	MEVRewardsWeiTotal decimal.Decimal `db:"mev_rewards_wei_total"`
+
+	MEVPerformance1d   decimal.Decimal `db:"-"`
+	MEVPerformance7d   decimal.Decimal `db:"-"`
+	MEVPerformance31d  decimal.Decimal `db:"-"`
+	MEVPerformance365d decimal.Decimal `db:"-"`
 }


### PR DESCRIPTION
Removes min & max fields from the validator stats calculation. Drastic speed up for the statistics process for networks with a huge validator set.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ae07c2b</samp>

This pull request enhances the statistics module to support different node types and sync committee data. It uses the `rpc` package to query nodes directly, and fixes some bugs and performance issues in the database and exporter functions. It also adds new types to the `types` package for sync committee data.
