### PR TITLE
(NOBIDS) Send server error instead of user error

### DIFF
--- a/db/bigtable_eth1.go
+++ b/db/bigtable_eth1.go
@@ -39,7 +39,7 @@ import (
 )
 
 // when changing this, you will have to update the swagger docu for func ApiEth1Address too
-var ECR20TokensPerAddressLimit = uint64(200)
+const ECR20TokensPerAddressLimit = uint64(200)
 
 var ErrBlockNotFound = errors.New("block not found")
 

--- a/handlers/api_eth1.go
+++ b/handlers/api_eth1.go
@@ -392,7 +392,7 @@ func ApiEth1AddressERC20Tokens(w http.ResponseWriter, r *http.Request) {
 	metadata, err := db.BigtableClient.GetMetadataForAddress(common.FromHex(address), uint64(offset), uint64(limit))
 	if err != nil {
 		utils.LogError(err, "error could not get metadata for address", 0, errFields)
-		sendErrorResponse(w, r.URL.String(), "error could not get metadata for address")
+		sendServerErrorResponse(w, r.URL.String(), "error could not get metadata for address")
 		return
 	}
 

--- a/handlers/api_eth1.go
+++ b/handlers/api_eth1.go
@@ -317,7 +317,7 @@ func ApiEth1Address(w http.ResponseWriter, r *http.Request) {
 	metadata, err := db.BigtableClient.GetMetadataForAddress(common.FromHex(address), 0, 200)
 	if err != nil {
 		logger.Errorf("error retrieving metadata for address: %v route: %v err: %v", address, r.URL.String(), err)
-		sendErrorResponse(w, r.URL.String(), "error could not get metadata for address")
+		sendServerErrorResponse(w, r.URL.String(), "error could not get metadata for address")
 		return
 	}
 


### PR DESCRIPTION
This PR causes the API endpoints `/execution/address/{address}` and `/execution/address/{address}/erc20tokens` to return 500 instead of 400 when metadata could not be fetched.
Furthermore, `ECR20TokensPerAddressLimit` is changed to const.