### PR TITLE
(BIDS-2663) Add sorting to postgres query using pagination

### DIFF
--- a/handlers/api.go
+++ b/handlers/api.go
@@ -3784,6 +3784,7 @@ func ApiWithdrawalCredentialsValidators(w http.ResponseWriter, r *http.Request) 
 		pubkey
 	FROM validators
 	WHERE withdrawalcredentials = $1
+	ORDER BY validatorindex ASC
 	LIMIT $2
 	OFFSET $3
 	`, credentials, limit, offset)


### PR DESCRIPTION
This PR adds sorting to the `api1/validator/withdrawalCredentials/{withdrawalCredentialsOrEth1address}` API endpoint to ensure correct pagination.

This should fix https://github.com/gobitfly/eth2-beaconchain-explorer/issues/2681.