### PR TITLE
Bids 2613/add tooltips to withdrawals for full amount

### DIFF
--- a/handlers/common.go
+++ b/handlers/common.go
@@ -318,7 +318,7 @@ func GetValidatorEarnings(validators []uint64, currency string) (*types.Validato
 	earnings.LastWeekFormatted = utils.FormatIncomeClEl(earnings.Income7d, currency)
 	earnings.LastMonthFormatted = utils.FormatIncomeClEl(earnings.Income31d, currency)
 	earnings.TotalFormatted = utils.FormatIncomeClEl(earnings.IncomeTotal, currency)
-	earnings.TotalBalance = "<b>" + utils.FormatClCurrency(totalBalance, currency, 5, true, false, false) + "</b>"
+	earnings.TotalBalance = "<b>" + utils.FormatClCurrency(totalBalance, currency, 5, true, false, false, false) + "</b>"
 	return earnings, balancesMap, nil
 }
 

--- a/handlers/dashboard.go
+++ b/handlers/dashboard.go
@@ -439,7 +439,7 @@ func getNextWithdrawalRow(queryValidators []uint64, currency string) ([][]interf
 		template.HTML(fmt.Sprintf(`<span class="text-muted">~ %s</span>`, utils.FormatBlockSlot(utils.TimeToSlot(uint64(timeToWithdrawal.Unix()))))),
 		template.HTML(fmt.Sprintf(`<span class="">~ %s</span>`, utils.FormatTimestamp(timeToWithdrawal.Unix()))),
 		withdrawalCredentialsTemplate,
-		template.HTML(fmt.Sprintf(`<span class="text-muted"><span data-toggle="tooltip" title="If the withdrawal were to be processed at this very moment, this amount would be withdrawn"><i class="far ml-1 fa-question-circle" style="margin-left: 0px !important;"></i></span> %s</span>`, utils.FormatClCurrency(withdrawalAmount, currency, 6, true, false, false))),
+		template.HTML(fmt.Sprintf(`<span class="text-muted"><span data-toggle="tooltip" title="If the withdrawal were to be processed at this very moment, this amount would be withdrawn"><i class="far ml-1 fa-question-circle" style="margin-left: 0px !important;"></i></span> %s</span>`, utils.FormatClCurrency(withdrawalAmount, currency, 6, true, false, false, true))),
 	})
 
 	return nextData, nil
@@ -681,8 +681,7 @@ func DashboardDataWithdrawals(w http.ResponseWriter, r *http.Request) {
 			template.HTML(fmt.Sprintf("%v", utils.FormatBlockSlot(w.Slot))),
 			template.HTML(fmt.Sprintf("%v", utils.FormatTimestamp(utils.SlotToTime(w.Slot).Unix()))),
 			template.HTML(fmt.Sprintf("%v", utils.FormatAddress(w.Address, nil, "", false, false, true))),
-			template.HTML(utils.FormatClCurrency(w.Amount, reqCurrency, 6, true, false, false)),
-			// template.HTML(fmt.Sprintf("%v", utils.FormatAmount(new(big.Int).Mul(new(big.Int).SetUint64(w.Amount), big.NewInt(1e9)), utils.Config.Frontend.ElCurrency, 6))),
+			template.HTML(utils.FormatClCurrency(w.Amount, reqCurrency, 6, true, false, false, true)),
 		})
 	}
 

--- a/handlers/eth1Account.go
+++ b/handlers/eth1Account.go
@@ -159,7 +159,7 @@ func Eth1Address(w http.ResponseWriter, r *http.Request) {
 				template.HTML(fmt.Sprintf("%v", utils.FormatBlockSlot(w.Slot))),
 				template.HTML(fmt.Sprintf("%v", utils.FormatTimestamp(utils.SlotToTime(w.Slot).Unix()))),
 				template.HTML(fmt.Sprintf("%v", utils.FormatValidator(w.ValidatorIndex))),
-				template.HTML(utils.FormatClCurrency(w.Amount, currency, 6, true, false, false)),
+				template.HTML(utils.FormatClCurrency(w.Amount, currency, 6, true, false, false, true)),
 			})
 		}
 
