### PR TITLE
(BIDS-2547) added ❗to failed transactions

### DIFF
--- a/db/bigtable_eth1.go
+++ b/db/bigtable_eth1.go
@@ -2140,7 +2140,7 @@ func (bigtable *Bigtable) GetAddressTransactionsTableData(address []byte, search
 		method := bigtable.GetMethodLabel(t.MethodId, t.InvokesContract)
 
 		tableData[i] = []interface{}{
-			utils.FormatTransactionHash(t.Hash),
+			utils.FormatTransactionHash(t.Hash, t.ErrorMsg == ""),
 			utils.FormatMethod(method),
 			utils.FormatBlockNumber(t.BlockNumber),
 			utils.FormatTimestamp(t.Time.AsTime().Unix()),
@@ -2439,7 +2439,7 @@ func (bigtable *Bigtable) GetAddressBlobTableData(address []byte, search string,
 		to := utils.FormatAddress(t.To, nil, toName, false, false, !bytes.Equal(t.To, address))
 
 		tableData[i] = []interface{}{
-			utils.FormatTransactionHash(t.Hash),
+			utils.FormatTransactionHash(t.Hash, t.ErrorMsg == ""),
 			utils.FormatBlockNumber(t.BlockNumber),
 			utils.FormatTimestamp(t.Time.AsTime().Unix()),
 			from,
@@ -2562,7 +2562,7 @@ func (bigtable *Bigtable) GetAddressInternalTableData(address []byte, search str
 		to := utils.FormatAddress(t.To, nil, toName, false, false, !bytes.Equal(t.To, address))
 
 		tableData[i] = []interface{}{
-			utils.FormatTransactionHash(t.ParentHash),
+			utils.FormatTransactionHash(t.ParentHash, true),
 			utils.FormatBlockNumber(t.BlockNumber),
 			utils.FormatTimestamp(t.Time.AsTime().Unix()),
 			from,
@@ -2888,7 +2888,7 @@ func (bigtable *Bigtable) GetAddressErc20TableData(address []byte, search string
 		}
 
 		tableData[i] = []interface{}{
-			utils.FormatTransactionHash(t.ParentHash),
+			utils.FormatTransactionHash(t.ParentHash, true),
 			utils.FormatBlockNumber(t.BlockNumber),
 			utils.FormatTimestamp(t.Time.AsTime().Unix()),
 			from,
@@ -3006,7 +3006,7 @@ func (bigtable *Bigtable) GetAddressErc721TableData(address string, search strin
 		to := utils.FormatAddress(t.To, t.TokenAddress, toName, false, false, fmt.Sprintf("%x", t.To) != address)
 
 		tableData[i] = []interface{}{
-			utils.FormatTransactionHash(t.ParentHash),
+			utils.FormatTransactionHash(t.ParentHash, true),
 			utils.FormatBlockNumber(t.BlockNumber),
 			utils.FormatTimestamp(t.Time.AsTime().Unix()),
 			from,
@@ -3120,7 +3120,7 @@ func (bigtable *Bigtable) GetAddressErc1155TableData(address string, search stri
 		to := utils.FormatAddress(t.To, t.TokenAddress, toName, false, false, fmt.Sprintf("%x", t.To) != address)
 
 		tableData[i] = []interface{}{
-			utils.FormatTransactionHash(t.ParentHash),
+			utils.FormatTransactionHash(t.ParentHash, true),
 			utils.FormatBlockNumber(t.BlockNumber),
 			utils.FormatTimestamp(t.Time.AsTime().Unix()),
 			from,
@@ -3962,7 +3962,7 @@ func (bigtable *Bigtable) GetTokenTransactionsTableData(token []byte, address []
 		}
 
 		tableData[i] = []interface{}{
-			utils.FormatTransactionHash(t.ParentHash),
+			utils.FormatTransactionHash(t.ParentHash, true),
 			utils.FormatTimestamp(t.Time.AsTime().Unix()),
 			from,
 			utils.FormatInOutSelf(address, t.From, t.To),

--- a/handlers/eth1Block.go
+++ b/handlers/eth1Block.go
@@ -184,7 +184,7 @@ func GetExecutionBlockPageData(number uint64, limit int) (*types.Eth1BlockPageDa
 
 		txs = append(txs, types.Eth1BlockPageTransaction{
 			Hash:          fmt.Sprintf("%#x", tx.Hash),
-			HashFormatted: utils.FormatAddressWithLimits(tx.Hash, "", false, "tx", 15, 18, true),
+			HashFormatted: utils.FormatTransactionHash(tx.Hash, tx.ErrorMsg == ""),
 			From:          fmt.Sprintf("%#x", tx.From),
 			FromFormatted: utils.FormatAddressWithLimits(tx.From, names[string(tx.From)], false, "address", 15, 20, true),
 			To:            fmt.Sprintf("%#x", tx.To),

--- a/utils/eth1.go
+++ b/utils/eth1.go
@@ -88,7 +88,7 @@ func FormatTransactionHash(hash []byte, successful bool) template.HTML {
 	}
 	failedStr := ""
 	if !successful {
-		failedStr = "❗"
+		failedStr = `<span data-toggle="tooltip" title="Transaction failed">❗</span>`
 	}
 	return template.HTML(fmt.Sprintf(`<a class="text-monospace" href="/tx/0x%x">0x%x…%x</a>%s`, hash, hash[:3], hash[len(hash)-3:], failedStr))
 }

--- a/utils/eth1.go
+++ b/utils/eth1.go
@@ -82,11 +82,15 @@ func FormatBlockHash(hash []byte) template.HTML {
 	return template.HTML(fmt.Sprintf(`<a class="text-monospace" href="/block/0x%x">0x%x…%x</a> %v`, hash, hash[:2], hash[len(hash)-2:], CopyButton(hex.EncodeToString(hash))))
 }
 
-func FormatTransactionHash(hash []byte) template.HTML {
+func FormatTransactionHash(hash []byte, successful bool) template.HTML {
 	if len(hash) < 20 {
 		return template.HTML("N/A")
 	}
-	return template.HTML(fmt.Sprintf(`<a class="text-monospace" href="/tx/0x%x">0x%x…%x</a>`, hash, hash[:3], hash[len(hash)-3:]))
+	failedStr := ""
+	if !successful {
+		failedStr = "❗"
+	}
+	return template.HTML(fmt.Sprintf(`<a class="text-monospace" href="/tx/0x%x">0x%x…%x</a>%s`, hash, hash[:3], hash[len(hash)-3:], failedStr))
 }
 
 func FormatInOutSelf(address, from, to []byte) template.HTML {


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ab52558</samp>

This pull request adds a new `FormatTransactionHash` function to the `utils` package and updates various functions and pages to use it. The function formats eth1 transaction hashes with a link and a warning symbol if the transaction failed or reverted. The purpose is to improve the user interface and feedback for eth1 transactions on the explorer website.
