### PR TITLE
(NOBIDS) improve handling of the global last attestation slot

### DIFF
--- a/db/bigtable.go
+++ b/db/bigtable.go
@@ -75,6 +75,8 @@ type Bigtable struct {
 	v2SchemaCutOffEpoch uint64
 
 	machineMetricsQueuedWritesChan chan (types.BulkMutation)
+
+	globalLastAttestationSlot types.Slot
 }
 
 func InitBigtable(project, instance, chainId, redisAddress string) (*Bigtable, error) {
@@ -676,10 +678,18 @@ func (bigtable *Bigtable) SaveAttestationDuties(duties map[types.Slot]map[types.
 			bigtable.LastAttestationCacheMux.Unlock()
 			return err
 		}
+
+		for _, lastAttestationSlot := range bigtable.LastAttestationCache {
+			if types.Slot(lastAttestationSlot) > bigtable.globalLastAttestationSlot {
+				bigtable.globalLastAttestationSlot = types.Slot(lastAttestationSlot)
+			}
+		}
 		logger.Infof("initialized in memory last attestation slot cache with %v validators in %v", len(bigtable.LastAttestationCache), time.Since(t))
 
 	}
 	bigtable.LastAttestationCacheMux.Unlock()
+
+	newGlobalLastAttestationSlot := bigtable.globalLastAttestationSlot
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*5)
 	defer cancel()
@@ -716,6 +726,10 @@ func (bigtable *Bigtable) SaveAttestationDuties(duties map[types.Slot]map[types.
 					mutLastAttestationSlot.Set(ATTESTATIONS_FAMILY, fmt.Sprintf("%d", validator), gcp_bigtable.Timestamp((attestedSlot)*1000), []byte{})
 					bigtable.LastAttestationCache[uint64(validator)] = uint64(attestedSlot)
 					mutLastAttestationSlotCount++
+
+					if attestedSlot > newGlobalLastAttestationSlot {
+						newGlobalLastAttestationSlot = attestedSlot
+					}
 
 					if mutLastAttestationSlotCount == MAX_BATCH_MUTATIONS {
 						mutStart := time.Now()
@@ -771,6 +785,19 @@ func (bigtable *Bigtable) SaveAttestationDuties(duties map[types.Slot]map[types.
 		}
 	}
 
+	// store the global last attestation slot in a separate row
+	if newGlobalLastAttestationSlot > bigtable.globalLastAttestationSlot {
+		logger.Infof("incrementing global last attestation slot from %d to %d", bigtable.globalLastAttestationSlot, newGlobalLastAttestationSlot)
+		mut := gcp_bigtable.NewMutation()
+		mut.Set(ATTESTATIONS_FAMILY, "s", gcp_bigtable.Timestamp(0), []byte(fmt.Sprintf("%d", newGlobalLastAttestationSlot)))
+		err := bigtable.tableValidators.Apply(ctx, fmt.Sprintf("%s:globalLastAttestationSlot", bigtable.chainId), mut)
+		if err != nil {
+			return fmt.Errorf("error applying global last attestation slot mutation: %v", err)
+		}
+
+		bigtable.globalLastAttestationSlot = newGlobalLastAttestationSlot
+	}
+
 	logger.Infof("exported %v attestations to bigtable in %v", writes, time.Since(start))
 	return nil
 }
@@ -788,6 +815,28 @@ func (bigtable *Bigtable) SetLastAttestationSlot(validator uint64, lastAttestati
 	}
 
 	return nil
+}
+
+// Retrieves the last seen global last attestation slot
+func (bigtable *Bigtable) GetGlobalLastAttestationSlot() (uint64, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+	defer cancel()
+
+	row, err := bigtable.tableValidators.ReadRow(ctx, fmt.Sprintf("%s:globalLastAttestationSlot", bigtable.chainId))
+
+	if err != nil {
+		return 0, err
+	}
+
+	globalLastAttestationSlot := uint64(0)
+
+	if row == nil || row[ATTESTATIONS_FAMILY] == nil || len(row[ATTESTATIONS_FAMILY]) == 0 {
+		return globalLastAttestationSlot, nil
+	}
+
+	val := row[ATTESTATIONS_FAMILY][0].Value
+
+	return strconv.ParseUint(string(val), 10, 64)
 }
 
 func (bigtable *Bigtable) SaveProposal(block *types.Block) error {

--- a/services/monitoring.go
+++ b/services/monitoring.go
@@ -37,21 +37,14 @@ func startClDataMonitoringService() {
 		firstRun = false
 
 		// retrieve the max attestationslot from the validators table and check that it is not older than 15 minutes
-		var maxAttestationSlot uint64
-		lastAttestationSlots, err := db.BigtableClient.GetLastAttestationSlots([]uint64{})
+		globalLastAttestationSlot, err := db.BigtableClient.GetGlobalLastAttestationSlot()
 		if err != nil {
 			logger.Errorf("error retrieving max attestation slot data from bigtable: %v", err)
 			continue
 		}
 
-		for _, lastAttestationSlot := range lastAttestationSlots {
-			if lastAttestationSlot > maxAttestationSlot {
-				maxAttestationSlot = lastAttestationSlot
-			}
-		}
-
-		if time.Since(utils.SlotToTime(maxAttestationSlot)) > time.Minute*15 {
-			errorMsg := fmt.Errorf("error: max attestation slot is older than 15 minutes: %v", time.Since(utils.SlotToTime(maxAttestationSlot)))
+		if time.Since(utils.SlotToTime(globalLastAttestationSlot)) > time.Minute*15 {
+			errorMsg := fmt.Errorf("error: max attestation slot is older than 15 minutes: %v", time.Since(utils.SlotToTime(globalLastAttestationSlot)))
 			utils.LogError(nil, errorMsg, 0)
 			ReportStatus(name, errorMsg.Error(), nil)
 			continue
@@ -66,7 +59,7 @@ func startClDataMonitoringService() {
 		}
 
 		if time.Since(utils.SlotToTime(maxSlot)) > time.Minute*15 {
-			errorMsg := fmt.Errorf("error: max slot in blocks table is older than 15 minutes: %v", time.Since(utils.SlotToTime(maxAttestationSlot)))
+			errorMsg := fmt.Errorf("error: max slot in blocks table is older than 15 minutes: %v", time.Since(utils.SlotToTime(maxSlot)))
 			utils.LogError(nil, errorMsg, 0)
 			ReportStatus(name, errorMsg.Error(), nil)
 			continue
@@ -81,7 +74,7 @@ func startClDataMonitoringService() {
 		}
 
 		if time.Since(utils.EpochToTime(maxEpoch)) > time.Minute*15 {
-			errorMsg := fmt.Errorf("error: max epoch in epochs table is older than 15 minutes: %v", time.Since(utils.SlotToTime(maxAttestationSlot)))
+			errorMsg := fmt.Errorf("error: max epoch in epochs table is older than 15 minutes: %v", time.Since(utils.SlotToTime(maxEpoch*utils.Config.Chain.ClConfig.SlotsPerEpoch)))
 			utils.LogError(nil, errorMsg, 0)
 			ReportStatus(name, errorMsg.Error(), nil)
 			continue


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5e1afa2</samp>

This pull request optimizes and fixes the handling of the highest attestation slot for validators in the bigtable database. It introduces a global variable `globalLastAttestationSlot` in the `db` package and uses it in the `SaveValidators` and `startClDataMonitoringService` functions. It also improves the error handling and time conversions in these functions.
