### PR TITLE
(BIDS-2768) use total sync stat columns

### DIFF
--- a/handlers/validator.go
+++ b/handlers/validator.go
@@ -722,11 +722,11 @@ func Validator(w http.ResponseWriter, r *http.Request) {
 			if lastStatsDay > 0 {
 				err = db.ReaderDb.Get(&syncStats, `
 					SELECT
-						COALESCE(SUM(participated_sync), 0) AS participated_sync,
-						COALESCE(SUM(missed_sync), 0) AS missed_sync,
-						COALESCE(SUM(orphaned_sync), 0) AS orphaned_sync
+						COALESCE(participated_sync_total, 0) AS participated_sync,
+						COALESCE(missed_sync_total, 0) AS missed_sync,
+						COALESCE(orphaned_sync_total, 0) AS orphaned_sync
 					FROM validator_stats
-					WHERE validatorindex = $1`, index)
+					WHERE validatorindex = $1 AND day = $2`, index, lastStatsDay)
 				if err != nil {
 					return fmt.Errorf("error getting validator syncStats: %w", err)
 				}


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 2e4045a</samp>

Refactor sync participation metrics query to use cumulative data. Update `handlers/validator.go` to use the new columns and filter by the last day of stats.