@@ -177,7 +177,7 @@ func Eth1Address(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			return fmt.Errorf("GetAddressWithdrawalsTotal: %w", err)
 		}
-		withdrawalSummary = template.HTML(utils.FormatClCurrency(sumWithdrawals, currency, 6, true, false, false))
+		withdrawalSummary = template.HTML(utils.FormatClCurrency(sumWithdrawals, currency, 6, true, false, false, false))
 		return nil
 	})
 
@@ -396,7 +396,7 @@ func Eth1AddressWithdrawals(w http.ResponseWriter, r *http.Request) {
 			template.HTML(fmt.Sprintf("%v", utils.FormatBlockSlot(w.Slot))),
 			template.HTML(fmt.Sprintf("%v", utils.FormatTimestamp(utils.SlotToTime(w.Slot).Unix()))),
 			template.HTML(fmt.Sprintf("%v", utils.FormatValidator(w.ValidatorIndex))),
-			template.HTML(utils.FormatClCurrency(w.Amount, currency, 6, true, false, false)),
+			template.HTML(utils.FormatClCurrency(w.Amount, currency, 6, true, false, false, true)),
 		}
 	}
 

--- a/handlers/eth1Account.go
+++ b/handlers/eth1Account.go
@@ -177,7 +177,7 @@ func Eth1Address(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			return fmt.Errorf("GetAddressWithdrawalsTotal: %w", err)
 		}
-		withdrawalSummary = template.HTML(utils.FormatClCurrency(sumWithdrawals, currency, 6, true, false, false, false))
+		withdrawalSummary = template.HTML(utils.FormatClCurrency(sumWithdrawals, currency, 6, true, false, false, true))
 		return nil
 	})
 

--- a/handlers/slot.go
+++ b/handlers/slot.go
@@ -786,7 +786,7 @@ func SlotWithdrawalData(w http.ResponseWriter, r *http.Request) {
 			template.HTML(fmt.Sprintf("%v", w.Index)),
 			template.HTML(fmt.Sprintf("%v", utils.FormatValidator(w.ValidatorIndex))),
 			template.HTML(fmt.Sprintf("%v", utils.FormatAddress(w.Address, nil, "", false, false, true))),
-			template.HTML(utils.FormatClCurrency(w.Amount, currency, 6, true, false, false)),
+			template.HTML(utils.FormatClCurrency(w.Amount, currency, 6, true, false, false, true)),
 		})
 	}
 

