### PR TITLE
Fix for webhook notifications containing html

### DIFF
--- a/services/notifications.go
+++ b/services/notifications.go
@@ -1989,7 +1989,7 @@ func (n *validatorWithdrawalNotification) GetEventFilter() string {
 }
 
 func (n *validatorWithdrawalNotification) GetInfoMarkdown() string {
-	generalPart := fmt.Sprintf(`An automatic withdrawal of %[2]v has been processed for validator [%[1]v](https://%[6]v/validator/%[1]v) during slot [%[3]v](https://%[6]v/slot/%[3]v). The funds have been sent to: [%[4]v](https://%[6]v/address/%[4]v).`, n.ValidatorIndex, utils.FormatClCurrencyString(n.Amount, utils.Config.Frontend.MainCurrency, 6, true, false), n.Slot, utils.FormatHashRaw(n.Address), n.Address, utils.Config.Frontend.SiteDomain)
+	generalPart := fmt.Sprintf(`An automatic withdrawal of %[2]v has been processed for validator [%[1]v](https://%[6]v/validator/%[1]v) during slot [%[3]v](https://%[6]v/slot/%[3]v). The funds have been sent to: [%[4]v](https://%[6]v/address/0x%[5]x).`, n.ValidatorIndex, utils.FormatClCurrencyString(n.Amount, utils.Config.Frontend.MainCurrency, 6, true, false), n.Slot, utils.FormatHashRaw(n.Address), n.Address, utils.Config.Frontend.SiteDomain)
 	return generalPart
 }
 

--- a/services/notifications.go
+++ b/services/notifications.go
@@ -1973,7 +1973,7 @@ func (n *validatorWithdrawalNotification) GetEventName() types.EventName {
 }
 
 func (n *validatorWithdrawalNotification) GetInfo(includeUrl bool) string {
-	generalPart := fmt.Sprintf(`An automatic withdrawal of %v has been processed for validator %v.`, utils.FormatClCurrency(n.Amount, utils.Config.Frontend.MainCurrency, 6, true, false, false), n.ValidatorIndex)
+	generalPart := fmt.Sprintf(`An automatic withdrawal of %v has been processed for validator %v.`, utils.FormatClCurrencyString(n.Amount, utils.Config.Frontend.MainCurrency, 6, true, false), n.ValidatorIndex)
 	if includeUrl {
 		return generalPart + getUrlPart(n.ValidatorIndex)
 	}
@@ -1989,7 +1989,7 @@ func (n *validatorWithdrawalNotification) GetEventFilter() string {
 }
 
 func (n *validatorWithdrawalNotification) GetInfoMarkdown() string {
-	generalPart := fmt.Sprintf(`An automatic withdrawal of %[2]v has been processed for validator [%[1]v](https://%[6]v/validator/%[1]v) during slot [%[3]v](https://%[6]v/slot/%[3]v). The funds have been sent to: [%[4]v](https://%[6]v/address/%[4]v).`, n.ValidatorIndex, utils.FormatClCurrency(n.Amount, utils.Config.Frontend.MainCurrency, 6, true, false, false), n.Slot, utils.FormatHashRaw(n.Address), n.Address, utils.Config.Frontend.SiteDomain)
+	generalPart := fmt.Sprintf(`An automatic withdrawal of %[2]v has been processed for validator [%[1]v](https://%[6]v/validator/%[1]v) during slot [%[3]v](https://%[6]v/slot/%[3]v). The funds have been sent to: [%[4]v](https://%[6]v/address/%[4]v).`, n.ValidatorIndex, utils.FormatClCurrencyString(n.Amount, utils.Config.Frontend.MainCurrency, 6, true, false), n.Slot, utils.FormatHashRaw(n.Address), n.Address, utils.Config.Frontend.SiteDomain)
 	return generalPart
 }
 

--- a/utils/format.go
+++ b/utils/format.go
@@ -237,7 +237,7 @@ func FormatCurrency(valIf interface{}, valueCurrency, targetCurrency string, dig
 		classes = ` class="text-success"`
 	}
 
-	return template.HTML(fmt.Sprintf(`<span%s>%s%s</span>`, classes, result))
+	return template.HTML(fmt.Sprintf(`<span%s>%s</span>`, classes, result))
 }
 
 // IfToDec trys to parse given parameter to decimal.Decimal, it only logs on error

--- a/utils/format.go
+++ b/utils/format.go
@@ -197,7 +197,15 @@ func FormatClCurrency(value interface{}, targetCurrency string, digitsAfterComma
 	return FormatCurrency(ClToCurrency(value, Config.Frontend.ClCurrency), Config.Frontend.ClCurrency, targetCurrency, digitsAfterComma, showCurrencySymbol, showPlusSign, colored)
 }
 
