### PR TITLE
(BIDS-2782) Remove duplicated code in two functions of eth1Account.go

### DIFF
--- a/db/bigtable_eth1.go
+++ b/db/bigtable_eth1.go
@@ -2002,7 +2002,7 @@ func (bigtable *Bigtable) GetAddressTransactionsTableData(address []byte, pageTo
 		pageToken = fmt.Sprintf("%s:I:TX:%x:%s:", bigtable.chainId, address, FILTER_TIME)
 	}
 
-	transactions, lastKey, err := BigtableClient.GetEth1TxForAddress(pageToken, 25)
+	transactions, lastKey, err := BigtableClient.GetEth1TxForAddress(pageToken, DefaultSizeOfRowsQueries)
 	if err != nil {
 		return nil, err
 	}
@@ -2117,7 +2117,7 @@ func (bigtable *Bigtable) GetAddressBlocksMinedTableData(address string, pageTok
 		pageToken = fmt.Sprintf("%s:I:B:%s:", bigtable.chainId, address)
 	}
 
-	blocks, lastKey, err := BigtableClient.GetEth1BlocksForAddress(pageToken, 25)
+	blocks, lastKey, err := BigtableClient.GetEth1BlocksForAddress(pageToken, DefaultSizeOfRowsQueries)
 	if err != nil {
 		return nil, err
 	}
@@ -2214,7 +2214,7 @@ func (bigtable *Bigtable) GetAddressUnclesMinedTableData(address string, pageTok
 		pageToken = fmt.Sprintf("%s:I:U:%s:", bigtable.chainId, address)
 	}
 
-	uncles, lastKey, err := BigtableClient.GetEth1UnclesForAddress(pageToken, 25)
+	uncles, lastKey, err := BigtableClient.GetEth1UnclesForAddress(pageToken, DefaultSizeOfRowsQueries)
 	if err != nil {
 		return nil, err
 	}
@@ -2307,7 +2307,7 @@ func (bigtable *Bigtable) GetAddressBlobTableData(address []byte, pageToken stri
 		pageToken = fmt.Sprintf("%s:I:BTX:%x:%s:", bigtable.chainId, address, FILTER_TIME)
 	}
 
-	transactions, lastKey, err := bigtable.GetEth1BtxForAddress(pageToken, 25)
+	transactions, lastKey, err := bigtable.GetEth1BtxForAddress(pageToken, DefaultSizeOfRowsQueries)
 	if err != nil {
 		return nil, err
 	}
@@ -2426,7 +2426,7 @@ func (bigtable *Bigtable) GetAddressInternalTableData(address []byte, pageToken 
 		pageToken = fmt.Sprintf("%s:I:ITX:%x:%s:", bigtable.chainId, address, FILTER_TIME)
 	}
 
-	transactions, lastKey, err := bigtable.GetEth1ItxForAddress(pageToken, 25)
+	transactions, lastKey, err := bigtable.GetEth1ItxForAddress(pageToken, DefaultSizeOfRowsQueries)
 	if err != nil {
 		return nil, err
 	}
@@ -2739,7 +2739,7 @@ func (bigtable *Bigtable) GetAddressErc20TableData(address []byte, pageToken str
 		pageToken = fmt.Sprintf("%s:I:ERC20:%x:%s:", bigtable.chainId, address, FILTER_TIME)
 	}
 
-	transactions, lastKey, err := bigtable.GetEth1ERC20ForAddress(pageToken, 25)
+	transactions, lastKey, err := bigtable.GetEth1ERC20ForAddress(pageToken, DefaultSizeOfRowsQueries)
 	if err != nil {
 		return nil, err
 	}
@@ -2865,7 +2865,7 @@ func (bigtable *Bigtable) GetAddressErc721TableData(address []byte, pageToken st
 		pageToken = fmt.Sprintf("%s:I:ERC721:%x:%s:", bigtable.chainId, address, FILTER_TIME)
 	}
 
-	transactions, lastKey, err := bigtable.GetEth1ERC721ForAddress(pageToken, 25)
+	transactions, lastKey, err := bigtable.GetEth1ERC721ForAddress(pageToken, DefaultSizeOfRowsQueries)
 	if err != nil {
 		return nil, err
 	}
