### PR TITLE
(NOBIDS) Handle default ELConfig case

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -636,6 +636,12 @@ func ReadConfig(cfg *types.Config, path string) error {
 		if err != nil {
 			return err
 		}
+		if minimalCfg.ByzantiumBlock == nil {
+			minimalCfg.ByzantiumBlock = big.NewInt(0)
+		}
+		if minimalCfg.ConstantinopleBlock == nil {
+			minimalCfg.ConstantinopleBlock = big.NewInt(0)
+		}
 		cfg.Chain.ElConfig = &params.ChainConfig{
 			ChainID:             big.NewInt(int64(cfg.Chain.Id)),
 			ByzantiumBlock:      minimalCfg.ByzantiumBlock,


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 9df2954</samp>

Support minimal configuration for Ethereum 1 chain in explorer. Set default hard fork blocks in `utils/utils.go` to prevent errors.
