### PR TITLE
(NOBIDS) add slot to proposal notifications

### DIFF
--- a/services/notifications.go
+++ b/services/notifications.go
@@ -1265,6 +1265,7 @@ func collectBlockProposalNotifications(notificationsByUserID map[uint64]map[type
 				EventName:      eventName,
 				Reward:         event.ExecRewardETH,
 				EventFilter:    hex.EncodeToString(pubkey),
+				Slot:           event.Slot,
 			}
 			if _, exists := notificationsByUserID[*sub.UserID]; !exists {
 				notificationsByUserID[*sub.UserID] = map[types.EventName][]types.Notification{}


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e4cdb72</samp>

Add slot number to block proposal notifications. This change enhances the `services/notifications.go` file to include the slot number of each block proposal event in the notification data sent to users.
