### PR TITLE
Fix wrong sync committee participation association

### DIFF
--- a/cmd/misc/main.go
+++ b/cmd/misc/main.go
@@ -1243,24 +1243,11 @@ OUTER:
 		}
 
 		if exportToToday {
-			// update end day since export might take a couple days to finish
-			lastEpoch, err := db.GetLatestFinalizedEpoch()
+			dayEnd, err = db.GetLastExportedStatisticDay()
 			if err != nil {
-				utils.LogError(err, "error getting latest finalized epoch", 0)
+				utils.LogError(err, "error getting last exported statistic day", 0)
 				return
 			}
-			if lastEpoch > 0 { // guard against underflows
-				lastEpoch = lastEpoch - 1
-			}
-
-			_, err = db.GetLastExportedStatisticDay()
-			if err != nil {
-				logrus.Infof("skipping exporting stats, first day has not been indexed yet")
-				return
-			}
-
-			epochsPerDay := utils.EpochsPerDay()
-			dayEnd = lastEpoch / epochsPerDay
 		}
 		logrus.Infof("finished exporting stats totals for columns '%v for day %v, took %v", columns, day, time.Since(timeDay))
 	}

--- a/cmd/misc/main.go
+++ b/cmd/misc/main.go
@@ -1246,7 +1246,7 @@ func exportSyncCommittee(rpcClient rpc.Client, bt *db.Bigtable, startDay, endDay
 
 	firstPeriod := utils.SyncPeriodOfEpoch(utils.Config.Chain.ClConfig.AltairForkEpoch)
 	if endDay <= 0 {
-		currEpoch := services.LatestFinalizedEpoch()
+		currEpoch = services.LatestFinalizedEpoch()
 		if currEpoch > 0 { // guard against underflows
 			currEpoch = currEpoch - 1
 		}

--- a/cmd/misc/main.go
+++ b/cmd/misc/main.go
@@ -1446,9 +1446,9 @@ func UpdateValidatorStatisticsSyncData(day uint64, client rpc.Client, dryRun boo
 	}
 	defer tx.Rollback()
 
-	logrus.Infof("updating statistics data into the validator_stats table %v | %v", len(onlySyncValidatorData), len(validatorData))
+	logrus.Infof("updating statistics data into the validator_stats table %v | %v", len(onlySyncCommitteeValidatorData), len(validatorData))
 
-	for _, data := range onlySyncValidatorData {
+	for _, data := range onlySyncCommitteeValidatorData {
 		if dryRun {
 			logrus.Infof(
 				"validator %v: participated sync: %v -> %v, missed sync: %v -> %v, orphaned sync: %v -> %v, total participated: %v -> %v, total missed sync: %v -> %v, total orphaned sync: %v -> %v",

--- a/cmd/misc/main.go
+++ b/cmd/misc/main.go
@@ -1246,7 +1246,12 @@ func exportSyncCommitteePeriods(rpcClient rpc.Client, bt *db.Bigtable, startDay,
 
 	firstPeriod := utils.SyncPeriodOfEpoch(utils.Config.Chain.ClConfig.AltairForkEpoch)
 	if endDay <= 0 {
-		currEpoch = services.LatestFinalizedEpoch()
+		var err error
+		currEpoch, err = db.GetLatestFinalizedEpoch()
+		if err != nil {
+			logrus.WithError(err).Errorf("error getting latest finalized epoch")
+			return
+		}
 		if currEpoch > 0 { // guard against underflows
 			currEpoch = currEpoch - 1
 		}
@@ -1291,7 +1296,12 @@ func exportSyncCommitteeValidatorStats(rpcClient rpc.Client, bt *db.Bigtable, st
 	var currEpoch = uint64(0)
 
 	if endDay <= 0 {
-		currEpoch = services.LatestFinalizedEpoch()
+		var err error
+		currEpoch, err = db.GetLatestFinalizedEpoch()
+		if err != nil {
+			logrus.WithError(err).Errorf("error getting latest finalized epoch")
+			return
+		}
 		if currEpoch > 0 { // guard against underflows
 			currEpoch = currEpoch - 1
 		}

--- a/db/statistics.go
+++ b/db/statistics.go
@@ -36,7 +36,7 @@ func WriteValidatorStatisticsForDay(day uint64, client rpc.Client) error {
 
 	logger.Infof("exporting statistics for day %v (epoch %v to %v)", day, firstEpoch, lastEpoch)
 
-	if err := checkIfDayIsFinalized(day); err != nil {
+	if err := CheckIfDayIsFinalized(day); err != nil {
 		return err
 	}
 
@@ -105,7 +105,7 @@ func WriteValidatorStatisticsForDay(day uint64, client rpc.Client) error {
 		return nil
 	})
 	g.Go(func() error {
-		if err := gatherValidatorSyncDutiesForDay(validators, day, validatorData, validatorDataMux); err != nil {
+		if err := GatherValidatorSyncDutiesForDay(validators, day, validatorData, validatorDataMux); err != nil {
 			return fmt.Errorf("error in GatherValidatorSyncDutiesForDay: %w", err)
 		}
 		return nil
@@ -138,7 +138,7 @@ func WriteValidatorStatisticsForDay(day uint64, client rpc.Client) error {
 	var statisticsData1d []*types.ValidatorStatsTableDbRow
 	g.Go(func() error {
 		var err error
-		statisticsData1d, err = gatherStatisticsForDay(int64(day) - 1) // convert to int64 to avoid underflows
+		statisticsData1d, err = GatherStatisticsForDay(int64(day) - 1) // convert to int64 to avoid underflows
 		if err != nil {
 			return fmt.Errorf("error in GatherPreviousDayStatisticsData: %w", err)
 		}
@@ -147,7 +147,7 @@ func WriteValidatorStatisticsForDay(day uint64, client rpc.Client) error {
 	var statisticsData7d []*types.ValidatorStatsTableDbRow
 	g.Go(func() error {
 		var err error
-		statisticsData7d, err = gatherStatisticsForDay(int64(day) - 7) // convert to int64 to avoid underflows
+		statisticsData7d, err = GatherStatisticsForDay(int64(day) - 7) // convert to int64 to avoid underflows
 		if err != nil {
 			return fmt.Errorf("error in GatherPreviousDayStatisticsData: %w", err)
 		}
@@ -156,7 +156,7 @@ func WriteValidatorStatisticsForDay(day uint64, client rpc.Client) error {
 	var statisticsData31d []*types.ValidatorStatsTableDbRow
 	g.Go(func() error {
 		var err error
-		statisticsData31d, err = gatherStatisticsForDay(int64(day) - 31) // convert to int64 to avoid underflows
+		statisticsData31d, err = GatherStatisticsForDay(int64(day) - 31) // convert to int64 to avoid underflows
 		if err != nil {
 			return fmt.Errorf("error in GatherPreviousDayStatisticsData: %w", err)
 		}
@@ -165,7 +165,7 @@ func WriteValidatorStatisticsForDay(day uint64, client rpc.Client) error {
 	var statisticsData365d []*types.ValidatorStatsTableDbRow
 	g.Go(func() error {
 		var err error
-		statisticsData31d, err = gatherStatisticsForDay(int64(day) - 365) // convert to int64 to avoid underflows
+		statisticsData31d, err = GatherStatisticsForDay(int64(day) - 365) // convert to int64 to avoid underflows
 		if err != nil {
 			return fmt.Errorf("error in GatherPreviousDayStatisticsData: %w", err)
 		}
@@ -884,7 +884,7 @@ func gatherValidatorDepositWithdrawals(day uint64, data []*types.ValidatorStatsT
 	return nil
 }
 
-func gatherValidatorSyncDutiesForDay(validators []uint64, day uint64, data []*types.ValidatorStatsTableDbRow, mux *sync.Mutex) error {
+func GatherValidatorSyncDutiesForDay(validators []uint64, day uint64, data []*types.ValidatorStatsTableDbRow, mux *sync.Mutex) error {
 	exportStart := time.Now()
 	defer func() {
 		metrics.TaskDuration.WithLabelValues("db_update_validator_sync_stats").Observe(time.Since(exportStart).Seconds())
@@ -898,9 +898,11 @@ func gatherValidatorSyncDutiesForDay(validators []uint64, day uint64, data []*ty
 		return nil
 	}
 	logger := logger.WithFields(logrus.Fields{
-		"day":        day,
-		"firstEpoch": firstEpoch,
-		"lastEpoch":  lastEpoch,
+		"day":         day,
+		"firstEpoch":  firstEpoch,
+		"lastEpoch":   lastEpoch,
+		"startPeriod": utils.SyncPeriodOfEpoch(firstEpoch),
+		"endPeriod":   utils.SyncPeriodOfEpoch(lastEpoch),
 	})
 	logger.Infof("gathering sync duties")
 
@@ -1105,7 +1107,7 @@ func gatherValidatorMissedAttestationsStatisticsForDay(validators []uint64, day 
 	return nil
 }
 
-func gatherStatisticsForDay(day int64) ([]*types.ValidatorStatsTableDbRow, error) {
+func GatherStatisticsForDay(day int64) ([]*types.ValidatorStatsTableDbRow, error) {
 
 	if day < 0 {
 		return nil, nil
@@ -1790,7 +1792,7 @@ func WriteGraffitiStatisticsForDay(day int64) error {
 	return nil
 }
 
-func checkIfDayIsFinalized(day uint64) error {
+func CheckIfDayIsFinalized(day uint64) error {
 	_, lastEpoch := utils.GetFirstAndLastEpochForDay(day)
 
 	latestFinalizedEpoch, err := GetLatestFinalizedEpoch()

--- a/exporter/sync_committees.go
+++ b/exporter/sync_committees.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/jmoiron/sqlx"
 	"github.com/sirupsen/logrus"
 )
 
@@ -44,7 +45,7 @@ func exportSyncCommittees(rpcClient rpc.Client) error {
 		_, exists := dbPeriodsMap[p]
 		if !exists {
 			t0 := time.Now()
-			err = exportSyncCommitteeAtPeriod(rpcClient, p)
+			err = ExportSyncCommitteeAtPeriod(rpcClient, p, nil)
 			if err != nil {
 				return fmt.Errorf("error exporting sync-committee at period %v: %w", p, err)
 			}
@@ -58,7 +59,48 @@ func exportSyncCommittees(rpcClient rpc.Client) error {
 	return nil
 }
 
-func exportSyncCommitteeAtPeriod(rpcClient rpc.Client, p uint64) error {
+func ExportSyncCommitteeAtPeriod(rpcClient rpc.Client, p uint64, providedTx *sqlx.Tx) error {
+
+	data, err := GetSyncCommitteAtPeriod(rpcClient, p)
+	if err != nil {
+		return err
+	}
+
+	tx := providedTx
+	if tx == nil {
+		tx, err = db.WriterDb.Beginx()
+		if err != nil {
+			return err
+		}
+		defer tx.Rollback()
+	}
+
+	nArgs := 3
+	valueArgs := make([]interface{}, len(data)*nArgs)
+	valueIds := make([]string, len(data))
+	for i, entry := range data {
+		valueArgs[i*nArgs+0] = entry.Period
+		valueArgs[i*nArgs+1] = entry.ValidatorIndex
+		valueArgs[i*nArgs+2] = entry.CommitteeIndex
+		valueIds[i] = fmt.Sprintf("($%d,$%d,$%d)", i*nArgs+1, i*nArgs+2, i*nArgs+3)
+	}
+	_, err = tx.Exec(
+		fmt.Sprintf(`
+			INSERT INTO sync_committees (period, validatorindex, committeeindex) 
+			VALUES %s ON CONFLICT (period, validatorindex, committeeindex) DO NOTHING`,
+			strings.Join(valueIds, ",")),
+		valueArgs...)
+	if err != nil {
+		return err
+	}
+
+	if providedTx == nil {
+		return tx.Commit()
+	}
+	return nil
+}
+
+func GetSyncCommitteAtPeriod(rpcClient rpc.Client, p uint64) ([]SyncCommittee, error) {
 
 	stateID := uint64(0)
 	if p > 0 {
@@ -79,53 +121,32 @@ func exportSyncCommitteeAtPeriod(rpcClient rpc.Client, p uint64) error {
 	// and determines which bit reflects them in the block sync aggregate bits
 	c, err := rpcClient.GetSyncCommittee(fmt.Sprintf("%d", stateID), epoch)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	validatorsU64 := make([]uint64, len(c.Validators))
 	for i, idxStr := range c.Validators {
 		idxU64, err := strconv.ParseUint(idxStr, 10, 64)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		validatorsU64[i] = idxU64
 	}
 
-	// start := time.Now()
-	//
-	// firstSlot := firstEpoch * utils.Config.Chain.ClConfig.SlotsPerEpoch
-	// lastSlot := lastEpoch*utils.Config.Chain.ClConfig.SlotsPerEpoch + utils.Config.Chain.ClConfig.SlotsPerEpoch - 1
-	// logger.Infof("exporting sync committee assignments for period %v (epoch %v to %v, slot %v to %v) to bigtable", p, firstEpoch, lastEpoch, firstSlot, lastSlot)
-
-	// err = db.BigtableClient.SaveSyncCommitteesAssignments(firstSlot, lastSlot, validatorsU64)
-	// if err != nil {
-	// 	return fmt.Errorf("error saving sync committee assignments: %v", err)
-	// }
-	// logger.Infof("exported sync committee assignments for period %v to bigtable in %v", p, time.Since(start))
-	tx, err := db.WriterDb.Beginx()
-	if err != nil {
-		return err
-	}
-	defer tx.Rollback()
-
-	nArgs := 3
-	valueArgs := make([]interface{}, len(validatorsU64)*nArgs)
-	valueIds := make([]string, len(validatorsU64))
+	result := make([]SyncCommittee, len(validatorsU64))
 	for i, idxU64 := range validatorsU64 {
-		valueArgs[i*nArgs+0] = p
-		valueArgs[i*nArgs+1] = idxU64
-		valueArgs[i*nArgs+2] = i
-		valueIds[i] = fmt.Sprintf("($%d,$%d,$%d)", i*nArgs+1, i*nArgs+2, i*nArgs+3)
-	}
-	_, err = tx.Exec(
-		fmt.Sprintf(`
-			INSERT INTO sync_committees (period, validatorindex, committeeindex) 
-			VALUES %s ON CONFLICT (period, validatorindex, committeeindex) DO NOTHING`,
-			strings.Join(valueIds, ",")),
-		valueArgs...)
-	if err != nil {
-		return err
+		result = append(result, SyncCommittee{
+			Period:         p,
+			ValidatorIndex: idxU64,
+			CommitteeIndex: uint64(i),
+		})
 	}
 
-	return tx.Commit()
+	return result, nil
+}
+
+type SyncCommittee struct {
+	Period         uint64 `json:"period"`
+	ValidatorIndex uint64 `json:"validatorindex"`
+	CommitteeIndex uint64 `json:"committeeindex"`
 }

--- a/exporter/sync_committees.go
+++ b/exporter/sync_committees.go
@@ -75,6 +75,8 @@ func exportSyncCommitteeAtPeriod(rpcClient rpc.Client, p uint64) error {
 
 	logger.Infof("exporting sync committee assignments for period %v (epoch %v to %v)", p, firstEpoch, lastEpoch)
 
+	// Note that the order we receive the validators from the node in is crucial
+	// and determines which bit reflects them in the block sync aggregate bits
 	c, err := rpcClient.GetSyncCommittee(fmt.Sprintf("%d", stateID), epoch)
 	if err != nil {
 		return err
@@ -87,17 +89,6 @@ func exportSyncCommitteeAtPeriod(rpcClient rpc.Client, p uint64) error {
 			return err
 		}
 		validatorsU64[i] = idxU64
-	}
-
-	dedupMap := make(map[uint64]bool)
-
-	for _, validator := range validatorsU64 {
-		dedupMap[validator] = true
-	}
-
-	validatorsU64 = make([]uint64, 0, len(dedupMap))
-	for validator := range dedupMap {
-		validatorsU64 = append(validatorsU64, validator)
 	}
 
 	// start := time.Now()

--- a/exporter/sync_committees.go
+++ b/exporter/sync_committees.go
@@ -124,17 +124,12 @@ func GetSyncCommitteAtPeriod(rpcClient rpc.Client, p uint64) ([]SyncCommittee, e
 		return nil, err
 	}
 
-	validatorsU64 := make([]uint64, len(c.Validators))
+	result := make([]SyncCommittee, len(c.Validators))
 	for i, idxStr := range c.Validators {
 		idxU64, err := strconv.ParseUint(idxStr, 10, 64)
 		if err != nil {
 			return nil, err
 		}
-		validatorsU64[i] = idxU64
-	}
-
-	result := make([]SyncCommittee, len(validatorsU64))
-	for i, idxU64 := range validatorsU64 {
 		result = append(result, SyncCommittee{
 			Period:         p,
 			ValidatorIndex: idxU64,

--- a/handlers/api.go
+++ b/handlers/api.go
@@ -732,6 +732,8 @@ func ApiSyncCommittee(w http.ResponseWriter, r *http.Request) {
 		period = utils.SyncPeriodOfEpoch(services.LatestEpoch()) + 1
 	}
 
+	// Beware that we do not deduplicate here since a validator can be part multiple times of the same sync committee period
+	// and the order of the committeeindex is important, deduplicating it would mess up the order
 	rows, err := db.ReaderDb.Query(`SELECT period, GREATEST(period*$2, $3) AS start_epoch, ((period+1)*$2)-1 AS end_epoch, ARRAY_AGG(validatorindex ORDER BY committeeindex) AS validators FROM sync_committees WHERE period = $1 GROUP BY period`, period, utils.Config.Chain.ClConfig.EpochsPerSyncCommitteePeriod, utils.Config.Chain.ClConfig.AltairForkEpoch)
 	if err != nil {
 		logger.WithError(err).WithField("url", r.URL.String()).Errorf("error querying db")
@@ -1020,15 +1022,24 @@ func ApiDashboard(w http.ResponseWriter, r *http.Request) {
 }
 
 func getSyncCommitteeInfoForValidators(validators []uint64, period uint64) ([]interface{}, error) {
-	rows, err := db.ReaderDb.Query(
-		`SELECT 
-			period, 
-			GREATEST(period*$3, $4) AS start_epoch, 
-			((period+1)*$3)-1 AS end_epoch, 
-			ARRAY_AGG(validatorindex ORDER BY committeeindex) AS validators 
-		FROM sync_committees 
-		WHERE period = $1 AND validatorindex = ANY($2)
-		GROUP BY period`,
+	rows, err := db.ReaderDb.Query(`
+			WITH
+				data as (
+					SELECT 
+						period,
+						validatorindex,
+						max(committeeindex) as committeeindex
+					FROM sync_committees 
+					WHERE period = $1 AND validatorindex = ANY($2)
+					group by period, validatorindex
+				)	
+			SELECT 
+				period, 
+				GREATEST(period*$3, $4) AS start_epoch, 
+				((period+1)*$3)-1 AS end_epoch, 
+				ARRAY_AGG(validatorindex ORDER BY committeeindex) AS validators 
+			FROM data 	
+			group by period;`,
 		period, pq.Array(validators),
 		utils.Config.Chain.ClConfig.EpochsPerSyncCommitteePeriod, utils.Config.Chain.ClConfig.AltairForkEpoch,
 	)
@@ -1218,7 +1229,7 @@ func getSyncCommitteeSlotsStatistics(validators []uint64, epoch uint64) (types.S
 			Validators pq.Int64Array `db:"validators"`
 		}
 		query, args, err := sqlx.In(`
-			SELECT period, COALESCE(ARRAY_AGG(validatorindex), '{}') AS validators
+			SELECT period, COALESCE(ARRAY_AGG(distinct validatorindex), '{}') AS validators
 			FROM sync_committees
 			WHERE period IN (?) AND validatorindex IN (?)
 			GROUP BY period

--- a/handlers/validator.go
+++ b/handlers/validator.go
@@ -1992,7 +1992,7 @@ func ValidatorSync(w http.ResponseWriter, r *http.Request) {
 	var syncPeriods []uint64 = []uint64{}
 
 	err = db.ReaderDb.Select(&syncPeriods, `
-		SELECT period
+		SELECT distinct period
 		FROM sync_committees 
 		WHERE validatorindex = $1
 		ORDER BY period desc`, validatorIndex)


### PR DESCRIPTION
Note that this PR restores functionality of the sync committee stats and does not aim to fully support the edge case of a validator being part of the same sync committee twice as this requires a wider refactor of how we handle sync committees on the frontend. Will create a jira task for that special case.

Main culprit of current approach was that the de duplication on statistics exporter level shuffled the sync committee index. Removed de duplication in this level since a validator can be elected into the same sync committee multiple times and kept current frontend handling (which does not handle this case at all atm, but so far this hasn't occurred on mainnet or prater yet.)

**Requires a re-export via misc tool, command:**
```
misc \
--command=export-sync-committee-periods \
--dry-run=false \
--config path_to_config.yml \
&& misc \
--command=export-sync-committee-validator-stats \
--dry-run=false \
--config path_to_config.yml \
&& misc \
--command=export-stats-totals \
--columns=missed_attestations_total,participated_sync_total,missed_sync_total,orphaned_sync_total \
--day-start=0 \
--day-end=0
```

_Fun Fact: Sync period 827 is utterly wrong on prater db, every one of the 512 validators has a second entry with a different committee indices. Should be fixed via re-export also._

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b3baa4a</samp>

This pull request fixes various bugs and inconsistencies in the sync committee data for validators, both in the exporter and the API handler. It also improves the SQL queries and adds comments to make the code more clear and reliable.
