### PR TITLE
Bids 2567/stats page for validators without index

### DIFF
--- a/templates/404notfound.html
+++ b/templates/404notfound.html
@@ -10,7 +10,7 @@
       <div class="container">
         <div style="padding-top: 2rem;" class="row justify-content-between align-items-center">
           <div class="col-md-6 mb-5">
-            <h2 style="font-size:1.8rem;">Sorry, the page you are looking for could not be found</h2>
+            <h2 style="font-size:1.8rem;">Sorry, the page you are looking for could not be found.</h2>
           </div>
           <div class="col-md-5 p-3">
             {{ template "relax_svg" }}

--- a/templates/dashboardnotfound.html
+++ b/templates/dashboardnotfound.html
@@ -3,7 +3,7 @@
 {{ define "content" }}
   {{ with .Data }}
     <div class="container mt-2">
-      <h1 class="mt-4 text-center">Sorry but we could not find the dashboard you are looking for</h1>
+      <h1 class="mt-4 text-center">Sorry but we could not find the dashboard you are looking for.</h1>
     </div>
   {{ end }}
 {{ end }}

--- a/templates/epochnotfound.html
+++ b/templates/epochnotfound.html
@@ -21,7 +21,7 @@
       </div>
       <div class="card">
         <div class="card-body">
-          <div class="d-1">Sorry but we could not find the epoch you are looking for</div>
+          <div class="d-1">Sorry but we could not find the epoch you are looking for.</div>
         </div>
       </div>
     </div>

--- a/templates/eth1txnotfound.html
+++ b/templates/eth1txnotfound.html
@@ -20,7 +20,7 @@
       </div>
       <div class="card">
         <div class="card-body">
-          <div class="d-1">Sorry but we could not find the tx you are looking for</div>
+          <div class="d-1">Sorry but we could not find the tx you are looking for.</div>
         </div>
       </div>
     </div>

--- a/templates/slotnotfound.html
+++ b/templates/slotnotfound.html
@@ -21,7 +21,7 @@
       </div>
       <div class="card">
         <div class="card-body">
-          <div class="d-1">Sorry but we could not find the {{ if eq . "block" }}block{{ else }}slot{{ end }} you are looking for</div>
+          <div class="d-1">Sorry but we could not find the {{ if eq . "block" }}block{{ else }}slot{{ end }} you are looking for.</div>
         </div>
       </div>
     </div>

--- a/templates/validator/heading.html
+++ b/templates/validator/heading.html
@@ -36,11 +36,13 @@
               </button>
             </span>
           {{ end }}
-          <span class="mx-1" data-toggle="tooltip" title="View daily statistics">
-            <a class="btn btn-dark text-white btn-sm" href="/validator/{{ .Index }}/stats">
-              <i class="fas fa-table"></i>
-            </a>
-          </span>
+          {{ if (and (ne .Status "deposited") (ne .Status "deposited_invalid") (ne .Status "pending")) }}
+            <span class="mx-1" data-toggle="tooltip" title="View daily statistics">
+              <a class="btn btn-dark text-white btn-sm" href="/validator/{{ .Index }}/stats">
+                <i class="fas fa-table"></i>
+              </a>
+            </span>
+          {{ end }}
         </h1>
       </div>
       <nav aria-label="breadcrumb">

--- a/templates/validator/validatornotfound.html
+++ b/templates/validator/validatornotfound.html
@@ -22,7 +22,6 @@
       <div class="card">
         <div class="card-body">
           <div class="d-1">Sorry, but we could not find the validator you are looking for.</div>
-          <div class="d-1">Stay calm, depending on the gas price of the transaction, <a href="https://kb.beaconcha.in/ethereum-2.0-and-depositing-process">it may still be in the mempool.</a></div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
This PR mainly hides the stats tables on the validator page whenever a validator that is still only "deposited" or "pending" is shown.

Furthermore it improves and unifies the error logging within `validator.go`, removes a sentence that makes so sense on `validatornotfound.html` and adds periods to all "not found"-pages.