### PR TITLE
(NOBIDS) fix error when first slot of stats day is empty

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -1969,7 +1969,7 @@ func GetSlotVizData(latestEpoch uint64) ([]*types.SlotVizEpochs, error) {
 }
 
 func GetBlockNumber(slot uint64) (block uint64, err error) {
-	err = ReaderDb.Get(&block, `SELECT exec_block_number FROM blocks where slot = $1`, slot)
+	err = ReaderDb.Get(&block, `SELECT exec_block_number FROM blocks where slot >= $1 AND exec_block_number > 0 ORDER BY slot LIMIT 1`, slot)
 	return
 }
 

--- a/db/statistics.go
+++ b/db/statistics.go
@@ -1494,7 +1494,7 @@ func WriteExecutionChartSeriesForDay(day int64) error {
 	}
 
 	if firstBlock <= 15537394 {
-		return fmt.Errorf("this function does not yet handle pre merge statistics")
+		return fmt.Errorf("this function does not yet handle pre merge statistics, firstBlock is %v, firstSlot is %v", firstBlock, firstSlot)
 	}
 
 	lastBlock, err := GetBlockNumber(uint64(lastSlot))


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bc91f8c</samp>

This pull request enhances the beacon chain explorer by adding support for skipped and future slots in the `GetBlockNumber` function and by improving the error handling for execution layer statistics in the `WriteExecutionChartSeriesForDay` function.
