### PR TITLE
(BIDS-2591) Improve return value for dashboard effectiveness

### DIFF
--- a/handlers/dashboard.go
+++ b/handlers/dashboard.go
@@ -988,7 +988,8 @@ func DashboardDataEffectiveness(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if len(activeValidators) == 0 {
-		w.WriteHeader(http.StatusNoContent)
+		// valid 200 response with empty data
+		w.Write([]byte(`{}`))
 		return
 	}
 

--- a/handlers/dashboard.go
+++ b/handlers/dashboard.go
@@ -988,7 +988,7 @@ func DashboardDataEffectiveness(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if len(activeValidators) == 0 {
-		http.Error(w, "Invalid query", http.StatusBadRequest)
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 

--- a/static/js/dashboard.js
+++ b/static/js/dashboard.js
@@ -975,6 +975,7 @@ $(document).ready(function () {
       fetch(`/dashboard/data/effectiveness${getValidatorQueryString()}`, {
         method: "GET",
       }).then((res) => {
+        if (res.status !== 200) return
         res.json().then((data) => {
           let sum = 0.0
           for (let eff of data) {

--- a/static/js/dashboard.js
+++ b/static/js/dashboard.js
@@ -975,8 +975,10 @@ $(document).ready(function () {
       fetch(`/dashboard/data/effectiveness${getValidatorQueryString()}`, {
         method: "GET",
       }).then((res) => {
-        if (res.status !== 200) return
         res.json().then((data) => {
+          if (Object.keys(data).length === 0) {
+            return
+          }
           let sum = 0.0
           for (let eff of data) {
             sum += eff


### PR DESCRIPTION
This PR causes `/dashboard/data/effectiveness` to return 204 (no content) if no active validator is part of the query. Before, 400 (bad request) was returned which is not correct as a dashboard for only an exited validator is still valid.