### PR TITLE
Client Update Notification Fix

### DIFF
--- a/handlers/pageData.go
+++ b/handlers/pageData.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"eth2-exporter/db"
-	ethclients "eth2-exporter/ethClients"
 	"eth2-exporter/price"
 	"eth2-exporter/services"
 	"eth2-exporter/types"
@@ -56,7 +55,6 @@ func InitPageData(w http.ResponseWriter, r *http.Request, active, path, title st
 		Rates:                 services.GetRates(GetCurrency(r)),
 		Mainnet:               utils.Config.Chain.ClConfig.ConfigName == "mainnet" || utils.Config.Chain.ClConfig.ConfigName == "gnosis",
 		DepositContract:       utils.Config.Chain.ClConfig.DepositContractAddress,
-		ClientsUpdated:        ethclients.ClientsUpdated(),
 		ChainConfig:           utils.Config.Chain.ClConfig,
 		Lang:                  "en-US",
 		NoAds:                 user.Authenticated && user.Subscription != "",

--- a/services/services.go
+++ b/services/services.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"eth2-exporter/cache"
 	"eth2-exporter/db"
+	ethclients "eth2-exporter/ethClients"
 	"eth2-exporter/price"
 	"eth2-exporter/types"
 	"eth2-exporter/utils"
@@ -96,6 +97,8 @@ func InitNotificationCollector(pubkeyCachePath string) {
 	if err != nil {
 		logger.Fatalf("error initializing pubkey cache path for notifications: %v", err)
 	}
+
+	go ethclients.Init()
 
 	go notificationCollector()
 }

--- a/types/templates.go
+++ b/types/templates.go
@@ -41,7 +41,6 @@ type PageData struct {
 	DepositContract       string
 	Rates                 *Rates
 	InfoBanner            *template.HTML
-	ClientsUpdated        bool
 	// IsUserClientUpdated   func(uint64) bool
 	ChainConfig         ClChainConfig
 	Lang                string


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 028d893</samp>

This pull request refactors the code related to fetching and displaying the ETH client releases from the GitHub API. It removes unused code and dependencies, and improves the notification collector service to use the latest release data. It affects the `ethclients`, `handlers`, `services`, and `types` packages.
