### PR TITLE
(NOBIDS) Add electra_fork_epoch for tx spammer

### DIFF
--- a/local-deployment/main.star
+++ b/local-deployment/main.star
@@ -67,7 +67,7 @@ def run(plan, args):
 
 	if args["start_tx_spammer"]:
 		plan.print("Launching transaction spammer")
-		transaction_spammer.launch_transaction_spammer(plan, genesis_constants.PRE_FUNDED_ACCOUNTS, fuzz_target , args_with_right_defaults.tx_spammer_params)
+		transaction_spammer.launch_transaction_spammer(plan, genesis_constants.PRE_FUNDED_ACCOUNTS, fuzz_target, args_with_right_defaults.tx_spammer_params, network_params.electra_fork_epoch)
 		plan.print("Succesfully launched transaction spammer")
 
 	if args["start_blob_spammer"]:

--- a/local-deployment/network-params.json
+++ b/local-deployment/network-params.json
@@ -22,7 +22,8 @@
       "seconds_per_slot": 12,
       "genesis_delay": 10,
       "capella_fork_epoch": 0,
-      "deneb_fork_epoch": 999999999
+      "deneb_fork_epoch": 999999999,
+      "electra_fork_epoch": 999999999
     },
     "global_client_log_level": "info",
     "start_tx_spammer": true,


### PR DESCRIPTION
This PR adds the `electra_fork_epoch` to `network-params.json` and uses it for the transaction spammer via `main.star`. This is relevant for the local deployment only.