### PR TITLE
(NOBIDS) Add local-deployment/.env to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ cmd/forkwatch
 **/.DS_Store
 _gitignore/
 local-deployment/config.yml
+local-deployment/.env


### PR DESCRIPTION
This PR adds the dynamically created `local-deployment/.env` to `.gitignore`.