-func FormatCurrency(valIf interface{}, valueCurrency, targetCurrency string, digitsAfterComma int, showCurrencySymbol, showPlusSign, colored bool) template.HTML {
+func FormatElCurrencyString(value interface{}, targetCurrency string, digitsAfterComma int, showCurrencySymbol, showPlusSign bool) string {
+	return FormatCurrencyString(ElToCurrency(value, Config.Frontend.ElCurrency), Config.Frontend.ElCurrency, targetCurrency, digitsAfterComma, showCurrencySymbol, showPlusSign)
+}
+
+func FormatClCurrencyString(value interface{}, targetCurrency string, digitsAfterComma int, showCurrencySymbol, showPlusSign bool) string {
+	return FormatCurrencyString(ClToCurrency(value, Config.Frontend.ClCurrency), Config.Frontend.ClCurrency, targetCurrency, digitsAfterComma, showCurrencySymbol, showPlusSign)
+}
+
+func FormatCurrencyString(valIf interface{}, valueCurrency, targetCurrency string, digitsAfterComma int, showCurrencySymbol, showPlusSign bool) string {
 	val := IfToDec(valIf)
 	valPriced := val
 	if valueCurrency != targetCurrency {
@@ -210,23 +218,26 @@ func FormatCurrency(valIf interface{}, valueCurrency, targetCurrency string, dig
 		resStr = valPriced.StringFixed(int32(digitsAfterComma))
 	}
 
-	classes := ""
 	plusSign := ""
 
 	if valPriced.Cmp(decimal.NewFromInt(0)) >= 0 {
 		if showPlusSign {
 			plusSign = "+"
 		}
-		if colored {
-			classes = ` class="text-success"`
-		}
-	} else {
-		if colored {
-			classes = ` class="text-danger"`
-		}
 	}
 
-	return template.HTML(fmt.Sprintf(`<span%s>%s%s</span>`, classes, plusSign, resStr))
+	return fmt.Sprintf(`%s%s`, plusSign, resStr)
+}
+
+func FormatCurrency(valIf interface{}, valueCurrency, targetCurrency string, digitsAfterComma int, showCurrencySymbol, showPlusSign, colored bool) template.HTML {
+	result := FormatCurrencyString(valIf, valueCurrency, targetCurrency, digitsAfterComma, showCurrencySymbol, showPlusSign)
+	classes := ""
+
+	if colored {
+		classes = ` class="text-success"`
+	}
+
+	return template.HTML(fmt.Sprintf(`<span%s>%s%s</span>`, classes, result))
 }
 
 // IfToDec trys to parse given parameter to decimal.Decimal, it only logs on error

--- a/utils/format.go
+++ b/utils/format.go
@@ -627,9 +627,12 @@ func FormatHash(hash []byte, trunc_opt ...bool) template.HTML {
 	return template.HTML(fmt.Sprintf("<span class=\"text-monospace\">%s</span>", FormatHashRaw(hash, trunc_opt...)))
 }
 
-// FormatHashRaw will return a hash formated
-// hash is required, trunc is optional.
-// Only the first value in trunc_opt will be used.
+/*
+  - FormatHashRaw will return a hash formated
+    hash is required, trunc is optional.
+    Only the first value in trunc_opt will be used.
+    ATTENTION: IT TRUNCATES BY DEFAULT, PASS FALSE TO trunc_opt TO DISABLE
+*/
 func FormatHashRaw(hash []byte, trunc_opt ...bool) string {
 	s := fmt.Sprintf("%#x", hash)
 	if len(s) == 42 { // if it's an address, we checksum it (0x + 40)

--- a/utils/format.go
+++ b/utils/format.go
@@ -620,9 +620,12 @@ func FormatGraffitiAsLink(graffiti []byte) template.HTML {
 	return template.HTML(fmt.Sprintf("<span aria-graffiti=\"%#x\"><a href=\"/slots?q=%s\">%s</a></span>", graffiti, u, h))
 }
 
-// FormatHash will return a hash formated as html
-// hash is required, trunc is optional.
-// Only the first value in trunc_opt will be used.
+/*
+  - FormatHash will return a hash formated as html
+    hash is required, trunc is optional.
+    Only the first value in trunc_opt will be used.
+    ATTENTION: IT TRUNCATES BY DEFAULT, PASS FALSE TO trunc_opt TO DISABLE
+*/
 func FormatHash(hash []byte, trunc_opt ...bool) template.HTML {
 	return template.HTML(fmt.Sprintf("<span class=\"text-monospace\">%s</span>", FormatHashRaw(hash, trunc_opt...)))
 }


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2f506be</samp>

Improved the notification text for validator withdrawals and refactored the currency formatting functions in the `utils` package. Extracted common logic for formatting currency values as strings into separate functions in `utils/format.go`.
