### PR TITLE
(NOBIDS) Change blobs value names to look more "frontend-y"

### DIFF
--- a/templates/slot/blobs.html
+++ b/templates/slot/blobs.html
@@ -12,9 +12,9 @@
       <tbody id="blobs_table">
         <tr style="background-color: var(--bg-color-light);">
           <th class="border-0">Index</th>
-          <th class="border-0">KzgCommitment</th>
-          <th class="border-0">KzgProof</th>
-          <th class="border-0">BlobVersionedHash</th>
+          <th class="border-0">KZG Commitment</th>
+          <th class="border-0">KZG Proof</th>
+          <th class="border-0">Blob Versioned Hash</th>
         </tr>
         {{ range .BlobSidecars }}
           <tr class="border-bottom">


### PR DESCRIPTION
This PR changes the value names on the blobs page from PascalCase to "frontend-y" (sorry, don't know the technical term for that).