--- a/handlers/slot.go
+++ b/handlers/slot.go
@@ -781,7 +781,6 @@ func SlotWithdrawalData(w http.ResponseWriter, r *http.Request) {
 
 	tableData := make([][]interface{}, 0, len(withdrawals))
 	for _, w := range withdrawals {
-		// logger.Infof("w: %+v", w)
 		tableData = append(tableData, []interface{}{
 			template.HTML(fmt.Sprintf("%v", w.Index)),
 			template.HTML(fmt.Sprintf("%v", utils.FormatValidator(w.ValidatorIndex))),
@@ -793,8 +792,7 @@ func SlotWithdrawalData(w http.ResponseWriter, r *http.Request) {
 	data := &types.DataTableResponse{
 		Draw:         1,
 		RecordsTotal: uint64(len(withdrawals)),
-		// RecordsFiltered: uint64(len(withdrawals)),
-		Data: tableData,
+		Data:         tableData,
 	}
 
 	err = json.NewEncoder(w).Encode(data)

--- a/handlers/validator.go
+++ b/handlers/validator.go
@@ -498,7 +498,7 @@ func Validator(w http.ResponseWriter, r *http.Request) {
 						template.HTML(fmt.Sprintf(`<span class="text-muted">~ %s</span>`, utils.FormatBlockSlot(utils.TimeToSlot(uint64(timeToWithdrawal.Unix()))))),
 						template.HTML(fmt.Sprintf(`<span class="">~ %s</span>`, utils.FormatTimestamp(timeToWithdrawal.Unix()))),
 						withdrawalCredentialsTemplate,
-						template.HTML(fmt.Sprintf(`<span class="text-muted"><span data-toggle="tooltip" title="If the withdrawal were to be processed at this very moment, this amount would be withdrawn"><i class="far ml-1 fa-question-circle" style="margin-left: 0px !important;"></i></span> %s</span>`, utils.FormatClCurrency(withdrawalAmount, currency, 6, true, false, false))),
+						template.HTML(fmt.Sprintf(`<span class="text-muted"><span data-toggle="tooltip" title="If the withdrawal were to be processed at this very moment, this amount would be withdrawn"><i class="far ml-1 fa-question-circle" style="margin-left: 0px !important;"></i></span> %s</span>`, utils.FormatClCurrency(withdrawalAmount, currency, 6, true, false, false, true))),
 					})
 
 					validatorPageData.NextWithdrawalRow = tableData
@@ -1292,7 +1292,8 @@ func ValidatorWithdrawals(w http.ResponseWriter, r *http.Request) {
 			template.HTML(fmt.Sprintf("%v", utils.FormatBlockSlot(w.Slot))),
 			template.HTML(fmt.Sprintf("%v", utils.FormatTimestamp(utils.SlotToTime(w.Slot).Unix()))),
 			template.HTML(fmt.Sprintf("%v", utils.FormatAddress(w.Address, nil, "", false, false, true))),
-			template.HTML(utils.FormatClCurrency(w.Amount, reqCurrency, 6, true, false, false)),
+			template.HTML(utils.FormatClCurrency(w.Amount, reqCurrency, 6, true, false, false, true)),
+			// utils.FormatAmount(new(big.Int).Mul(new(big.Int).SetUint64(w.Amount), big.NewInt(1e9)), formatCurrency, 6))
 		})
 	}
 

--- a/handlers/validator.go
+++ b/handlers/validator.go
@@ -1293,7 +1293,6 @@ func ValidatorWithdrawals(w http.ResponseWriter, r *http.Request) {
 			template.HTML(fmt.Sprintf("%v", utils.FormatTimestamp(utils.SlotToTime(w.Slot).Unix()))),
 			template.HTML(fmt.Sprintf("%v", utils.FormatAddress(w.Address, nil, "", false, false, true))),
 			template.HTML(utils.FormatClCurrency(w.Amount, reqCurrency, 6, true, false, false, true)),
-			// utils.FormatAmount(new(big.Int).Mul(new(big.Int).SetUint64(w.Amount), big.NewInt(1e9)), formatCurrency, 6))
 		})
 	}
 

--- a/handlers/validators_leaderboard.go
+++ b/handlers/validators_leaderboard.go
@@ -145,10 +145,10 @@ func ValidatorsLeaderboardData(w http.ResponseWriter, r *http.Request) {
 			utils.FormatValidatorWithName(b.Index, b.Name),
 			utils.FormatPublicKey(b.PublicKey),
 			fmt.Sprintf("%v", b.Balance),
-			utils.FormatClCurrency(b.Performance1d, currency, 5, true, true, true),
-			utils.FormatClCurrency(b.Performance7d, currency, 5, true, true, true),
-			utils.FormatClCurrency(b.Performance31d, currency, 5, true, true, true),
-			utils.FormatClCurrency(b.Performance365d, currency, 5, true, true, true),
+			utils.FormatClCurrency(b.Performance1d, currency, 5, true, true, true, false),
+			utils.FormatClCurrency(b.Performance7d, currency, 5, true, true, true, false),
+			utils.FormatClCurrency(b.Performance31d, currency, 5, true, true, true, false),
+			utils.FormatClCurrency(b.Performance365d, currency, 5, true, true, true, false),
 		}
 	}
 