@@ -2975,7 +2975,7 @@ func (bigtable *Bigtable) GetAddressErc1155TableData(address []byte, pageToken s
 		pageToken = fmt.Sprintf("%s:I:ERC1155:%x:%s:", bigtable.chainId, address, FILTER_TIME)
 	}
 
-	transactions, lastKey, err := bigtable.GetEth1ERC1155ForAddress(pageToken, 25)
+	transactions, lastKey, err := bigtable.GetEth1ERC1155ForAddress(pageToken, DefaultSizeOfRowsQueries)
 	if err != nil {
 		return nil, err
 	}
@@ -3805,7 +3805,7 @@ func (bigtable *Bigtable) GetTokenTransactionsTableData(token []byte, address []
 		}
 	}
 
-	transactions, lastKey, err := BigtableClient.GetEth1TxForToken(pageToken, 25)
+	transactions, lastKey, err := BigtableClient.GetEth1TxForToken(pageToken, DefaultSizeOfRowsQueries)
 	if err != nil {
 		return nil, err
 	}

--- a/db/bigtable_eth1.go
+++ b/db/bigtable_eth1.go
@@ -2002,7 +2002,7 @@ func (bigtable *Bigtable) GetAddressTransactionsTableData(address []byte, pageTo
 		pageToken = fmt.Sprintf("%s:I:TX:%x:%s:", bigtable.chainId, address, FILTER_TIME)
 	}
 
-	transactions, lastKey, err := BigtableClient.GetEth1TxForAddress(pageToken, DefaultSizeOfRowsQueries)
+	transactions, lastKey, err := BigtableClient.GetEth1TxForAddress(pageToken, DefaultInfScrollRows)
 	if err != nil {
 		return nil, err
 	}
@@ -2117,7 +2117,7 @@ func (bigtable *Bigtable) GetAddressBlocksMinedTableData(address string, pageTok
 		pageToken = fmt.Sprintf("%s:I:B:%s:", bigtable.chainId, address)
 	}
 
-	blocks, lastKey, err := BigtableClient.GetEth1BlocksForAddress(pageToken, DefaultSizeOfRowsQueries)
+	blocks, lastKey, err := BigtableClient.GetEth1BlocksForAddress(pageToken, DefaultInfScrollRows)
 	if err != nil {
 		return nil, err
 	}
@@ -2214,7 +2214,7 @@ func (bigtable *Bigtable) GetAddressUnclesMinedTableData(address string, pageTok
 		pageToken = fmt.Sprintf("%s:I:U:%s:", bigtable.chainId, address)
 	}
 
-	uncles, lastKey, err := BigtableClient.GetEth1UnclesForAddress(pageToken, DefaultSizeOfRowsQueries)
+	uncles, lastKey, err := BigtableClient.GetEth1UnclesForAddress(pageToken, DefaultInfScrollRows)
 	if err != nil {
 		return nil, err
 	}
@@ -2307,7 +2307,7 @@ func (bigtable *Bigtable) GetAddressBlobTableData(address []byte, pageToken stri
 		pageToken = fmt.Sprintf("%s:I:BTX:%x:%s:", bigtable.chainId, address, FILTER_TIME)
 	}
 
-	transactions, lastKey, err := bigtable.GetEth1BtxForAddress(pageToken, DefaultSizeOfRowsQueries)
+	transactions, lastKey, err := bigtable.GetEth1BtxForAddress(pageToken, DefaultInfScrollRows)
 	if err != nil {
 		return nil, err
 	}
@@ -2426,7 +2426,7 @@ func (bigtable *Bigtable) GetAddressInternalTableData(address []byte, pageToken 
 		pageToken = fmt.Sprintf("%s:I:ITX:%x:%s:", bigtable.chainId, address, FILTER_TIME)
 	}
 
-	transactions, lastKey, err := bigtable.GetEth1ItxForAddress(pageToken, DefaultSizeOfRowsQueries)
+	transactions, lastKey, err := bigtable.GetEth1ItxForAddress(pageToken, DefaultInfScrollRows)
 	if err != nil {
 		return nil, err
 	}
@@ -2739,7 +2739,7 @@ func (bigtable *Bigtable) GetAddressErc20TableData(address []byte, pageToken str
 		pageToken = fmt.Sprintf("%s:I:ERC20:%x:%s:", bigtable.chainId, address, FILTER_TIME)
 	}
 
