### PR TITLE
(NOBIDS) frontend: order by block per default on deposits-page

### DIFF
--- a/templates/deposits.html
+++ b/templates/deposits.html
@@ -21,7 +21,7 @@
               stateLoadCallback: function (settings) {
                 return JSON.parse(localStorage.getItem("DataTables_" + settings.sInstance))
               },
-              order: [[4, 'desc']],
+              order: [[6, 'desc']],
               searching: true,
               ajax: dataTableLoader('/validators/initiated-deposits/data'),
               pagingType: 'input',


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f1ec95e</samp>

Changed the default sorting of the deposits table in `templates/deposits.html` to show the deposit status column first. This improves the user experience by highlighting the most relevant information.
