### PR TITLE
BIDS-2561/use_eth_getblockreciepts

### DIFF
--- a/local-deployment/network-params.json
+++ b/local-deployment/network-params.json
@@ -25,7 +25,7 @@
       "deneb_fork_epoch": 999999999
     },
     "global_client_log_level": "info",
-    "start_tx_spammer": false,
+    "start_tx_spammer": true,
     "start_blob_spammer": false
   }
   

--- a/rpc/erigon.go
+++ b/rpc/erigon.go
@@ -166,7 +166,7 @@ func (client *ErigonClient) GetBlock(number int64, traceMode string) (*types.Eth
 		sender, err := geth_types.Sender(geth_types.NewCancunSigner(tx.ChainId()), tx)
 		if err != nil {
 			from, _ = hex.DecodeString("abababababababababababababababababababab")
-			logrus.Errorf("error converting tx %v to msg: %w", tx.Hash(), err)
+			logrus.Errorf("error converting tx %v to msg: %v", tx.Hash(), err)
 		} else {
 			from = sender.Bytes()
 		}

--- a/rpc/erigon.go
+++ b/rpc/erigon.go
@@ -337,9 +337,7 @@ func (client *ErigonClient) GetBlock(number int64, traceMode string) (*types.Eth
 	timings.Receipts = time.Since(start)
 	start = time.Now()
 
-	for i := range receipts {
-		r := receipts[i]
-
+	for i, r := range receipts {
 		c.Transactions[i].ContractAddress = r.ContractAddress[:]
 		c.Transactions[i].CommulativeGasUsed = r.CumulativeGasUsed
 		c.Transactions[i].GasUsed = r.GasUsed

--- a/rpc/erigon.go
+++ b/rpc/erigon.go
@@ -218,7 +218,7 @@ func (client *ErigonClient) GetBlock(number int64, traceMode string) (*types.Eth
 				if traceMode == "parity" {
 					return fmt.Errorf("error tracing block via parity style traces (%v), %v: %w", block.Number(), block.Hash(), err)
 				} else {
-					logger.Errorf("error tracing block via parity style traces (%v), %v: %w", block.Number(), block.Hash(), err)
+					logger.Errorf("error tracing block via parity style traces (%v), %v: %v", block.Number(), block.Hash(), err)
 
 				}
 				traceError = err


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d913be0</samp>

This pull request adds support for `Erigon` as an Ethereum client and improves the efficiency of the `GetBlock` function in `./rpc/erigon.go`. It also enables the transaction spammer tool in the local deployment configuration file `network-params.json` to test the network performance.
