### PR TITLE
(NOBIDS) revert wrong lookback for attestation effectiveness

### DIFF
--- a/db/bigtable.go
+++ b/db/bigtable.go
@@ -1990,7 +1990,7 @@ func (bigtable *Bigtable) GetValidatorSyncDutiesStatistics(validators []uint64, 
 func (bigtable *Bigtable) GetValidatorEffectiveness(validators []uint64, epoch uint64) ([]*types.ValidatorEffectiveness, error) {
 	end := epoch
 	start := uint64(0)
-	lookback := uint64(9)
+	lookback := uint64(99)
 	if end > lookback {
 		start = end - lookback
 	}


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2b9b075</samp>

Increased the `lookback` parameter for validator effectiveness calculation in `db/bigtable.go`. This improves the metric's accuracy and stability by using more historical data.