-	transactions, lastKey, err := bigtable.GetEth1ERC20ForAddress(pageToken, DefaultSizeOfRowsQueries)
+	transactions, lastKey, err := bigtable.GetEth1ERC20ForAddress(pageToken, DefaultInfScrollRows)
 	if err != nil {
 		return nil, err
 	}
@@ -2865,7 +2865,7 @@ func (bigtable *Bigtable) GetAddressErc721TableData(address []byte, pageToken st
 		pageToken = fmt.Sprintf("%s:I:ERC721:%x:%s:", bigtable.chainId, address, FILTER_TIME)
 	}
 
-	transactions, lastKey, err := bigtable.GetEth1ERC721ForAddress(pageToken, DefaultSizeOfRowsQueries)
+	transactions, lastKey, err := bigtable.GetEth1ERC721ForAddress(pageToken, DefaultInfScrollRows)
 	if err != nil {
 		return nil, err
 	}
@@ -2975,7 +2975,7 @@ func (bigtable *Bigtable) GetAddressErc1155TableData(address []byte, pageToken s
 		pageToken = fmt.Sprintf("%s:I:ERC1155:%x:%s:", bigtable.chainId, address, FILTER_TIME)
 	}
 
-	transactions, lastKey, err := bigtable.GetEth1ERC1155ForAddress(pageToken, DefaultSizeOfRowsQueries)
+	transactions, lastKey, err := bigtable.GetEth1ERC1155ForAddress(pageToken, DefaultInfScrollRows)
 	if err != nil {
 		return nil, err
 	}
@@ -3805,7 +3805,7 @@ func (bigtable *Bigtable) GetTokenTransactionsTableData(token []byte, address []
 		}
 	}
 
-	transactions, lastKey, err := BigtableClient.GetEth1TxForToken(pageToken, DefaultSizeOfRowsQueries)
+	transactions, lastKey, err := BigtableClient.GetEth1TxForToken(pageToken, DefaultInfScrollRows)
 	if err != nil {
 		return nil, err
 	}