--- a/services/notifications.go
+++ b/services/notifications.go
@@ -1956,7 +1956,7 @@ func (n *validatorWithdrawalNotification) GetEventName() types.EventName {
 }
 
 func (n *validatorWithdrawalNotification) GetInfo(includeUrl bool) string {
-	generalPart := fmt.Sprintf(`An automatic withdrawal of %v has been processed for validator %v.`, utils.FormatClCurrencyString(n.Amount, utils.Config.Frontend.MainCurrency, 6, true, false), n.ValidatorIndex)
+	generalPart := fmt.Sprintf(`An automatic withdrawal of %v has been processed for validator %v.`, utils.FormatClCurrencyString(n.Amount, utils.Config.Frontend.MainCurrency, 6, true, false, false), n.ValidatorIndex)
 	if includeUrl {
 		return generalPart + getUrlPart(n.ValidatorIndex)
 	}
@@ -1972,7 +1972,7 @@ func (n *validatorWithdrawalNotification) GetEventFilter() string {
 }
 
 func (n *validatorWithdrawalNotification) GetInfoMarkdown() string {
-	generalPart := fmt.Sprintf(`An automatic withdrawal of %[2]v has been processed for validator [%[1]v](https://%[6]v/validator/%[1]v) during slot [%[3]v](https://%[6]v/slot/%[3]v). The funds have been sent to: [%[4]v](https://%[6]v/address/0x%[5]x).`, n.ValidatorIndex, utils.FormatClCurrencyString(n.Amount, utils.Config.Frontend.MainCurrency, 6, true, false), n.Slot, utils.FormatHashRaw(n.Address), n.Address, utils.Config.Frontend.SiteDomain)
+	generalPart := fmt.Sprintf(`An automatic withdrawal of %[2]v has been processed for validator [%[1]v](https://%[6]v/validator/%[1]v) during slot [%[3]v](https://%[6]v/slot/%[3]v). The funds have been sent to: [%[4]v](https://%[6]v/address/0x%[5]x).`, n.ValidatorIndex, utils.FormatClCurrencyString(n.Amount, utils.Config.Frontend.MainCurrency, 6, true, false, false), n.Slot, utils.FormatHashRaw(n.Address), n.Address, utils.Config.Frontend.SiteDomain)
 	return generalPart
 }
 

--- a/templates/eth1tx.html
+++ b/templates/eth1tx.html
@@ -226,7 +226,7 @@
                 <div class="col-md-9">
                   {{ formatBytesAmount .Value config.Frontend.ElCurrency 8 }}
                   <span id="valuePriceButton" class="badge badge-pill align-middle bg-dark text-white" data-html="true" data-toggle="tooltip" data-placement="bottom" data-original-title="Current Value" {{ if .HistoricalEtherPrice }}onclick="togglePriceContent('{{ .CurrentEtherPrice }}','{{ .HistoricalEtherPrice }}')" style="cursor: pointer;"{{ end }}>
-                    {{ formatElCurrency .Value $.Rates.SelectedCurrency 2 true false false }}
+                    {{ formatElCurrency .Value $.Rates.SelectedCurrency 2 true false false false }}
                   </span>
                 </div>
               </div>
@@ -235,7 +235,7 @@
                 <div class="col-md-9">
                   {{ formatBytesAmount .Gas.TxFee config.Frontend.ElCurrency 8 }}
                   <span id="valuePriceButton" class="badge badge-pill align-middle bg-dark text-white" data-html="true" data-toggle="tooltip" data-placement="bottom" data-original-title="Current Value">
-                    {{ formatElCurrency .Gas.TxFee $.Rates.SelectedCurrency 2 true false false }}
+                    {{ formatElCurrency .Gas.TxFee $.Rates.SelectedCurrency 2 true false false false }}
                   </span>
                 </div>
               </div>

--- a/templates/validator/overview.html
+++ b/templates/validator/overview.html
@@ -85,9 +85,9 @@
           <div class="px-2 mx-auto" style="max-width: 50rem;">
             <span>
               {{ if eq .InclusionDelay 0 }}
-                A deposit has been made, and your validator will be voted into the activation queue once the deposited amount sums up to {{ formatClCurrency config.Chain.ClConfig.MaxEffectiveBalance $.Rates.ClCurrency 0 true false false }}.
+                A deposit has been made, and your validator will be voted into the activation queue once the deposited amount sums up to {{ formatClCurrency config.Chain.ClConfig.MaxEffectiveBalance $.Rates.ClCurrency 0 true false false false }}.
               {{ else }}
-                The last deposit to the Deposit contract was made {{ if gt .Deposits.LastEth1DepositTs 0 }}<span aria-ethereum-date-format="FROMNOW" aria-ethereum-date="{{ .Deposits.LastEth1DepositTs }}"></span>{{ end }}, it will take <a href="https://kb.beaconcha.in/ethereum-2.0-and-depositing-process">around 16-24 hours</a> until your deposit is processed by the beacon chain. This validator will be eligible for activation once the deposited amount sums up to {{ formatClCurrency config.Chain.ClConfig.MaxEffectiveBalance $.Rates.ClCurrency 0 true false false }}.
+                The last deposit to the Deposit contract was made {{ if gt .Deposits.LastEth1DepositTs 0 }}<span aria-ethereum-date-format="FROMNOW" aria-ethereum-date="{{ .Deposits.LastEth1DepositTs }}"></span>{{ end }}, it will take <a href="https://kb.beaconcha.in/ethereum-2.0-and-depositing-process">around 16-24 hours</a> until your deposit is processed by the beacon chain. This validator will be eligible for activation once the deposited amount sums up to {{ formatClCurrency config.Chain.ClConfig.MaxEffectiveBalance $.Rates.ClCurrency 0 true false false false }}.
               {{ end }}
               <br />
               Join our <a href="https://dsc.gg/beaconchain">Discord server</a> for support, questions and suggestions.
@@ -153,7 +153,7 @@
       <div class="m-3 position-relative" style="flex-basis: 4rem; white-space: nowrap;">
         <span style="top:-1.2rem; white-space: nowrap;" class="text-muted font-weight-lighter position-absolute"><small>Balance</small></span>
         <div class="d-flex flex-column">
-          <span style="font-weight: bold; font-size:18px;">{{ formatClCurrency .CurrentBalance $.Rates.SelectedCurrency 5 true false false }}</span>
+          <span style="font-weight: bold; font-size:18px;">{{ formatClCurrency .CurrentBalance $.Rates.SelectedCurrency 5 true false false false }}</span>
           <span style="font-size: 0.8rem; color: gray"
             >{{ formatEffectiveBalance .EffectiveBalance config.Frontend.MainCurrency }}
             <span data-toggle="tooltip" title="The effective balance is used to calculate the base rewards of a validator"
@@ -183,7 +183,7 @@
       <div class="m-3 position-relative">
         <span style="top:-1.2rem;" class="text-muted font-weight-lighter position-absolute"><small>Balance</small></span>
         <div style="width: 8.32rem" class="d-flex flex-column">
-          <span style="font-weight: bold; font-size:18px;">{{ formatClCurrency .CurrentBalance $.Rates.SelectedCurrency 5 true false false }}</span>
+          <span style="font-weight: bold; font-size:18px;">{{ formatClCurrency .CurrentBalance $.Rates.SelectedCurrency 5 true false false false }}</span>
           <span
             >{{ formatEffectiveBalance .EffectiveBalance config.Frontend.MainCurrency }}
             <span style="font-size:0.8rem; color:gray" data-toggle="tooltip" title="The effective balance is used to calculate the base rewards of a validator"

--- a/templates/validator/tables.html
+++ b/templates/validator/tables.html
@@ -687,9 +687,9 @@
               data-toggle="tooltip"
               data-html="true"
               title="
-                CL: {{ formatElCurrency .Income.IncomeTotal.Cl $.Rates.SelectedCurrency 5 true true true }} <br /> 
-                EL: {{ formatElCurrency .Income.IncomeTotal.El $.Rates.SelectedCurrency 5 true true true }}">
-              <b>{{ formatElCurrency .Income.IncomeTotal.Total $.Rates.SelectedCurrency 5 true true true }}</b>
+                CL: {{ formatElCurrency .Income.IncomeTotal.Cl $.Rates.SelectedCurrency 5 true true true false }} <br /> 
+                EL: {{ formatElCurrency .Income.IncomeTotal.El $.Rates.SelectedCurrency 5 true true true false }}">
+              <b>{{ formatElCurrency .Income.IncomeTotal.Total $.Rates.SelectedCurrency 5 true true true false }}</b>
             </span>
           </td>
         </tr>
@@ -700,9 +700,9 @@
               data-toggle="tooltip"
               data-html="true"
               title="
-                CL: {{ formatElCurrency .Income.IncomeToday.Cl $.Rates.SelectedCurrency 5 true true true }} <br /> 
-                EL: {{ formatElCurrency .Income.IncomeToday.El $.Rates.SelectedCurrency 5 true true true }}">
-              <b>{{ formatElCurrency .Income.IncomeToday.Total $.Rates.SelectedCurrency 5 true true true }}</b>
+                CL: {{ formatElCurrency .Income.IncomeToday.Cl $.Rates.SelectedCurrency 5 true true true false }} <br /> 
+                EL: {{ formatElCurrency .Income.IncomeToday.El $.Rates.SelectedCurrency 5 true true true false }}">
+              <b>{{ formatElCurrency .Income.IncomeToday.Total $.Rates.SelectedCurrency 5 true true true false }}</b>
             </span>
           </td>
         </tr>
@@ -714,13 +714,13 @@
               data-toggle="tooltip"
               data-html="true"
               title="
-                CL: {{ formatElCurrency .Income.Income1d.Cl $.Rates.SelectedCurrency 5 true true true }} | {{ formatElCurrency .Income.Income7d.Cl $.Rates.SelectedCurrency 5 true true true }} | {{ formatElCurrency .Income.Income31d.Cl $.Rates.SelectedCurrency 5 true true true }} <br> 
-                EL: {{ formatElCurrency .Income.Income1d.El $.Rates.SelectedCurrency 5 true true true }} | {{ formatElCurrency .Income.Income7d.El $.Rates.SelectedCurrency 5 true true true }} | {{ formatElCurrency .Income.Income31d.El $.Rates.SelectedCurrency 5 true true true }}">
-              <b>{{ formatElCurrency .Income.Income1d.Total $.Rates.SelectedCurrency 5 false true true }}</b>
+                CL: {{ formatElCurrency .Income.Income1d.Cl $.Rates.SelectedCurrency 5 true true true false }} | {{ formatElCurrency .Income.Income7d.Cl $.Rates.SelectedCurrency 5 true true true false }} | {{ formatElCurrency .Income.Income31d.Cl $.Rates.SelectedCurrency 5 true true true false }} <br> 
+                EL: {{ formatElCurrency .Income.Income1d.El $.Rates.SelectedCurrency 5 true true true false }} | {{ formatElCurrency .Income.Income7d.El $.Rates.SelectedCurrency 5 true true true false }} | {{ formatElCurrency .Income.Income31d.El $.Rates.SelectedCurrency 5 true true true false }}">
+              <b>{{ formatElCurrency .Income.Income1d.Total $.Rates.SelectedCurrency 5 false true true false }}</b>
               |
-              <b>{{ formatElCurrency .Income.Income7d.Total $.Rates.SelectedCurrency 5 false true true }}</b>
+              <b>{{ formatElCurrency .Income.Income7d.Total $.Rates.SelectedCurrency 5 false true true false }}</b>
               |
-              <b>{{ formatElCurrency .Income.Income31d.Total $.Rates.SelectedCurrency 5 false true true }}</b>
+              <b>{{ formatElCurrency .Income.Income31d.Total $.Rates.SelectedCurrency 5 false true true false }}</b>
             </span>
           </td>
         </tr>
@@ -749,10 +749,10 @@
               data-toggle="tooltip"
               data-html="true"
               title="
-                  CL: 1d: {{ formatElCurrency .Income1d.Cl $.Rates.SelectedCurrency 5 false true true }} | 7d: {{ formatElCurrency .Income.Income7d.Cl $.Rates.SelectedCurrency 5 false true true }} | 31d: {{ formatElCurrency .Income.Income31d.Cl $.Rates.SelectedCurrency 5 true true true }} <br /> 
-                  EL: 1d: {{ formatElCurrency .Income1d.El $.Rates.SelectedCurrency 5 false true true }} | 7d: {{ formatElCurrency .Income.Income7d.El $.Rates.SelectedCurrency 5 false true true }} | 31d: {{ formatElCurrency .Income.Income31d.El $.Rates.SelectedCurrency 5 true true true }} <br /> 
-                  All: 1d: {{ formatElCurrency .Income1d.Total $.Rates.SelectedCurrency 5 false true true }} | 7d: {{ formatElCurrency .Income.Income7d.Total $.Rates.SelectedCurrency 5 false true true }} | 31d: {{ formatElCurrency .Income.Income31d.Total $.Rates.SelectedCurrency 5 true true true }}">
-              <b>{{ formatElCurrency .Income.Income7d.Total $.Rates.SelectedCurrency 5 true true true }}</b>
+                  CL: 1d: {{ formatElCurrency .Income1d.Cl $.Rates.SelectedCurrency 5 false true true false }} | 7d: {{ formatElCurrency .Income.Income7d.Cl $.Rates.SelectedCurrency 5 false true true false }} | 31d: {{ formatElCurrency .Income.Income31d.Cl $.Rates.SelectedCurrency 5 true true true false }} <br /> 
+                  EL: 1d: {{ formatElCurrency .Income1d.El $.Rates.SelectedCurrency 5 false true true false }} | 7d: {{ formatElCurrency .Income.Income7d.El $.Rates.SelectedCurrency 5 false true true false }} | 31d: {{ formatElCurrency .Income.Income31d.El $.Rates.SelectedCurrency 5 true true true false }} <br /> 
+                  All: 1d: {{ formatElCurrency .Income1d.Total $.Rates.SelectedCurrency 5 false true true false }} | 7d: {{ formatElCurrency .Income.Income7d.Total $.Rates.SelectedCurrency 5 false true true false }} | 31d: {{ formatElCurrency .Income.Income31d.Total $.Rates.SelectedCurrency 5 true true true false }}">
+              <b>{{ formatElCurrency .Income.Income7d.Total $.Rates.SelectedCurrency 5 true true true false }}</b>
               <i class="far fa-question-circle"></i>
             </span>
           </td>

--- a/templates/validator/withdrawalOverviewRow.html
+++ b/templates/validator/withdrawalOverviewRow.html
@@ -9,7 +9,7 @@
             </div>
             <div class="d-flex justify-content-between align-items-center">
               <span class="h6 font-weight-normal mb-0" title="Number of withdrawals Processed"><b>{{ formatAddCommas .WithdrawalCount }}</b> <small>processed</small></span>
-              <span class="h6 font-weight-normal mb-0"><b>{{ formatClCurrency .TotalAmountWithdrawn config.Frontend.MainCurrency 2 true false false false }}</b> <small>distributed</small></span>
+              <span class="h6 font-weight-normal mb-0"><b>{{ formatClCurrency .TotalAmountWithdrawn config.Frontend.MainCurrency 2 true false false true }}</b> <small>distributed</small></span>
             </div>
           </div>
         </div>

--- a/templates/validator/withdrawalOverviewRow.html
+++ b/templates/validator/withdrawalOverviewRow.html
@@ -9,7 +9,7 @@
             </div>
             <div class="d-flex justify-content-between align-items-center">
               <span class="h6 font-weight-normal mb-0" title="Number of withdrawals Processed"><b>{{ formatAddCommas .WithdrawalCount }}</b> <small>processed</small></span>
-              <span class="h6 font-weight-normal mb-0"><b>{{ formatClCurrency .TotalAmountWithdrawn config.Frontend.MainCurrency 2 true false false }}</b> <small>distributed</small></span>
+              <span class="h6 font-weight-normal mb-0"><b>{{ formatClCurrency .TotalAmountWithdrawn config.Frontend.MainCurrency 2 true false false false }}</b> <small>distributed</small></span>
             </div>
           </div>
         </div>

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -86,7 +86,6 @@ func GetTemplateFuncs() template.FuncMap {
 		"formatNotificationChannel":               FormatNotificationChannel,
 		"formatBalanceSql":                        FormatBalanceSql,
 		"formatCurrentBalance":                    FormatCurrentBalance,
-		"formatCurrency":                          FormatCurrency,
 		"formatElCurrency":                        FormatElCurrency,
 		"formatClCurrency":                        FormatClCurrency,
 		"formatEffectiveBalance":                  FormatEffectiveBalance,


### PR DESCRIPTION
This PR adds another parameter to various EL/CL value formatting functions: `truncateAndAddTooltip`
It will truncate (no rounding) decimal places if there are more than `digitsAfterComma`. If digits are truncated, a tooltip for the complete amount is shown.
If `truncateAndAddTooltip` is set and there are less than `digitsAfterComma`, trailing 0s will be added.

This is only used for withdrawal-related numbers.