### PR TITLE
(NOBIDS) fix local deployment elconfig

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,4 +30,5 @@ cmd/forkwatch
 **/.DS_Store
 _gitignore/
 local-deployment/config.yml
+local-deployment/elconfig.json
 local-deployment/.env

--- a/local-deployment/elconfig.json
+++ b/local-deployment/elconfig.json
@@ -1,0 +1,4 @@
+{
+    "byzantiumBlock": 0,
+    "constantinopleBlock": 0
+}

--- a/local-deployment/elconfig.json
+++ b/local-deployment/elconfig.json
@@ -1,4 +1,0 @@
-{
-    "byzantiumBlock": 0,
-    "constantinopleBlock": 0
-}

--- a/local-deployment/explorer-config-template.yml
+++ b/local-deployment/explorer-config-template.yml
@@ -1,6 +1,6 @@
 chain:
   clConfigPath: 'node'
-  elConfigPath: '' # Works for public networks like mainnet, prater, holesky, sepolia, specify a file for custom chains
+  elConfigPath: '' # Works for well known public networks like mainnet, prater, holesky, sepolia. Specify a file for custom chains
 readerDatabase:
   name: db
   host: {{.DBHost}}

--- a/local-deployment/explorer-config-template.yml
+++ b/local-deployment/explorer-config-template.yml
@@ -1,5 +1,6 @@
 chain:
-  configPath: 'node'
+  clConfigPath: 'node'
+  elConfigPath: '' # Works for public networks like mainnet, prater, holesky, sepolia, specify a file for custom chains
 readerDatabase:
   name: db
   host: {{.DBHost}}

--- a/local-deployment/provision-explorer-config.sh
+++ b/local-deployment/provision-explorer-config.sh
@@ -22,6 +22,15 @@ POSTGRES_PORT=$POSTGRES_PORT
 LBT_PORT=$LBT_PORT
 EOF
 
+touch elconfig.json
+cat >elconfig.json <<EOL
+{
+    "byzantiumBlock": 0,
+    "constantinopleBlock": 0
+}
+EOL
+
+
 touch config.yml
 
 cat >config.yml <<EOL

--- a/local-deployment/provision-explorer-config.sh
+++ b/local-deployment/provision-explorer-config.sh
@@ -35,7 +35,7 @@ touch config.yml
 cat >config.yml <<EOL
 chain:
   clConfigPath: 'node'
-  elConfigPath: 'elconfig.json'
+  elConfigPath: 'local-deployment/elconfig.json'
 readerDatabase:
   name: db
   host: 127.0.0.1
@@ -108,11 +108,11 @@ echo "initializing bigtable schema"
 PROJECT="explorer"
 INSTANCE="explorer"
 HOST="127.0.0.1:$LBT_PORT"
-
-go run ../cmd/misc/main.go -config config.yml -command initBigtableSchema
+cd ..
+go run ./cmd/misc/main.go -config local-deployment/config.yml -command initBigtableSchema
 
 echo "bigtable schema initialization completed"
 
 echo "provisioning postgres db schema"
-go run ../cmd/misc/main.go -config config.yml -command applyDbSchema
+go run ./cmd/misc/main.go -config local-deployment/config.yml -command applyDbSchema
 echo "postgres db schema initialization completed"

--- a/local-deployment/provision-explorer-config.sh
+++ b/local-deployment/provision-explorer-config.sh
@@ -30,7 +30,6 @@ cat >elconfig.json <<EOL
 }
 EOL
 
-
 touch config.yml
 
 cat >config.yml <<EOL

--- a/local-deployment/provision-explorer-config.sh
+++ b/local-deployment/provision-explorer-config.sh
@@ -27,6 +27,7 @@ touch config.yml
 cat >config.yml <<EOL
 chain:
   clConfigPath: 'node'
+  elConfigPath: 'elconfig.json'
 readerDatabase:
   name: db
   host: 127.0.0.1

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -653,7 +653,7 @@ func ReadConfig(cfg *types.Config, path string) error {
 			return fmt.Errorf("error opening EL Chain Config file %v: %w", cfg.Chain.ElConfigPath, err)
 		}
 		var chainConfig *params.ChainConfig
-		decoder := yaml.NewDecoder(f)
+		decoder := json.NewDecoder(f)
 		err = decoder.Decode(&chainConfig)
 		if err != nil {
 			return fmt.Errorf("error decoding EL Chain Config file %v: %v", cfg.Chain.ElConfigPath, err)


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 5bd5c94</samp>

This pull request adds support for configuring the Ethereum hard fork blocks for the local deployment of the explorer. It modifies the `local-deployment/elconfig.json` file and the `local-deployment/provision-explorer-config.sh` script to enable this feature.
