### PR TITLE
(BIDS-2634) reordered transactions, fix almost-empty table

### DIFF
--- a/db/bigtable_eth1.go
+++ b/db/bigtable_eth1.go
@@ -2120,7 +2120,7 @@ func (bigtable *Bigtable) GetEth1TxsForAddress(prefix string, limit int64) ([]*t
 		return true
 	})
 	if err != nil {
-		logger.WithError(err).WithField("prefix", prefix).WithField("limit", limit).Errorf("error reading rows in bigtable_eth1 / GetEth1TxForAddress")
+		logger.WithError(err).WithField("prefix", prefix).WithField("limit", limit).Errorf("error reading rows in bigtable_eth1 / GetEth1TxsForAddress")
 		return nil, nil, err
 	}
 

--- a/db/bigtable_eth1.go
+++ b/db/bigtable_eth1.go
@@ -1994,7 +1994,7 @@ func (bigtable *Bigtable) rearrangeReversePaddedIndexZero(ctx context.Context, i
 	}
 
 	// first find out if we've a (sub)transaction with index 0 whose block/transaction has maybe not been completed by the request
-	// if we find one, make sure we do. So we won't miss that (i)tx next time (=> ignoring the query limit)
+	// if we find one, make sure we do complete the request by querying the remainder from bigtable. So we won't miss that (i)tx next time (=> ignoring the query limit)
 	for i := 0; i < len(indexes); i++ {
 		splits := strings.Split(indexes[i], ":")
 		if len(splits) < 7 {

--- a/db/bigtable_eth1.go
+++ b/db/bigtable_eth1.go
@@ -2129,7 +2129,8 @@ func (bigtable *Bigtable) GetAddressTransactionsTableData(address []byte, pageTo
 	}
 
 	tableData := make([][]interface{}, len(transactions))
-	for i, t := range transactions {
+	for i := len(transactions) - 1; i >= 0; i-- {
+		t := transactions[i]
 		fromName := names[string(t.From)]
 		var contractInteraction types.ContractInteractionType
 		if len(contractInteractionTypes) > i {
@@ -2440,7 +2441,8 @@ func (bigtable *Bigtable) GetAddressBlobTableData(address []byte, pageToken stri
 	}
 
 	tableData := make([][]interface{}, len(transactions))
-	for i, t := range transactions {
+	for i := len(transactions) - 1; i >= 0; i-- {
+		t := transactions[i]
 
 		fromName := names[string(t.From)]
 		toName := names[string(t.To)]
@@ -2898,7 +2900,8 @@ func (bigtable *Bigtable) GetAddressErc20TableData(address []byte, pageToken str
 
 	tableData := make([][]interface{}, len(transactions))
 
-	for i, t := range transactions {
+	for i := len(transactions) - 1; i >= 0; i-- {
+		t := transactions[i]
 
 		fromName := names[string(t.From)]
 		toName := names[string(t.To)]
@@ -3021,7 +3024,8 @@ func (bigtable *Bigtable) GetAddressErc721TableData(address []byte, pageToken st
 	}
 
 	tableData := make([][]interface{}, len(transactions))
-	for i, t := range transactions {
+	for i := len(transactions) - 1; i >= 0; i-- {
+		t := transactions[i]
 		fromName := names[string(t.From)]
 		toName := names[string(t.To)]
 
@@ -3132,7 +3136,8 @@ func (bigtable *Bigtable) GetAddressErc1155TableData(address []byte, pageToken s
 		return nil, err
 	}
 
-	for i, t := range transactions {
+	for i := len(transactions) - 1; i >= 0; i-- {
+		t := transactions[i]
 		fromName := names[string(t.From)]
 		toName := names[string(t.To)]
 

--- a/db/bigtable_eth1.go
+++ b/db/bigtable_eth1.go
@@ -1971,15 +1971,15 @@ func (sbi SortByIndexes) Less(i, j int) bool {
 	}
 	// tx idx
 	if i_splits[6] != j_splits[6] {
-		if i_splits[6] == "10000" || j_splits[6] == "10000" {
-			return j_splits[6] == "10000"
+		if i_splits[6] == strconv.Itoa(TX_PER_BLOCK_LIMIT) || j_splits[6] == strconv.Itoa(TX_PER_BLOCK_LIMIT) {
+			return j_splits[6] == strconv.Itoa(TX_PER_BLOCK_LIMIT)
 		}
 		return i_splits[6] < j_splits[6]
 	}
 	// itx idx
 	if len(i_splits) > 7 && i_splits[7] != j_splits[7] {
-		if i_splits[7] == "100000" || j_splits[7] == "100000" {
-			return j_splits[7] == "100000"
+		if i_splits[7] == strconv.Itoa(ITX_PER_TX_LIMIT) || j_splits[7] == strconv.Itoa(ITX_PER_TX_LIMIT) {
+			return j_splits[7] == strconv.Itoa(ITX_PER_TX_LIMIT)
 		}
 		return i_splits[7] < j_splits[7]
 	}
@@ -2002,7 +2002,7 @@ func (bigtable *Bigtable) rearrangeReversePaddedIndexZero(ctx context.Context, i
 			continue
 		}
 
-		if splits[6] != "10000" && len(splits) > 7 && splits[7] != "100000" {
+		if splits[6] != strconv.Itoa(TX_PER_BLOCK_LIMIT) && len(splits) > 7 && splits[7] != strconv.Itoa(ITX_PER_TX_LIMIT) {
 			continue
 		}
 		// check if results list all following (i)txs already
@@ -2052,7 +2052,7 @@ func skipBlockIfLastTxIndex(key string) string {
 		utils.LogError(nil, "unexpected bigtable transaction index", 0, map[string]interface{}{"index": key})
 		return key
 	}
-	if len(splits) == 8 && splits[7] == "100000" && splits[6] != "10000" {
+	if len(splits) == 8 && splits[7] == strconv.Itoa(ITX_PER_TX_LIMIT) && splits[6] != strconv.Itoa(TX_PER_BLOCK_LIMIT) {
 		i, err := strconv.Atoi(splits[6])
 		if err != nil {
 			utils.LogError(err, "error converting bigtable transaction index", 0, map[string]interface{}{"index": splits[6]})
@@ -2061,7 +2061,7 @@ func skipBlockIfLastTxIndex(key string) string {
 		}
 		splits = splits[:7]
 	}
-	if splits[6] == "10000" {
+	if splits[6] == strconv.Itoa(TX_PER_BLOCK_LIMIT) {
 		i, err := strconv.Atoi(splits[5])
 		if err != nil {
 			utils.LogError(err, "error converting bigtable transaction index timestamp", 0, map[string]interface{}{"index": splits[5]})

--- a/db/bigtable_eth1.go
+++ b/db/bigtable_eth1.go
@@ -2073,7 +2073,7 @@ func skipBlockIfLastTxIndex(key string) string {
 	return key
 }
 
-func (bigtable *Bigtable) GetEth1TxForAddress(prefix string, limit int64) ([]*types.Eth1TransactionIndexed, string, error) {
+func (bigtable *Bigtable) GetEth1TxsForAddress(prefix string, limit int64) ([]*types.Eth1TransactionIndexed, []string, error) {
 
 	tmr := time.AfterFunc(REPORT_TIMEOUT, func() {
 		logger.WithFields(logrus.Fields{
@@ -2130,7 +2130,8 @@ func (bigtable *Bigtable) GetEth1TxForAddress(prefix string, limit int64) ([]*ty
 		}
 	}
 
-	return data, skipBlockIfLastTxIndex(indexes[len(indexes)-1]), nil
+	indexes[len(indexes)-1] = skipBlockIfLastTxIndex(indexes[len(indexes)-1])
+	return data, indexes, nil
 }
 
 func (bigtable *Bigtable) GetAddressesNamesArMetadata(names *map[string]string, inputMetadata *map[string]*types.ERC20Metadata) (map[string]string, map[string]*types.ERC20Metadata, error) {
@@ -2662,7 +2663,8 @@ func (bigtable *Bigtable) GetEth1ItxsForAddress(prefix string, limit int64) ([]*
 		}
 	}
 
-	return data, skipBlockIfLastTxIndex(indexes[len(indexes)-1]), nil
+	indexes[len(indexes)-1] = skipBlockIfLastTxIndex(indexes[len(indexes)-1])
+	return data, indexes, nil
 }
 
 func (bigtable *Bigtable) GetAddressInternalTableData(address []byte, pageToken string) (*types.DataTableResponse, error) {

--- a/handlers/eth1Transactions.go
+++ b/handlers/eth1Transactions.go
@@ -55,7 +55,7 @@ func getTransactionDataStartingWithPageToken(pageToken string) *types.DataTableR
 			}
 		}
 	}
-	if pageTokenId == 0 {
+	if pageTokenId == 0 && pageToken != "0" {
 		pageTokenId = services.LatestEth1BlockNumber()
 	}
 
@@ -87,7 +87,8 @@ func getTransactionDataStartingWithPageToken(pageToken string) *types.DataTableR
 		}
 
 		var wg errgroup.Group
-		for i, v := range t {
+		for i := len(t) - 1; i >= 0; i-- {
+			v := t[i]
 			wg.Go(func() error {
 				method := "Transfer"
 				{

--- a/templates/execution/address.html
+++ b/templates/execution/address.html
@@ -245,9 +245,9 @@
                 content.innerHTML = col
                 el.appendChild(content)
                 infLoading.insertAdjacentElement("beforebegin", el)
-                drawCallback()
               }
             }
+            drawCallback()
           } else if (data.pagingToken === "") {
             infLoading.remove()
           } else if (data && data.data && data.data.length == 0) {

--- a/templates/execution/token.html
+++ b/templates/execution/token.html
@@ -193,9 +193,9 @@
                 el.classList.add('text-truncate')
                 el.innerHTML = col
                 infLoading.insertAdjacentElement("beforebegin", el)
-                drawCallback()
               }
              }
+             drawCallback()
            } else if (data && data.data) {
             if (data.data.length < 25) {
               infLoading.innerText = ''


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a7a7b97</samp>

This pull request fixes some issues with the eth1 transactions API and the Bigtable database query. It improves the pagination and order of the `eth1Transactions.go` endpoint and prevents an error in the `GetBlocksDescending` function of `bigtable_eth1.go`.
