### PR TITLE
(BIDS-2606) fix validator queue update

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -657,8 +657,8 @@ func SetBlockStatus(blocks []*types.CanonBlock) error {
 }
 
 // SaveValidatorQueue will save the validator queue into the database
-func SaveValidatorQueue(validators *types.ValidatorQueue) error {
-	_, err := WriterDb.Exec(`
+func SaveValidatorQueue(validators *types.ValidatorQueue, tx *sqlx.Tx) error {
+	_, err := tx.Exec(`
 		INSERT INTO queue (ts, entering_validators_count, exiting_validators_count)
 		VALUES (date_trunc('hour', now()), $1, $2)
 		ON CONFLICT (ts) DO UPDATE SET

--- a/exporter/slot_exporter.go
+++ b/exporter/slot_exporter.go
@@ -181,12 +181,12 @@ func RunSlotExporter(client rpc.Client, firstRun bool) error {
 					logger.Infof("exporting validation queue")
 					queue, err := client.GetValidatorQueue()
 					if err != nil {
-						return fmt.Errorf("error retrieving validator queue data: %v", err)
+						return fmt.Errorf("error retrieving validator queue data: %w", err)
 					}
 
 					err = db.SaveValidatorQueue(queue, tx)
 					if err != nil {
-						return err
+						return fmt.Errorf("error saving validator queue data: %w", err)
 					}
 				}
 

--- a/exporter/slot_exporter.go
+++ b/exporter/slot_exporter.go
@@ -177,7 +177,19 @@ func RunSlotExporter(client rpc.Client, firstRun bool) error {
 					if err != nil {
 						return err
 					}
+
+					logger.Infof("exporting validation queue")
+					queue, err := client.GetValidatorQueue()
+					if err != nil {
+						return fmt.Errorf("error retrieving validator queue data: %v", err)
+					}
+
+					err = db.SaveValidatorQueue(queue, tx)
+					if err != nil {
+						return err
+					}
 				}
+
 			}
 		} else { // check if a late slot has been proposed in the meantime
 			if len(dbSlot.BlockRoot) < 32 && header != nil { // we have no slot in the db, but the node has a slot, export it


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7417ef8</samp>

Refactored the `db` package to use transactions for exporting data, and added the functionality of exporting the validator queue data from the beacon node API to the database. This improves performance and consistency, and enables displaying the validator queue on the explorer website.
