### PR TITLE
(BIDS-2503) Fix parameter handling in query

### DIFF
--- a/handlers/api.go
+++ b/handlers/api.go
@@ -1028,8 +1028,6 @@ func getSyncCommitteeInfoForValidators(validators []uint64, period uint64) ([]in
 		WHERE period = $1 AND validatorindex = ANY($2)
 		GROUP BY period`,
 		period,
-		utils.Config.Chain.ClConfig.EpochsPerSyncCommitteePeriod,
-		utils.Config.Chain.ClConfig.AltairForkEpoch,
 		pq.Array(validators),
 	)
 	if err != nil {


### PR DESCRIPTION
This PR fixes the parameter handling for the query used in `getSyncCommitteeInfoForValidators`.