### PR TITLE
Nobids/prater reexport tool

### DIFF
--- a/cmd/misc/main.go
+++ b/cmd/misc/main.go
@@ -1073,7 +1073,8 @@ OUTER:
 
 		// get max validator index for day
 		firstEpoch, _ := utils.GetFirstAndLastEpochForDay(day + 1)
-		maxValidatorIndex, err := db.BigtableClient.GetMaxValidatorindexForEpoch(firstEpoch)
+		var maxValidatorIndex uint64
+		err := db.ReaderDb.Get(&maxValidatorIndex, `SELECT MAX(validatorindex) FROM validator_stats WHERE day = $1`, day)
 		if err != nil {
 			utils.LogFatal(err, "error in GetMaxValidatorindexForEpoch: could not get max validator index", 0, map[string]interface{}{
 				"epoch": firstEpoch,

--- a/cmd/misc/main.go
+++ b/cmd/misc/main.go
@@ -1076,11 +1076,11 @@ OUTER:
 		var maxValidatorIndex uint64
 		err := db.ReaderDb.Get(&maxValidatorIndex, `SELECT MAX(validatorindex) FROM validator_stats WHERE day = $1`, day)
 		if err != nil {
-			utils.LogFatal(err, "error in GetMaxValidatorindexForEpoch: could not get max validator index", 0, map[string]interface{}{
+			utils.LogFatal(err, "error: could not get max validator index", 0, map[string]interface{}{
 				"epoch": firstEpoch,
 			})
 		} else if maxValidatorIndex == uint64(0) {
-			utils.LogFatal(err, "error in GetMaxValidatorindexForEpoch: no validator found", 0, map[string]interface{}{
+			utils.LogFatal(err, "error: no validator found", 0, map[string]interface{}{
 				"epoch": firstEpoch,
 			})
 		}


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3d891c1</samp>

Refactor `cmd/misc/main.go` to use PostgreSQL instead of Bigtable for querying validator indices. Simplify the query and update the error messages.
