### PR TITLE
(BIDS-1823) Remove duplicated code in eth1Account.go

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -10,6 +10,7 @@ import (
 	"eth2-exporter/types"
 	"eth2-exporter/utils"
 	"fmt"
+	"html/template"
 	"math/big"
 	"regexp"
 	"sort"
@@ -2202,30 +2203,31 @@ func GetEpochWithdrawalsTotal(epoch uint64) (total uint64, err error) {
 	return
 }
 
-// GetAddressWithdrawals returns the withdrawals for an address
-func GetAddressWithdrawals(address []byte, limit uint64, pageToken string) ([]*types.Withdrawals, string, error) {
+// GetAddressWithdrawals returns the withdrawal data for an address
+func GetAddressWithdrawals(address []byte, limit uint64, pageToken string, currency string) (*types.DataTableResponse, error) {
 	const endOfWithdrawalsData = "End of withdrawals data"
 
 	var withdrawals []*types.Withdrawals
 	if limit == 0 {
 		limit = 100
 	}
-
-	var withdrawalindex uint64
+	var withdrawalIndex uint64
 	var err error
+	var nextPageToken string
+
 	if pageToken == "" {
 		// Start from the beginning
-		withdrawalindex, err = GetTotalWithdrawals()
+		withdrawalIndex, err = GetTotalWithdrawals()
 		if err != nil {
-			return nil, "", fmt.Errorf("error getting total withdrawals for address: %x, %w", address, err)
+			return nil, fmt.Errorf("error getting total withdrawals for address: %x, %w", address, err)
 		}
 	} else if pageToken == endOfWithdrawalsData {
 		// Last page already shown, end the infinite scroll
-		return nil, "", nil
+		return nil, nil
 	} else {
-		withdrawalindex, err = strconv.ParseUint(pageToken, 10, 64)
+		withdrawalIndex, err = strconv.ParseUint(pageToken, 10, 64)
 		if err != nil {
-			return nil, "", fmt.Errorf("error parsing page token: %w", err)
+			return nil, fmt.Errorf("error parsing page token: %w", err)
 		}
 	}
 
@@ -2239,22 +2241,39 @@ func GetAddressWithdrawals(address []byte, limit uint64, pageToken string) ([]*t
 	FROM blocks_withdrawals w
 	INNER JOIN blocks b ON b.blockroot = w.block_root AND b.status = '1'
 	WHERE w.address = $1 AND w.withdrawalindex <= $2
-	ORDER BY w.withdrawalindex DESC LIMIT $3`, address, withdrawalindex, limit+1)
+	ORDER BY w.withdrawalindex DESC LIMIT $3`, address, withdrawalIndex, limit+1)
 	if err != nil {
-		if err == sql.ErrNoRows {
-			return withdrawals, "", nil
+		if err != sql.ErrNoRows {
+			return nil, fmt.Errorf("error getting blocks_withdrawals for address: %x: %w", address, err)
 		}
-		return nil, "", fmt.Errorf("error getting blocks_withdrawals for address: %x: %w", address, err)
+		nextPageToken = ""
+	} else {
+		// Get the next page token and remove that withdrawal from the results
+		nextPageToken = endOfWithdrawalsData
+		if len(withdrawals) == int(limit+1) {
+			nextPageToken = fmt.Sprintf("%d", withdrawals[limit].Index)
+			withdrawals = withdrawals[:limit]
+		}
 	}
 
-	// Get the next page token and remove that withdrawal from the results
-	nextPageToken := endOfWithdrawalsData
-	if len(withdrawals) == int(limit+1) {
-		nextPageToken = fmt.Sprintf("%d", withdrawals[limit].Index)
-		withdrawals = withdrawals[:limit]
+	withdrawalsData := make([][]interface{}, len(withdrawals))
+	for i, w := range withdrawals {
+		withdrawalsData[i] = []interface{}{
+			template.HTML(fmt.Sprintf("%v", utils.FormatEpoch(utils.EpochOfSlot(w.Slot)))),
+			template.HTML(fmt.Sprintf("%v", utils.FormatBlockSlot(w.Slot))),
+			template.HTML(fmt.Sprintf("%v", utils.FormatTimestamp(utils.SlotToTime(w.Slot).Unix()))),
+			template.HTML(fmt.Sprintf("%v", utils.FormatValidator(w.ValidatorIndex))),
+			template.HTML(utils.FormatClCurrency(w.Amount, currency, 6, true, false, false)),
+		}
 	}
 
-	return withdrawals, nextPageToken, nil
+	resultData := &types.DataTableResponse{
+		RecordsTotal: uint64(len(withdrawalsData)),
+		Data:         withdrawalsData,
+		PagingToken:  nextPageToken,
+	}
+
+	return resultData, nil
 }
 
 func GetEpochWithdrawals(epoch uint64) ([]*types.WithdrawalsNotification, error) {

--- a/handlers/eth1Account.go
+++ b/handlers/eth1Account.go
@@ -147,29 +147,11 @@ func Eth1Address(w http.ResponseWriter, r *http.Request) {
 	})
 	g.Go(func() error {
 		var err error
-		addressWithdrawals, nextPageToken, err := db.GetAddressWithdrawals(addressBytes, 25, "")
+		withdrawals, err := db.GetAddressWithdrawals(addressBytes, 25, "", currency)
 		if err != nil {
 			return fmt.Errorf("GetAddressWithdrawals: %w", err)
 		}
-
-		withdrawalsData := make([][]interface{}, 0, len(addressWithdrawals))
-		for _, w := range addressWithdrawals {
-			withdrawalsData = append(withdrawalsData, []interface{}{
-				template.HTML(fmt.Sprintf("%v", utils.FormatEpoch(utils.EpochOfSlot(w.Slot)))),
-				template.HTML(fmt.Sprintf("%v", utils.FormatBlockSlot(w.Slot))),
-				template.HTML(fmt.Sprintf("%v", utils.FormatTimestamp(utils.SlotToTime(w.Slot).Unix()))),
-				template.HTML(fmt.Sprintf("%v", utils.FormatValidator(w.ValidatorIndex))),
-				template.HTML(utils.FormatClCurrency(w.Amount, currency, 6, true, false, false)),
-			})
-		}
-
-		withdrawals = &types.DataTableResponse{
-			Draw:         1,
-			RecordsTotal: uint64(len(withdrawalsData)),
-			Data:         withdrawalsData,
-			PagingToken:  nextPageToken,
-		}
-
+		withdrawals.Draw = 1
 		return nil
 	})
 	g.Go(func() error {
@@ -382,30 +364,15 @@ func Eth1AddressWithdrawals(w http.ResponseWriter, r *http.Request) {
 	errFields := map[string]interface{}{
 		"route": r.URL.String()}
 
-	withdrawals, nextPageToken, err := db.GetAddressWithdrawals(common.HexToAddress(address).Bytes(), 25, q.Get("pageToken"))
+	withdrawalData, err := db.GetAddressWithdrawals(common.HexToAddress(address).Bytes(), 25, q.Get("pageToken"), currency)
+	withdrawalData.RecordsTotal = 0
 	if err != nil {
 		utils.LogError(err, "error getting address withdrawals data", 0, errFields)
 		http.Error(w, "Internal server error", http.StatusInternalServerError)
 		return
 	}
 
-	tableData := make([][]interface{}, len(withdrawals))
-	for i, w := range withdrawals {
-		tableData[i] = []interface{}{
-			template.HTML(fmt.Sprintf("%v", utils.FormatEpoch(utils.EpochOfSlot(w.Slot)))),
-			template.HTML(fmt.Sprintf("%v", utils.FormatBlockSlot(w.Slot))),
-			template.HTML(fmt.Sprintf("%v", utils.FormatTimestamp(utils.SlotToTime(w.Slot).Unix()))),
-			template.HTML(fmt.Sprintf("%v", utils.FormatValidator(w.ValidatorIndex))),
-			template.HTML(utils.FormatClCurrency(w.Amount, currency, 6, true, false, false)),
-		}
-	}
-
-	data := &types.DataTableResponse{
-		Data:        tableData,
-		PagingToken: nextPageToken,
-	}
-
-	err = json.NewEncoder(w).Encode(data)
+	err = json.NewEncoder(w).Encode(withdrawalData)
 	if err != nil {
 		utils.LogError(err, "error enconding json response", 0, errFields)
 		http.Error(w, "Internal server error", http.StatusInternalServerError)


### PR DESCRIPTION
Removes identical code appearing in functions `Eth1AddressWithdrawals()` and `Eth1Address()` in _eth1Account.go_. 
Instead, this duplicated logic is moved into `GetAddressWithdrawals()` in _db.go_.
The changes look a bit complicated, however they are the simplest way I found to replicate 1:1 the behavior of the original code.

I recommend the reviewer to study the modifications in `Eth1AddressWithdrawals()` and `Eth1Address()` before studying `GetAddressWithdrawals()`, it will help understanding.

copilot:summary
