### PR TITLE
(BIDS-2644) Add underflow protection for missed attestations

### DIFF
--- a/handlers/validator.go
+++ b/handlers/validator.go
@@ -623,6 +623,10 @@ func Validator(w http.ResponseWriter, r *http.Request) {
 				validatorPageData.ExecutedAttestationsCount = 0
 				validatorPageData.UnmissedAttestationsPercentage = 1
 			} else {
+				if attestationStats.MissedAttestations > validatorPageData.AttestationsCount {
+					// save guard against negative values (should never happen but happened once because of wrong data)
+					attestationStats.MissedAttestations = validatorPageData.AttestationsCount
+				}
 				validatorPageData.MissedAttestationsCount = attestationStats.MissedAttestations
 				validatorPageData.ExecutedAttestationsCount = validatorPageData.AttestationsCount - validatorPageData.MissedAttestationsCount
 				validatorPageData.UnmissedAttestationsPercentage = float64(validatorPageData.ExecutedAttestationsCount) / float64(validatorPageData.AttestationsCount)


### PR DESCRIPTION
This PR adds an underflow protection for the validator page (missed attestation count). It is required for wrong data on Prater currently. Data will be fixed later.