### PR TITLE
(NOBIDS) improve fetching of burn page data

### DIFF
--- a/db/bigtable.go
+++ b/db/bigtable.go
@@ -2723,7 +2723,7 @@ func (bigtable *Bigtable) getTotalIncomeEpochRanges(startEpoch uint64, endEpoch 
 		startEpoch = 0
 	}
 
-	rangeEnd := fmt.Sprintf("%s:%s:%s", bigtable.chainId, SUM_COLUMN, bigtable.reversedPaddedEpoch(startEpoch), "\x00")
+	rangeEnd := fmt.Sprintf("%s:%s:%s%s", bigtable.chainId, SUM_COLUMN, bigtable.reversedPaddedEpoch(startEpoch), "\x00")
 	rangeStart := fmt.Sprintf("%s:%s:%s", bigtable.chainId, SUM_COLUMN, bigtable.reversedPaddedEpoch(endEpoch))
 
 	return gcp_bigtable.NewRange(rangeStart, rangeEnd)


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at de229eb</samp>

This pull request improves the performance and accuracy of the burn page data by querying the total validator income from Bigtable more efficiently and using the latest finalized epoch and historical epochs for the calculations. It adds a new function `GetTotalValidatorIncomeDetailsHistory` to the `db` package and updates the `getBurnPageData` function in the `services` package. It also removes some redundant or obsolete code.
