### PR TITLE
Premium maxlimit for withdrawal api search

### DIFF
--- a/handlers/api.go
+++ b/handlers/api.go
@@ -3768,10 +3768,8 @@ func ApiWithdrawalCredentialsValidators(w http.ResponseWriter, r *http.Request) 
 	limit := parseUintWithDefault(limitQuery, 10)
 
 	// We set a max limit to limit the request call time.
-	var maxLimit uint64 = uint64(getUserPremium(r).MaxValidators)
-	if maxLimit < 200 {
-		maxLimit = 200
-	}
+	var maxLimit uint64 = utilMath.MaxU64(200, uint64(getUserPremium(r).MaxValidators))
+
 	limit = utilMath.MinU64(limit, maxLimit)
 
 	result := []struct {

--- a/handlers/api.go
+++ b/handlers/api.go
@@ -3768,7 +3768,10 @@ func ApiWithdrawalCredentialsValidators(w http.ResponseWriter, r *http.Request) 
 	limit := parseUintWithDefault(limitQuery, 10)
 
 	// We set a max limit to limit the request call time.
-	const maxLimit uint64 = 200
+	var maxLimit uint64 = uint64(getUserPremium(r).MaxValidators)
+	if maxLimit < 200 {
+		maxLimit = 200
+	}
 	limit = utilMath.MinU64(limit, maxLimit)
 
 	result := []struct {


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 199088d</samp>

Adjust the maximum number of validators that can be queried by the API based on the user's premium status. Modify `maxLimit` in `handlers/api.go` to use the `MaxValidators` field from the `getUserPremium` function.
