### PR TITLE
(BIDS-2669) api: fix ordering of result of /api/v1/validator/leaderboard

### DIFF
--- a/handlers/api.go
+++ b/handlers/api.go
@@ -2487,7 +2487,7 @@ func ApiValidatorLeaderboard(w http.ResponseWriter, r *http.Request) {
 				rank7d, 
 				validatorindex
 			FROM validator_performance 
-			ORDER BY rank7d DESC LIMIT 100`)
+			ORDER BY rank7d ASC LIMIT 100`)
 	if err != nil {
 		sendErrorResponse(w, r.URL.String(), "could not retrieve db results")
 		return


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ed84339</samp>

Fixed a bug in the `ApiValidatorLeaderboard` function that returned the wrong order of validators. Updated the SQL query in `handlers/api.go` to sort by rank7d in ascending order.
