### PR TITLE
(BIDS-2594) Add wrapper function and remove unused parameter

### DIFF
--- a/db/bigtable_eth1.go
+++ b/db/bigtable_eth1.go
@@ -2852,7 +2852,7 @@ func (bigtable *Bigtable) GetAddressErc721TableData(address []byte, pageToken st
 	defer tmr.Stop()
 
 	if pageToken == "" {
-		pageToken = fmt.Sprintf("%s:I:ERC721:%s:%s:", bigtable.chainId, address, FILTER_TIME)
+		pageToken = fmt.Sprintf("%s:I:ERC721:%x:%s:", bigtable.chainId, address, FILTER_TIME)
 	}
 
 	transactions, lastKey, err := bigtable.GetEth1ERC721ForAddress(pageToken, 25)
@@ -2962,7 +2962,7 @@ func (bigtable *Bigtable) GetAddressErc1155TableData(address []byte, pageToken s
 	defer tmr.Stop()
 
 	if pageToken == "" {
-		pageToken = fmt.Sprintf("%s:I:ERC1155:%s:%s:", bigtable.chainId, address, FILTER_TIME)
+		pageToken = fmt.Sprintf("%s:I:ERC1155:%x:%s:", bigtable.chainId, address, FILTER_TIME)
 	}
 
 	transactions, lastKey, err := bigtable.GetEth1ERC1155ForAddress(pageToken, 25)

--- a/db/bigtable_eth1.go
+++ b/db/bigtable_eth1.go
@@ -40,8 +40,8 @@ import (
 
 const (
 	ECR20TokensPerAddressLimit    = uint64(200) // when changing this, you will have to update the swagger docu for func ApiEth1Address too
-	digitLimitInAddressPagesTable = 18
-	nameLimitInAddressPagesTable  = 18
+	digitLimitInAddressPagesTable = 17
+	nameLimitInAddressPagesTable  = 0
 )
 
 var ErrBlockNotFound = errors.New("block not found")

--- a/handlers/eth1Account.go
+++ b/handlers/eth1Account.go
@@ -115,7 +115,7 @@ func Eth1Address(w http.ResponseWriter, r *http.Request) {
 	})
 	g.Go(func() error {
 		var err error
-		erc721, err = db.BigtableClient.GetAddressErc721TableData(address, "")
+		erc721, err = db.BigtableClient.GetAddressErc721TableData(addressBytes, "")
 		if err != nil {
 			return fmt.Errorf("GetAddressErc721TableData: %w", err)
 		}
@@ -123,7 +123,7 @@ func Eth1Address(w http.ResponseWriter, r *http.Request) {
 	})
 	g.Go(func() error {
 		var err error
-		erc1155, err = db.BigtableClient.GetAddressErc1155TableData(address, "")
+		erc1155, err = db.BigtableClient.GetAddressErc1155TableData(addressBytes, "")
 		if err != nil {
 			return fmt.Errorf("GetAddressErc1155TableData: %w", err)
 		}
@@ -502,12 +502,13 @@ func Eth1AddressErc721Transactions(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		return
 	}
+	addressBytes := common.FromHex(address)
 
 	errFields := map[string]interface{}{
 		"route": r.URL.String()}
 
 	pageToken := q.Get("pageToken")
-	data, err := db.BigtableClient.GetAddressErc721TableData(address, pageToken)
+	data, err := db.BigtableClient.GetAddressErc721TableData(addressBytes, pageToken)
 	if err != nil {
 		utils.LogError(err, "error getting eth1 ERC721 transactions table data", 0, errFields)
 	}
@@ -528,12 +529,13 @@ func Eth1AddressErc1155Transactions(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		return
 	}
+	addressBytes := common.FromHex(address)
 
 	errFields := map[string]interface{}{
 		"route": r.URL.String()}
 
 	pageToken := q.Get("pageToken")
-	data, err := db.BigtableClient.GetAddressErc1155TableData(address, pageToken)
+	data, err := db.BigtableClient.GetAddressErc1155TableData(addressBytes, pageToken)
 	if err != nil {
 		utils.LogError(err, "error getting eth1 ERC1155 transactions table data", 0, errFields)
 	}

--- a/handlers/mempoolView.go
+++ b/handlers/mempoolView.go
@@ -33,7 +33,7 @@ func _isContractCreation(tx *common.Address) string {
 	if tx == nil {
 		return "Contract Creation"
 	}
-	return string(utils.FormatAddressAll(tx.Bytes(), "", false, "address", "", int(12), int(12), true))
+	return string(utils.FormatAddressAll(tx.Bytes(), "", false, "address", int(12), int(12), true))
 }
 
 // This Function formats each Transaction into Html string.
@@ -62,7 +62,7 @@ func formatToTable(content *types.RawMempoolResponse) *types.DataTableResponse {
 func toTableDataRow(tx *types.RawMempoolTransaction) []interface{} {
 	return []any{
 		utils.FormatAddressWithLimits(tx.Hash.Bytes(), "", false, "tx", 15, 18, true),
-		utils.FormatAddressAll(tx.From.Bytes(), "", false, "address", "", int(12), int(12), true),
+		utils.FormatAddressAll(tx.From.Bytes(), "", false, "address", int(12), int(12), true),
 		_isContractCreation(tx.To),
 		utils.FormatAmount((*big.Int)(tx.Value), utils.Config.Frontend.ElCurrency, 5),
 		utils.FormatAddCommasFormatted(float64(tx.Gas.ToInt().Int64()), 0),

--- a/utils/eth1.go
+++ b/utils/eth1.go
@@ -216,10 +216,10 @@ func formatAddress(address []byte, token []byte, name string, isContract bool, l
 	} else {
 		if token != nil {
 			// link & token
-			ret += fmt.Sprintf(`<a href="/`+link+`/0x%x#erc20Txns" target="_parent" data-html="true" data-toggle="tooltip" data-placement="bottom" title="" data-original-title="%s">%s</a>`, address, tooltip, name)
+			ret += fmt.Sprintf(`<a href="/%s/0x%x#erc20Txns" target="_parent" data-html="true" data-toggle="tooltip" data-placement="bottom" title="" data-original-title="%s">%s</a>`, link, address, tooltip, name)
 		} else {
 			// just link
-			ret += fmt.Sprintf(`<a href="/`+link+`/0x%x" target="_parent" data-html="true" data-toggle="tooltip" data-placement="bottom" title="" data-original-title="%s">%s</a>`, address, tooltip, name)
+			ret += fmt.Sprintf(`<a href="/%s/0x%x" target="_parent" data-html="true" data-toggle="tooltip" data-placement="bottom" title="" data-original-title="%s">%s</a>`, link, address, tooltip, name)
 		}
 	}
 


### PR DESCRIPTION
This PR adds a new wrapper function called `FormatAddressWithLimitsInAddressPageTable`.
It furthermore removes an unused parameter from `formatAddress`.