### PR TITLE
(BIDS-2668) Fix wrong block rewards

### DIFF
--- a/utils/eth1.go
+++ b/utils/eth1.go
@@ -22,7 +22,9 @@ var Erc1155TransferSingleEventHash = common.HexToHash("0xc3d58168c5ae7397731d063
 
 func Eth1BlockReward(blockNumber uint64, difficulty []byte) *big.Int {
 
-	if len(difficulty) == 0 { // no block rewards for PoS blocks
+	// no block rewards for PoS blocks
+	// holesky genesis block has difficulty 1 and zero block reward (launched with pos)
+	if len(difficulty) == 0 || (len(difficulty) == 1 && difficulty[0] == 1) {
 		return big.NewInt(0)
 	}
 
@@ -30,6 +32,8 @@ func Eth1BlockReward(blockNumber uint64, difficulty []byte) *big.Int {
 		return big.NewInt(5e+18)
 	} else if blockNumber < Config.Chain.ElConfig.ConstantinopleBlock.Uint64() {
 		return big.NewInt(3e+18)
+	} else if Config.Chain.ClConfig.DepositChainID == 5 { // special case for goerli: https://github.com/eth-clients/goerli
+		return big.NewInt(0)
 	} else {
 		return big.NewInt(2e+18)
 	}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -610,6 +610,51 @@ func ReadConfig(cfg *types.Config, path string) error {
 		}
 		cfg.Chain.ClConfig = *chainConfig
 	}
+
+	type MinimalELConfig struct {
+		ByzantiumBlock      *big.Int `yaml:"BYZANTIUM_FORK_BLOCK,omitempty"`      // Byzantium switch block (nil = no fork, 0 = already on byzantium)
+		ConstantinopleBlock *big.Int `yaml:"CONSTANTINOPLE_FORK_BLOCK,omitempty"` // Constantinople switch block (nil = no fork, 0 = already activated)
+	}
+	if cfg.Chain.ElConfigPath == "" {
+		minimalCfg := MinimalELConfig{}
+		switch cfg.Chain.Name {
+		case "mainnet":
+			err = yaml.Unmarshal([]byte(config.MainnetChainYml), &minimalCfg)
+		case "prater":
+			err = yaml.Unmarshal([]byte(config.PraterChainYml), &minimalCfg)
+		case "ropsten":
+			err = yaml.Unmarshal([]byte(config.RopstenChainYml), &minimalCfg)
+		case "sepolia":
+			err = yaml.Unmarshal([]byte(config.SepoliaChainYml), &minimalCfg)
+		case "gnosis":
+			err = yaml.Unmarshal([]byte(config.GnosisChainYml), &minimalCfg)
+		case "holesky":
+			err = yaml.Unmarshal([]byte(config.HoleskyChainYml), &minimalCfg)
+		default:
+			return fmt.Errorf("tried to set known chain-config, but unknown chain-name: %v (path: %v)", cfg.Chain.Name, cfg.Chain.ElConfigPath)
+		}
+		if err != nil {
+			return err
+		}
+		cfg.Chain.ElConfig = &params.ChainConfig{
+			ChainID:             big.NewInt(int64(cfg.Chain.Id)),
+			ByzantiumBlock:      minimalCfg.ByzantiumBlock,
+			ConstantinopleBlock: minimalCfg.ConstantinopleBlock,
+		}
+	} else {
+		f, err := os.Open(cfg.Chain.ElConfigPath)
+		if err != nil {
+			return fmt.Errorf("error opening EL Chain Config file %v: %w", cfg.Chain.ElConfigPath, err)
+		}
+		var chainConfig *params.ChainConfig
+		decoder := yaml.NewDecoder(f)
+		err = decoder.Decode(&chainConfig)
+		if err != nil {
+			return fmt.Errorf("error decoding EL Chain Config file %v: %v", cfg.Chain.ElConfigPath, err)
+		}
+		cfg.Chain.ElConfig = chainConfig
+	}
+
 	cfg.Chain.Name = cfg.Chain.ClConfig.ConfigName
 
 	if cfg.Chain.GenesisTimestamp == 0 {


### PR DESCRIPTION
ELConfig was unused and never loaded, loading it now which fixed block rewards on mainnet

Goerli block rewards are always 0, handled that special case

Holesky block 0 reward was wrong, even though it started as a PoS network the genesis block difficulty is 1 which bypassed our "pos check" and showed the wrong reward
