### PR TITLE
Bids 2673/fix sync table on validator page

### DIFF
--- a/db/bigtable.go
+++ b/db/bigtable.go
@@ -1608,6 +1608,11 @@ func (bigtable *Bigtable) getValidatorMissedAttestationHistoryV1(validators []ui
 	return res, nil
 }
 
+// GetValidatorSyncDutiesHistory returns the sync participation status for the given validators ranging from startSlot to endSlot (both inclusive)
+//
+// The returned map uses the following keys: [validatorIndex][slot]
+//
+// The function is able to handle both V1 and V2 schema based on the configured v2SchemaCutOffEpoch
 func (bigtable *Bigtable) GetValidatorSyncDutiesHistory(validators []uint64, startSlot uint64, endSlot uint64) (map[uint64]map[uint64]*types.ValidatorSyncParticipation, error) {
 	if endSlot/utils.Config.Chain.ClConfig.SlotsPerEpoch < bigtable.v2SchemaCutOffEpoch {
 		if startSlot/utils.Config.Chain.ClConfig.SlotsPerEpoch == 0 {

--- a/db/db.go
+++ b/db/db.go
@@ -3124,6 +3124,9 @@ func GetBlockStatus(block int64, latestFinalizedEpoch uint64, epochInfo *types.E
 		block, latestFinalizedEpoch)
 }
 
+// Returns the participation rate for every slot between startSlot and endSlot (both inclusive) as a map with the slot as key
+//
+// If a slot is missed, the map will not contain an entry for it
 func GetSyncParticipationBySlotRange(startSlot, endSlot uint64) (map[uint64]uint64, error) {
 
 	rows := []struct {

--- a/handlers/validator.go
+++ b/handlers/validator.go
@@ -2053,8 +2053,7 @@ func ValidatorSync(w http.ResponseWriter, r *http.Request) {
 		endIndex := start
 
 		// retrieve sync duties and sync participations
-		syncDuties := make(map[uint64]map[uint64]*types.ValidatorSyncParticipation)
-		syncDuties[validatorIndex] = make(map[uint64]*types.ValidatorSyncParticipation, length)
+		syncDuties := make(map[uint64]*types.ValidatorSyncParticipation, length)
 		participations := make(map[uint64]uint64, length)
 		{
 			// the slot range for the given table page might contain multiplie sync periods and therefore we may need to split the queries to avoid fetching potentially thousands of duties at once
@@ -2086,7 +2085,7 @@ func ValidatorSync(w http.ResponseWriter, r *http.Request) {
 					return
 				}
 				for slot, duty := range sdh[validatorIndex] {
-					syncDuties[validatorIndex][slot] = duty
+					syncDuties[slot] = duty
 				}
 
 				par, err := db.GetSyncParticipationBySlotRange(slotRange.StartSlot, slotRange.EndSlot)
@@ -2126,13 +2125,11 @@ func ValidatorSync(w http.ResponseWriter, r *http.Request) {
 			participation := participations[slot]
 
 			status := uint64(0)
-			if syncDuties[validatorIndex] != nil {
-				if syncDuties[validatorIndex][slot] != nil {
-					status = syncDuties[validatorIndex][slot].Status
-				}
-				if _, ok := missedSlotsMap[slot]; ok {
-					status = 3
-				}
+			if syncDuties[slot] != nil {
+				status = syncDuties[slot].Status
+			}
+			if _, ok := missedSlotsMap[slot]; ok {
+				status = 3
 			}
 
 			tableData = append(tableData, []interface{}{

--- a/handlers/validator.go
+++ b/handlers/validator.go
@@ -2056,7 +2056,7 @@ func ValidatorSync(w http.ResponseWriter, r *http.Request) {
 		syncDuties := make(map[uint64]*types.ValidatorSyncParticipation, length)
 		participations := make(map[uint64]uint64, length)
 		{
-			// the slot range for the given table page might contain multiplie sync periods and therefore we may need to split the queries to avoid fetching potentially thousands of duties at once
+			// the slot range for the given table page might contain multiple sync periods and therefore we may need to split the queries to avoid fetching potentially thousands of duties at once
 			type SlotRange struct {
 				StartSlot uint64
 				EndSlot   uint64

--- a/handlers/validator.go
+++ b/handlers/validator.go
@@ -2063,8 +2063,8 @@ func ValidatorSync(w http.ResponseWriter, r *http.Request) {
 	}
 
 	startIndex := start + length - 1
-	if startIndex > uint64(len(slots)-1) {
-		startIndex = uint64(len(slots) - 1)
+	if startIndex >= totalCount {
+		startIndex = totalCount - 1
 	}
 	endIndex := start
 

--- a/handlers/validator.go
+++ b/handlers/validator.go
@@ -2033,8 +2033,9 @@ func ValidatorSync(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			utils.LogError(err, "error encoding json response", 0, errFields)
 			http.Error(w, "Internal server error", http.StatusInternalServerError)
-			return
 		}
+
+		return
 	}
 
 	totalCount := uint64(0) // total count of sync duties for this validator
@@ -2057,6 +2058,9 @@ func ValidatorSync(w http.ResponseWriter, r *http.Request) {
 	}
 
 	totalCount = uint64(len(slots))
+	if start >= totalCount {
+		start = totalCount - 1
+	}
 
 	startIndex := start + length - 1
 	if startIndex > uint64(len(slots)-1) {


### PR DESCRIPTION
This PR splits up the single slot range query for the sync duty history and the sync participation into sub ranges that contain consecutive slots only. This enables the sync table on the `/validator` page to show pages containing more than one sync period again.
It furthermore adds to comments explaining both `GetValidatorSyncDutiesHistory` and `GetSyncParticipationBySlotRange`.