### PR TITLE
(NOBIDS) mempoolUpdater: fix parsing maxuint in response

### DIFF
--- a/types/frontend.go
+++ b/types/frontend.go
@@ -530,9 +530,9 @@ type Eth1AddressSearchItem struct {
 }
 
 type RawMempoolResponse struct {
-	Pending map[string]map[int]*RawMempoolTransaction `json:"pending"`
-	Queued  map[string]map[int]*RawMempoolTransaction `json:"queued"`
-	BaseFee map[string]map[int]*RawMempoolTransaction `json:"baseFee"`
+	Pending map[string]map[string]*RawMempoolTransaction `json:"pending"`
+	Queued  map[string]map[string]*RawMempoolTransaction `json:"queued"`
+	BaseFee map[string]map[string]*RawMempoolTransaction `json:"baseFee"`
 
 	TxsByHash map[common.Hash]*RawMempoolTransaction
 }


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 7512781</samp>

Fixed a bug in parsing the eth1 mempool API response by using strings as keys for the `RawMempoolResponse` type in `types/frontend.go`. This also simplified the code by removing conversions between ints and strings.
