### PR TITLE
(BIDS-2645) Adapt epoch page to slot-based exporter

### DIFF
--- a/handlers/epochs.go
+++ b/handlers/epochs.go
@@ -127,9 +127,9 @@ func EpochsData(w http.ResponseWriter, r *http.Request) {
 		tableData[i] = []interface{}{
 			utils.FormatEpoch(b.Epoch),
 			utils.FormatTimestamp(utils.EpochToTime(b.Epoch).Unix()),
-			b.AttestationsCount,
-			fmt.Sprintf("%v / %v", b.DepositsCount, b.WithdrawalCount),
-			fmt.Sprintf("%v / %v", b.ProposerSlashingsCount, b.AttesterSlashingsCount),
+			utils.FormatCount(b.AttestationsCount, b.Finalized, false),
+			fmt.Sprintf("%v / %v", utils.FormatCount(b.DepositsCount, b.Finalized, true), utils.FormatCount(b.WithdrawalCount, b.Finalized, true)),
+			fmt.Sprintf("%v / %v", utils.FormatCount(b.ProposerSlashingsCount, b.Finalized, true), utils.FormatCount(b.AttesterSlashingsCount, b.Finalized, true)),
 			utils.FormatYesNo(b.Finalized),
 			utils.FormatBalance(b.EligibleEther, currency),
 			utils.FormatGlobalParticipationRate(b.VotedEther, b.GlobalParticipationRate, currency),

--- a/templates/epoch.html
+++ b/templates/epoch.html
@@ -177,11 +177,11 @@
             <div class="col-md-3">
               <span>Attestations:</span>
             </div>
-            <div class="col-md-9">{{ if or .Finalized .AttestationsCount }}{{ formatAddCommas .AttestationsCount }}{{ else }}Calculating...{{ end }}</div>
+            <div class="col-md-9">{{ if or .Finalized .AttestationsCount }}{{ formatAddCommas .AttestationsCount }}{{ else }}Calculating…{{ end }}</div>
           </div>
           <div class="row border-bottom p-3 mx-0">
             <div class="col-md-3">Deposits:</div>
-            <div class="col-md-9">{{ if or .Finalized .DepositsCount }}{{ .DepositsCount }}{{ else }}Calculating...{{ end }}</div>
+            <div class="col-md-9">{{ if or .Finalized .DepositsCount }}{{ .DepositsCount }}{{ else }}Calculating…{{ end }}</div>
           </div>
           <div class="row border-bottom p-3 mx-0">
             <div class="col-md-3">Withdrawals:</div>
@@ -200,7 +200,7 @@
                   {{ formatBalance .EligibleEther $.Rates.SelectedCurrency }}
                   <small class="text-muted ml-1">({{ formatPercentageWithPrecision .GlobalParticipationRate 1 }} %)</small>
                 {{ else }}
-                  Calculating... (total stake: {{ formatBalance .EligibleEther $.Rates.SelectedCurrency }})
+                  Calculating… (total stake: {{ formatBalance .EligibleEther $.Rates.SelectedCurrency }})
                 {{ end }}
               </div>
               <div class="progress" style="height: 5px; width: 250px;">
@@ -231,7 +231,7 @@
               {{ if or .Finalized .BlocksCount }}
                 {{ .BlocksCount }}
               {{ else }}
-                Calculating...
+                Calculating…
               {{ end }}
               <small class="text-muted"> ({{ if gt .ProposedCount 0 }}{{ .ProposedCount }} Proposed{{ end }}{{ if gt .MissedCount 0 }}, {{ .MissedCount }} Missed{{ end }}{{ if gt .ScheduledCount 0 }}, {{ .ScheduledCount }} Pending{{ end }}{{ if gt .OrphanedCount 0 }}, {{ .OrphanedCount }} Orphaned{{ end }}) </small>
             </div>

--- a/templates/epoch.html
+++ b/templates/epoch.html
@@ -189,7 +189,7 @@
           </div>
           <div class="row border-bottom p-3 mx-0">
             <div class="col-md-3">Slashings <span data-toggle="tooltip" data-placement="top" title="Proposers">P</span> / <span data-toggle="tooltip" data-placement="top" title="Attesters">A</span>:</div>
-            <div class="col-md-9">{{ .ProposerSlashingsCount }} / {{ .AttesterSlashingsCount }}</div>
+            <div class="col-md-9">{{ if or .Finalized .ProposerSlashingsCount }}{{ .ProposerSlashingsCount }}{{ else }}...{{ end }} / {{ if or .Finalized .AttesterSlashingsCount }}{{ .AttesterSlashingsCount }}{{ else }}...{{ end }}</div>
           </div>
           <div class="row border-bottom p-3 mx-0">
             <div class="col-md-3">Voting Participation:</div>

--- a/templates/epoch.html
+++ b/templates/epoch.html
@@ -177,11 +177,11 @@
             <div class="col-md-3">
               <span>Attestations:</span>
             </div>
-            <div class="col-md-9">{{ formatAddCommas .AttestationsCount }}</div>
+            <div class="col-md-9">{{ if or .Finalized .AttestationsCount }}{{ formatAddCommas .AttestationsCount }}{{ else }}Calculating...{{ end }}</div>
           </div>
           <div class="row border-bottom p-3 mx-0">
             <div class="col-md-3">Deposits:</div>
-            <div class="col-md-9">{{ .DepositsCount }}</div>
+            <div class="col-md-9">{{ if or .Finalized .DepositsCount }}{{ .DepositsCount }}{{ else }}Calculating...{{ end }}</div>
           </div>
           <div class="row border-bottom p-3 mx-0">
             <div class="col-md-3">Withdrawals:</div>
@@ -195,12 +195,13 @@
             <div class="col-md-3">Voting Participation:</div>
             <div class="col-md-9">
               <div>
-                {{ formatBalance .VotedEther $.Rates.SelectedCurrency }} of
-                {{ formatBalance .EligibleEther $.Rates.SelectedCurrency }}
-                <small class="text-muted ml-1"
-                  >({{ formatPercentageWithPrecision .GlobalParticipationRate 1 }}
-                  %)</small
-                >
+                {{ if or .Finalized .VotedEther }}
+                  {{ formatBalance .VotedEther $.Rates.SelectedCurrency }} of
+                  {{ formatBalance .EligibleEther $.Rates.SelectedCurrency }}
+                  <small class="text-muted ml-1">({{ formatPercentageWithPrecision .GlobalParticipationRate 1 }} %)</small>
+                {{ else }}
+                  Calculating... (total stake: {{ formatBalance .EligibleEther $.Rates.SelectedCurrency }})
+                {{ end }}
               </div>
               <div class="progress" style="height: 5px; width: 250px;">
                 <div class="progress-bar" role="progressbar" style="width: {{ .GlobalParticipationRate | formatPercentage }}%;" aria-valuenow="{{ .GlobalParticipationRate | formatPercentage }}" aria-valuemin="0" aria-valuemax="100"></div>
@@ -227,7 +228,11 @@
           <div class="row p-3 mx-0 collapsed">
             <div style="position:relative" class="col-md-3">Slots:</div>
             <div class="col-md-9">
-              {{ .BlocksCount }}
+              {{ if or .Finalized .BlocksCount }}
+                {{ .BlocksCount }}
+              {{ else }}
+                Calculating...
+              {{ end }}
               <small class="text-muted"> ({{ if gt .ProposedCount 0 }}{{ .ProposedCount }} Proposed{{ end }}{{ if gt .MissedCount 0 }}, {{ .MissedCount }} Missed{{ end }}{{ if gt .ScheduledCount 0 }}, {{ .ScheduledCount }} Pending{{ end }}{{ if gt .OrphanedCount 0 }}, {{ .OrphanedCount }} Orphaned{{ end }}) </small>
             </div>
           </div>

--- a/templates/epoch.html
+++ b/templates/epoch.html
@@ -189,7 +189,7 @@
           </div>
           <div class="row border-bottom p-3 mx-0">
             <div class="col-md-3">Slashings <span data-toggle="tooltip" data-placement="top" title="Proposers">P</span> / <span data-toggle="tooltip" data-placement="top" title="Attesters">A</span>:</div>
-            <div class="col-md-9">{{ if or .Finalized .ProposerSlashingsCount }}{{ .ProposerSlashingsCount }}{{ else }}...{{ end }} / {{ if or .Finalized .AttesterSlashingsCount }}{{ .AttesterSlashingsCount }}{{ else }}...{{ end }}</div>
+            <div class="col-md-9">{{ if or .Finalized .ProposerSlashingsCount }}{{ .ProposerSlashingsCount }}{{ else }}…{{ end }} / {{ if or .Finalized .AttesterSlashingsCount }}{{ .AttesterSlashingsCount }}{{ else }}…{{ end }}</div>
           </div>
           <div class="row border-bottom p-3 mx-0">
             <div class="col-md-3">Voting Participation:</div>

--- a/utils/format.go
+++ b/utils/format.go
@@ -613,13 +613,11 @@ func FormatGlobalParticipationRate(e uint64, r float64, currency string) templat
 func FormatCount(count uint64, finalized bool, shortenCalcHint bool) template.HTML {
 	if finalized || count > 0 {
 		return template.HTML(fmt.Sprintf("%v", count))
-	} else {
-		if shortenCalcHint {
-			return template.HTML("…")
-		} else {
-			return template.HTML(CalculatingHint)
-		}
 	}
+	if shortenCalcHint {
+		return template.HTML("…")
+	}
+	return template.HTML(CalculatingHint)
 }
 
 func FormatEtherValue(currency string, ethPrice decimal.Decimal, currentPrice template.HTML) template.HTML {

--- a/utils/format.go
+++ b/utils/format.go
@@ -30,7 +30,7 @@ import (
 	itypes "github.com/gobitfly/eth-rewards/types"
 )
 
-const CalculatingHint = `Calculating...`
+const CalculatingHint = `Calculating…`
 
 func FormatMessageToHtml(message string) template.HTML {
 	message = fmt.Sprint(strings.Replace(message, "Error: ", "", 1))
@@ -615,7 +615,7 @@ func FormatCount(count uint64, finalized bool, shortenCalcHint bool) template.HT
 		return template.HTML(fmt.Sprintf("%v", count))
 	} else {
 		if shortenCalcHint {
-			return template.HTML("...")
+			return template.HTML("…")
 		} else {
 			return template.HTML(CalculatingHint)
 		}

--- a/utils/format.go
+++ b/utils/format.go
@@ -608,8 +608,8 @@ func FormatGlobalParticipationRate(e uint64, r float64, currency string) templat
 	return template.HTML(p.Sprintf(tpl, float64(e)/float64(Config.Frontend.ClCurrencyDivisor)*price.GetPrice(Config.Frontend.ClCurrency, currency), rr))
 }
 
-// Returns 'count' as a string if parameter 'finalized' is true or if it holds a positive value.
 // When 'finalized' is false and 'count' is 0, a in-progress hint is returned (three dots if 'shortenCalcHint' is true)
+// If 'count' is positive or 'finalized' is true, 'count' is returned as a string
 func FormatCount(count uint64, finalized bool, shortenCalcHint bool) template.HTML {
 	if finalized || count > 0 {
 		return template.HTML(fmt.Sprintf("%v", count))

--- a/utils/format.go
+++ b/utils/format.go
@@ -30,6 +30,8 @@ import (
 	itypes "github.com/gobitfly/eth-rewards/types"
 )
 
+const CalculatingHint = `Calculating...`
+
 func FormatMessageToHtml(message string) template.HTML {
 	message = fmt.Sprint(strings.Replace(message, "Error: ", "", 1))
 	return template.HTML(message)
@@ -105,7 +107,7 @@ func FormatBalance(balanceInt uint64, currency string) template.HTML {
 // FormatBalance will return a string for a balance
 func FormatEligibleBalance(balanceInt uint64, currency string) template.HTML {
 	if balanceInt == 0 {
-		return `<span class="text-small text-muted">Calculating...</span>`
+		return `<span class="text-small text-muted">` + CalculatingHint + `</span>`
 	}
 	exchangeRate := price.GetPrice(Config.Frontend.ClCurrency, currency)
 	balance := FormatFloat((float64(balanceInt)/float64(Config.Frontend.ClCurrencyDivisor))*float64(exchangeRate), 2)
@@ -592,7 +594,7 @@ func FormatEth1TxHash(hash []byte) template.HTML {
 // FormatGlobalParticipationRate will return the global-participation-rate formated as html
 func FormatGlobalParticipationRate(e uint64, r float64, currency string) template.HTML {
 	if e == 0 {
-		return `<span class="text-small text-muted">Calculating...</span>`
+		return `<span class="text-small text-muted">` + CalculatingHint + `</span>`
 	}
 	p := message.NewPrinter(language.English)
 	rr := fmt.Sprintf("%v%%", math.Round(r*10000)/100)
@@ -604,6 +606,20 @@ func FormatGlobalParticipationRate(e uint64, r float64, currency string) templat
 	  </div>
 	</div>`
 	return template.HTML(p.Sprintf(tpl, float64(e)/float64(Config.Frontend.ClCurrencyDivisor)*price.GetPrice(Config.Frontend.ClCurrency, currency), rr))
+}
+
+// Returns 'count' as a string if parameter 'finalized' is true or if it holds a positive value.
+// When 'finalized' is false and 'count' is 0, a in-progress hint is returned (three dots if 'shortenCalcHint' is true)
+func FormatCount(count uint64, finalized bool, shortenCalcHint bool) template.HTML {
+	if finalized || count > 0 {
+		return template.HTML(fmt.Sprintf("%v", count))
+	} else {
+		if shortenCalcHint {
+			return template.HTML("...")
+		} else {
+			return template.HTML(CalculatingHint)
+		}
+	}
 }
 
 func FormatEtherValue(currency string, ethPrice decimal.Decimal, currentPrice template.HTML) template.HTML {


### PR DESCRIPTION
Adapt epoch.html to the slot-based exporter, so that the page displays "Calculating..." instead of "0" for certain fields during the ongoing epoch.

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 46ec6f5</samp>

Improve epoch page data accuracy and UX by adding "Calculating..." messages for unfinalized or unprocessed epochs in `templates/epoch.html`.
