### PR TITLE
(BIDS-2642) Fix lookback for missed attestations on / validator

### DIFF
--- a/handlers/validator.go
+++ b/handlers/validator.go
@@ -578,8 +578,15 @@ func Validator(w http.ResponseWriter, r *http.Request) {
 			validatorPageData.AttestationsCount = validatorPageData.ExitEpoch - validatorPageData.ActivationEpoch
 		} else if validatorPageData.ActivationEpoch > validatorPageData.Epoch {
 			validatorPageData.AttestationsCount = 0
+
+			return nil
 		} else if isPreGenesis {
 			validatorPageData.AttestationsCount = 1
+			validatorPageData.MissedAttestationsCount = 0
+			validatorPageData.ExecutedAttestationsCount = 0
+			validatorPageData.UnmissedAttestationsPercentage = 1
+
+			return nil
 		} else {
 			validatorPageData.AttestationsCount = validatorPageData.Epoch - validatorPageData.ActivationEpoch + 1
 
@@ -595,43 +602,37 @@ func Validator(w http.ResponseWriter, r *http.Request) {
 		}
 
 		if validatorPageData.AttestationsCount > 0 {
-			if isPreGenesis {
-				validatorPageData.MissedAttestationsCount = 0
-				validatorPageData.ExecutedAttestationsCount = 0
-				validatorPageData.UnmissedAttestationsPercentage = 1
-			} else {
-				// get attestationStats from validator_stats
-				attestationStats := struct {
-					MissedAttestations uint64 `db:"missed_attestations"`
-				}{}
-				if lastStatsDay > 0 {
-					err := db.ReaderDb.Get(&attestationStats, "SELECT missed_attestations_total AS missed_attestations FROM validator_stats WHERE validatorindex = $1 AND day = $2", index, lastStatsDay)
-					if err == sql.ErrNoRows {
-						logger.Warningf("no entry in validator_stats for validator index %v while lastStatsDay = %v", index, lastStatsDay)
-					} else if err != nil {
-						return fmt.Errorf("error getting validator attestationStats while lastStatsDay = %v: %w", lastStatsDay, err)
-					}
+			// get attestationStats from validator_stats
+			attestationStats := struct {
+				MissedAttestations uint64 `db:"missed_attestations"`
+			}{}
+			if lastStatsDay > 0 {
+				err := db.ReaderDb.Get(&attestationStats, "SELECT missed_attestations_total AS missed_attestations FROM validator_stats WHERE validatorindex = $1 AND day = $2", index, lastStatsDay)
+				if err == sql.ErrNoRows {
+					logger.Warningf("no entry in validator_stats for validator index %v while lastStatsDay = %v", index, lastStatsDay)
+				} else if err != nil {
+					return fmt.Errorf("error getting validator attestationStats while lastStatsDay = %v: %w", lastStatsDay, err)
 				}
-
-				// add attestationStats that are not yet in validator_stats (if any)
-				nextStatsDayFirstEpoch, _ := utils.GetFirstAndLastEpochForDay(lastStatsDay + 1)
-				if validatorPageData.Epoch > nextStatsDayFirstEpoch {
-					lookback := uint64(validatorPageData.Epoch - nextStatsDayFirstEpoch)
-					missedAttestations, err := db.BigtableClient.GetValidatorMissedAttestationHistory([]uint64{index}, validatorPageData.Epoch-uint64(lookback), validatorPageData.Epoch-1)
-					if err != nil {
-						return fmt.Errorf("error getting validator attestations not in stats from bigtable: %w", err)
-					}
-					attestationStats.MissedAttestations += uint64(len(missedAttestations[index]))
-				}
-
-				if attestationStats.MissedAttestations > validatorPageData.AttestationsCount {
-					// save guard against negative values (should never happen but happened once because of wrong data)
-					attestationStats.MissedAttestations = validatorPageData.AttestationsCount
-				}
-				validatorPageData.MissedAttestationsCount = attestationStats.MissedAttestations
-				validatorPageData.ExecutedAttestationsCount = validatorPageData.AttestationsCount - validatorPageData.MissedAttestationsCount
-				validatorPageData.UnmissedAttestationsPercentage = float64(validatorPageData.ExecutedAttestationsCount) / float64(validatorPageData.AttestationsCount)
 			}
+
+			// add attestationStats that are not yet in validator_stats (if any)
+			nextStatsDayFirstEpoch, _ := utils.GetFirstAndLastEpochForDay(lastStatsDay + 1)
+			if validatorPageData.Epoch > nextStatsDayFirstEpoch {
+				lookback := uint64(validatorPageData.Epoch - nextStatsDayFirstEpoch)
+				missedAttestations, err := db.BigtableClient.GetValidatorMissedAttestationHistory([]uint64{index}, validatorPageData.Epoch-uint64(lookback), validatorPageData.Epoch-1)
+				if err != nil {
+					return fmt.Errorf("error getting validator attestations not in stats from bigtable: %w", err)
+				}
+				attestationStats.MissedAttestations += uint64(len(missedAttestations[index]))
+			}
+
+			if attestationStats.MissedAttestations > validatorPageData.AttestationsCount {
+				// save guard against negative values (should never happen but happened once because of wrong data)
+				attestationStats.MissedAttestations = validatorPageData.AttestationsCount
+			}
+			validatorPageData.MissedAttestationsCount = attestationStats.MissedAttestations
+			validatorPageData.ExecutedAttestationsCount = validatorPageData.AttestationsCount - validatorPageData.MissedAttestationsCount
+			validatorPageData.UnmissedAttestationsPercentage = float64(validatorPageData.ExecutedAttestationsCount) / float64(validatorPageData.AttestationsCount)
 		}
 		return nil
 	})

--- a/handlers/validator.go
+++ b/handlers/validator.go
@@ -609,9 +609,9 @@ func Validator(w http.ResponseWriter, r *http.Request) {
 			}
 
 			// add attestationStats that are not yet in validator_stats
-			lookback := int64(lastFinalizedEpoch - (lastStatsDay+1)*utils.EpochsPerDay())
-			if lookback > 0 {
-				missedAttestations, err := db.BigtableClient.GetValidatorMissedAttestationHistory([]uint64{index}, lastFinalizedEpoch-uint64(lookback), lastFinalizedEpoch)
+			lookback := int64(validatorPageData.Epoch - (lastStatsDay+1)*utils.EpochsPerDay())
+			if lookback > 0 && validatorPageData.Epoch > 0 {
+				missedAttestations, err := db.BigtableClient.GetValidatorMissedAttestationHistory([]uint64{index}, validatorPageData.Epoch-uint64(lookback), validatorPageData.Epoch-1)
 				if err != nil {
 					return fmt.Errorf("error getting validator attestations not in stats from bigtable: %w", err)
 				}

--- a/handlers/validator.go
+++ b/handlers/validator.go
@@ -608,9 +608,10 @@ func Validator(w http.ResponseWriter, r *http.Request) {
 				}
 			}
 
-			// add attestationStats that are not yet in validator_stats
-			lookback := int64(validatorPageData.Epoch - (lastStatsDay+1)*utils.EpochsPerDay())
-			if lookback > 0 && validatorPageData.Epoch > 0 {
+			// add attestationStats that are not yet in validator_stats (if any)
+			nextStatsDayFirstEpoch, _ := utils.GetFirstAndLastEpochForDay(lastStatsDay + 1)
+			if validatorPageData.Epoch > nextStatsDayFirstEpoch {
+				lookback := uint64(validatorPageData.Epoch - nextStatsDayFirstEpoch)
 				missedAttestations, err := db.BigtableClient.GetValidatorMissedAttestationHistory([]uint64{index}, validatorPageData.Epoch-uint64(lookback), validatorPageData.Epoch-1)
 				if err != nil {
 					return fmt.Errorf("error getting validator attestations not in stats from bigtable: %w", err)

--- a/handlers/validator.go
+++ b/handlers/validator.go
@@ -618,7 +618,7 @@ func Validator(w http.ResponseWriter, r *http.Request) {
 			// add attestationStats that are not yet in validator_stats (if any)
 			nextStatsDayFirstEpoch, _ := utils.GetFirstAndLastEpochForDay(lastStatsDay + 1)
 			if validatorPageData.Epoch > nextStatsDayFirstEpoch {
-				lookback := uint64(validatorPageData.Epoch - nextStatsDayFirstEpoch)
+				lookback := validatorPageData.Epoch - nextStatsDayFirstEpoch
 				missedAttestations, err := db.BigtableClient.GetValidatorMissedAttestationHistory([]uint64{index}, validatorPageData.Epoch-uint64(lookback), validatorPageData.Epoch-1)
 				if err != nil {
 					return fmt.Errorf("error getting validator attestations not in stats from bigtable: %w", err)

--- a/handlers/validator.go
+++ b/handlers/validator.go
@@ -619,7 +619,7 @@ func Validator(w http.ResponseWriter, r *http.Request) {
 			nextStatsDayFirstEpoch, _ := utils.GetFirstAndLastEpochForDay(lastStatsDay + 1)
 			if validatorPageData.Epoch > nextStatsDayFirstEpoch {
 				lookback := validatorPageData.Epoch - nextStatsDayFirstEpoch
-				missedAttestations, err := db.BigtableClient.GetValidatorMissedAttestationHistory([]uint64{index}, validatorPageData.Epoch-uint64(lookback), validatorPageData.Epoch-1)
+				missedAttestations, err := db.BigtableClient.GetValidatorMissedAttestationHistory([]uint64{index}, validatorPageData.Epoch-lookback, validatorPageData.Epoch-1)
 				if err != nil {
 					return fmt.Errorf("error getting validator attestations not in stats from bigtable: %w", err)
 				}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1431,9 +1431,9 @@ func EpochsPerDay() uint64 {
 	return (uint64(day.Seconds()) / Config.Chain.ClConfig.SlotsPerEpoch) / Config.Chain.ClConfig.SecondsPerSlot
 }
 
-func GetFirstAndLastEpochForDay(day uint64) (uint64, uint64) {
-	firstEpoch := day * EpochsPerDay()
-	lastEpoch := firstEpoch + EpochsPerDay() - 1
+func GetFirstAndLastEpochForDay(day uint64) (firstEpoch uint64, lastEpoch uint64) {
+	firstEpoch = day * EpochsPerDay()
+	lastEpoch = firstEpoch + EpochsPerDay() - 1
 	return firstEpoch, lastEpoch
 }
 


### PR DESCRIPTION
This PR fixes the calculation of executed/missed attestations on `/validator` for the summary shown here:
![image](https://github.com/gobitfly/eth2-beaconchain-explorer/assets/114066135/dcb0205c-16fc-4e7a-9a6e-d1e574bc3f99)
