### PR TITLE
(NOBIDS) fix exporting graffiti_stats by using graffiti_stats_status

### DIFF
--- a/db/migrations/20231128164000_add_graffiti_stats_status.sql
+++ b/db/migrations/20231128164000_add_graffiti_stats_status.sql
@@ -1,0 +1,16 @@
+-- +goose Up
+-- +goose StatementBegin
+SELECT 'up SQL query - add table graffiti_stats_status';
+CREATE TABLE IF NOT EXISTS
+    graffiti_stats_status (
+        day INT NOT NULL,
+        status BOOLEAN NOT NULL,
+        PRIMARY KEY (DAY)
+    );
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+SELECT 'down SQL query - drop table graffiti_stats_status';
+DROP TABLE IF EXISTS graffiti_stats_status;
+-- +goose StatementEnd


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 1428ba4</samp>

This pull request adds a new table `graffiti_stats_status` to track the export status of graffiti statistics for each day and updates the `WriteGraffitiStatisticsForDay` and `statisticsLoop` functions to use the new table. These changes aim to improve the performance, reliability, and usability of the graffiti statistics feature.
