### PR TITLE
(BIDS-2775) Use correct class in FormatCurrency

### DIFF
--- a/utils/format.go
+++ b/utils/format.go
@@ -229,7 +229,12 @@ func FormatCurrency(valIf interface{}, valueCurrency, targetCurrency string, dig
 	classes := ""
 
 	if colored {
-		classes = ` class="text-success"`
+		val := IfToDec(valIf)
+		if val.Cmp(decimal.NewFromInt(0)) >= 0 {
+			classes = ` class="text-success"`
+		} else {
+			classes = ` class="text-danger"`
+		}
 	}
 
 	return template.HTML(fmt.Sprintf(`<span%s>%s</span>`, classes, result))


### PR DESCRIPTION
This PR causes `formatCurrency` to use the correct class for negative values.
It fixed a bug introduced here: https://github.com/gobitfly/eth2-beaconchain-explorer/pull/2674/files#diff-5020779d5bcfaa28d8f25d2f4799326a80ad320c4a6f9ee0e17be6407b7c5e00L220-R240