### PR TITLE
(BIDS-2813) fix forms on settings page

### DIFF
--- a/handlers/user.go
+++ b/handlers/user.go
@@ -1178,7 +1178,7 @@ func UserUpdateEmailPost(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// check if password is correct
-	formPassword := r.FormValue("password")
+	formPassword := r.FormValue("current-password")
 
 	err = bcrypt.CompareHashAndPassword([]byte(userData.Password), []byte(formPassword))
 	if err != nil {

--- a/templates/user/settings.html
+++ b/templates/user/settings.html
@@ -402,8 +402,8 @@
                     <form id="email-form" action="settings/email" method="POST">
                       {{ .CsrfField }}
                       <div class="form-group">
-                        <label for="password">Confirm Current Password</label>
-                        <input required type="password" minlength="5" maxlength="256" class="form-control" autocomplete="password" id="password" name="password" />
+                        <label for="current-password">Confirm Current Password</label>
+                        <input required type="password" minlength="5" maxlength="256" class="form-control" autocomplete="current-password" id="current-password" name="current-password" />
                       </div>
                       <div class="form-group">
                         <label for="email">New Email Address</label>


### PR DESCRIPTION
Two form inputs had the same ID on the user settings page, causing errors when trying to change passwords. This PR renames one input so that changing passwords works again.