--- a/db/db.go
+++ b/db/db.go
@@ -2215,10 +2215,8 @@ func GetAddressWithdrawalTableData(address []byte, pageToken string, currency st
 	var err error
 	var nextPageToken string
 	var emptyData = &types.DataTableResponse{
-		Draw:         0,
-		RecordsTotal: 0,
-		Data:         make([][]interface{}, 0),
-		PagingToken:  "",
+		Data:        make([][]interface{}, 0),
+		PagingToken: "",
 	}
 
 	tmr := time.AfterFunc(REPORT_TIMEOUT, func() {

--- a/handlers/eth1Account.go
+++ b/handlers/eth1Account.go
@@ -147,29 +147,11 @@ func Eth1Address(w http.ResponseWriter, r *http.Request) {
 	})
 	g.Go(func() error {
 		var err error
-		addressWithdrawals, nextPageToken, err := db.GetAddressWithdrawals(addressBytes, 25, "")
+		withdrawals, err = db.GetAddressWithdrawals(addressBytes, 25, "", currency)
 		if err != nil {
 			return fmt.Errorf("GetAddressWithdrawals: %w", err)
 		}
-
-		withdrawalsData := make([][]interface{}, 0, len(addressWithdrawals))
-		for _, w := range addressWithdrawals {
-			withdrawalsData = append(withdrawalsData, []interface{}{
-				template.HTML(fmt.Sprintf("%v", utils.FormatEpoch(utils.EpochOfSlot(w.Slot)))),
-				template.HTML(fmt.Sprintf("%v", utils.FormatBlockSlot(w.Slot))),
-				template.HTML(fmt.Sprintf("%v", utils.FormatTimestamp(utils.SlotToTime(w.Slot).Unix()))),
-				template.HTML(fmt.Sprintf("%v", utils.FormatValidator(w.ValidatorIndex))),
-				template.HTML(utils.FormatClCurrency(w.Amount, currency, 6, true, false, false, true)),
-			})
-		}
-
-		withdrawals = &types.DataTableResponse{
-			Draw:         1,
-			RecordsTotal: uint64(len(withdrawalsData)),
-			Data:         withdrawalsData,
-			PagingToken:  nextPageToken,
-		}
-
+		withdrawals.Draw = 1
 		return nil
 	})
 	g.Go(func() error {
@@ -382,30 +364,15 @@ func Eth1AddressWithdrawals(w http.ResponseWriter, r *http.Request) {
 	errFields := map[string]interface{}{
 		"route": r.URL.String()}
 
-	withdrawals, nextPageToken, err := db.GetAddressWithdrawals(common.HexToAddress(address).Bytes(), 25, q.Get("pageToken"))
+	withdrawalData, err := db.GetAddressWithdrawals(common.HexToAddress(address).Bytes(), 25, q.Get("pageToken"), currency)
+	withdrawalData.RecordsTotal = 0
 	if err != nil {
 		utils.LogError(err, "error getting address withdrawals data", 0, errFields)
 		http.Error(w, "Internal server error", http.StatusInternalServerError)
 		return
 	}
 
-	tableData := make([][]interface{}, len(withdrawals))
-	for i, w := range withdrawals {
-		tableData[i] = []interface{}{
-			template.HTML(fmt.Sprintf("%v", utils.FormatEpoch(utils.EpochOfSlot(w.Slot)))),
-			template.HTML(fmt.Sprintf("%v", utils.FormatBlockSlot(w.Slot))),
-			template.HTML(fmt.Sprintf("%v", utils.FormatTimestamp(utils.SlotToTime(w.Slot).Unix()))),
-			template.HTML(fmt.Sprintf("%v", utils.FormatValidator(w.ValidatorIndex))),
-			template.HTML(utils.FormatClCurrency(w.Amount, currency, 6, true, false, false, true)),
-		}
-	}
-
-	data := &types.DataTableResponse{
-		Data:        tableData,
-		PagingToken: nextPageToken,
-	}
-
-	err = json.NewEncoder(w).Encode(data)
+	err = json.NewEncoder(w).Encode(withdrawalData)
 	if err != nil {
 		utils.LogError(err, "error enconding json response", 0, errFields)
 		http.Error(w, "Internal server error", http.StatusInternalServerError)

--- a/handlers/eth1Account.go
+++ b/handlers/eth1Account.go
@@ -147,11 +147,10 @@ func Eth1Address(w http.ResponseWriter, r *http.Request) {
 	})
 	g.Go(func() error {
 		var err error
-		withdrawals, err = db.GetAddressWithdrawals(addressBytes, 25, "", currency)
+		withdrawals, err = db.GetAddressWithdrawalTableData(addressBytes, "", currency)
 		if err != nil {
-			return fmt.Errorf("GetAddressWithdrawals: %w", err)
+			return fmt.Errorf("GetAddressWithdrawalTableData: %w", err)
 		}
-		withdrawals.Draw = 1
 		return nil
 	})
 	g.Go(func() error {
@@ -364,15 +363,14 @@ func Eth1AddressWithdrawals(w http.ResponseWriter, r *http.Request) {
 	errFields := map[string]interface{}{
 		"route": r.URL.String()}
 
-	withdrawalData, err := db.GetAddressWithdrawals(common.HexToAddress(address).Bytes(), 25, q.Get("pageToken"), currency)
-	withdrawalData.RecordsTotal = 0
+	data, err := db.GetAddressWithdrawalTableData(common.HexToAddress(address).Bytes(), q.Get("pageToken"), currency)
 	if err != nil {
 		utils.LogError(err, "error getting address withdrawals data", 0, errFields)
 		http.Error(w, "Internal server error", http.StatusInternalServerError)
 		return
 	}
 
-	err = json.NewEncoder(w).Encode(withdrawalData)
+	err = json.NewEncoder(w).Encode(data)
 	if err != nil {
 		utils.LogError(err, "error enconding json response", 0, errFields)
 		http.Error(w, "Internal server error", http.StatusInternalServerError)


### PR DESCRIPTION
Removes identical code appearing in functions `Eth1Address()` and `Eth1AddressWithdrawals()` in _eth1Account.go_. 
Instead, this duplicated logic is moved into `GetAddressWithdrawals()` in _db.go_.
The changes in this last function look a bit complicated, however they are the simplest way I found to replicate 1:1 the behavior of the original code.

I recommend the reviewer to study the modifications in `Eth1Address()` and `Eth1AddressWithdrawals()` before studying `GetAddressWithdrawals()`, it will help understanding.

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 1caa68c</samp>

Refactored and simplified the code for fetching and displaying eth1 address withdrawals. Used the `html/template` package and a common response type for the withdrawals table. Improved the handling of no withdrawals and currency conversion.