### PR TITLE
(NOBIDS) Removal of 38 useless casting over 6 files

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -10,7 +10,6 @@ import (
 	"eth2-exporter/types"
 	"eth2-exporter/utils"
 	"fmt"
-	"html/template"
 	"math/big"
 	"regexp"
 	"sort"
@@ -2270,11 +2269,11 @@ func GetAddressWithdrawalTableData(address []byte, pageToken string, currency st
 	withdrawalsData := make([][]interface{}, len(withdrawals))
 	for i, w := range withdrawals {
 		withdrawalsData[i] = []interface{}{
-			template.HTML(fmt.Sprintf("%v", utils.FormatEpoch(utils.EpochOfSlot(w.Slot)))),
-			template.HTML(fmt.Sprintf("%v", utils.FormatBlockSlot(w.Slot))),
-			template.HTML(fmt.Sprintf("%v", utils.FormatTimestamp(utils.SlotToTime(w.Slot).Unix()))),
-			template.HTML(fmt.Sprintf("%v", utils.FormatValidator(w.ValidatorIndex))),
-			template.HTML(utils.FormatClCurrency(w.Amount, currency, 6, true, false, false, true)),
+			utils.FormatEpoch(utils.EpochOfSlot(w.Slot)),
+			utils.FormatBlockSlot(w.Slot),
+			utils.FormatTimestamp(utils.SlotToTime(w.Slot).Unix()),
+			utils.FormatValidator(w.ValidatorIndex),
+			utils.FormatClCurrency(w.Amount, currency, 6, true, false, false, true),
 		}
 	}
 

--- a/handlers/dashboard.go
+++ b/handlers/dashboard.go
@@ -434,7 +434,7 @@ func getNextWithdrawalRow(queryValidators []uint64, currency string) ([][]interf
 
 	nextData := make([][]interface{}, 0, 1)
 	nextData = append(nextData, []interface{}{
-		template.HTML(fmt.Sprintf("%v", utils.FormatValidator(nextValidator.Index))),
+		utils.FormatValidator(nextValidator.Index),
 		template.HTML(fmt.Sprintf(`<span class="text-muted">~ %s</span>`, utils.FormatEpoch(uint64(utils.TimeToEpoch(timeToWithdrawal))))),
 		template.HTML(fmt.Sprintf(`<span class="text-muted">~ %s</span>`, utils.FormatBlockSlot(utils.TimeToSlot(uint64(timeToWithdrawal.Unix()))))),
 		template.HTML(fmt.Sprintf(`<span class="">~ %s</span>`, utils.FormatTimestamp(timeToWithdrawal.Unix()))),
@@ -676,12 +676,12 @@ func DashboardDataWithdrawals(w http.ResponseWriter, r *http.Request) {
 
 	for _, w := range withdrawals {
 		tableData = append(tableData, []interface{}{
-			template.HTML(fmt.Sprintf("%v", utils.FormatValidator(w.ValidatorIndex))),
-			template.HTML(fmt.Sprintf("%v", utils.FormatEpoch(utils.EpochOfSlot(w.Slot)))),
-			template.HTML(fmt.Sprintf("%v", utils.FormatBlockSlot(w.Slot))),
-			template.HTML(fmt.Sprintf("%v", utils.FormatTimestamp(utils.SlotToTime(w.Slot).Unix()))),
-			template.HTML(fmt.Sprintf("%v", utils.FormatAddress(w.Address, nil, "", false, false, true))),
-			template.HTML(utils.FormatClCurrency(w.Amount, reqCurrency, 6, true, false, false, true)),
+			utils.FormatValidator(w.ValidatorIndex),
+			utils.FormatEpoch(utils.EpochOfSlot(w.Slot)),
+			utils.FormatBlockSlot(w.Slot),
+			utils.FormatTimestamp(utils.SlotToTime(w.Slot).Unix()),
+			utils.FormatAddress(w.Address, nil, "", false, false, true),
+			utils.FormatClCurrency(w.Amount, reqCurrency, 6, true, false, false, true),
 		})
 	}
 

--- a/handlers/eth1Account.go
+++ b/handlers/eth1Account.go
@@ -158,7 +158,7 @@ func Eth1Address(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			return fmt.Errorf("GetAddressWithdrawalsTotal: %w", err)
 		}
-		withdrawalSummary = template.HTML(utils.FormatClCurrency(sumWithdrawals, currency, 6, true, false, false, true))
+		withdrawalSummary = utils.FormatClCurrency(sumWithdrawals, currency, 6, true, false, false, true)
 		return nil
 	})
 

--- a/handlers/slot.go
+++ b/handlers/slot.go
@@ -783,9 +783,9 @@ func SlotWithdrawalData(w http.ResponseWriter, r *http.Request) {
 	for _, w := range withdrawals {
 		tableData = append(tableData, []interface{}{
 			template.HTML(fmt.Sprintf("%v", w.Index)),
-			template.HTML(fmt.Sprintf("%v", utils.FormatValidator(w.ValidatorIndex))),
-			template.HTML(fmt.Sprintf("%v", utils.FormatAddress(w.Address, nil, "", false, false, true))),
-			template.HTML(utils.FormatClCurrency(w.Amount, currency, 6, true, false, false, true)),
+			utils.FormatValidator(w.ValidatorIndex),
+			utils.FormatAddress(w.Address, nil, "", false, false, true),
+			utils.FormatClCurrency(w.Amount, currency, 6, true, false, false, true),
 		})
 	}
 
@@ -821,10 +821,10 @@ func SlotBlsChangeData(w http.ResponseWriter, r *http.Request) {
 	tableData := make([][]interface{}, 0, len(blsChange))
 	for _, c := range blsChange {
 		tableData = append(tableData, []interface{}{
-			template.HTML(fmt.Sprintf("%v", utils.FormatValidator(c.Validatorindex))),
-			template.HTML(fmt.Sprintf("%v", utils.FormatHashWithCopy(c.Signature))),
-			template.HTML(fmt.Sprintf("%v", utils.FormatHashWithCopy(c.BlsPubkey))),
-			template.HTML(fmt.Sprintf("%v", utils.FormatAddress(c.Address, nil, "", false, false, true))),
+			utils.FormatValidator(c.Validatorindex),
+			utils.FormatHashWithCopy(c.Signature),
+			utils.FormatHashWithCopy(c.BlsPubkey),
+			utils.FormatAddress(c.Address, nil, "", false, false, true),
 		})
 	}
 

--- a/handlers/validator.go
+++ b/handlers/validator.go
@@ -1288,11 +1288,11 @@ func ValidatorWithdrawals(w http.ResponseWriter, r *http.Request) {
 
 	for _, w := range withdrawals {
 		tableData = append(tableData, []interface{}{
-			template.HTML(fmt.Sprintf("%v", utils.FormatEpoch(utils.EpochOfSlot(w.Slot)))),
-			template.HTML(fmt.Sprintf("%v", utils.FormatBlockSlot(w.Slot))),
-			template.HTML(fmt.Sprintf("%v", utils.FormatTimestamp(utils.SlotToTime(w.Slot).Unix()))),
-			template.HTML(fmt.Sprintf("%v", utils.FormatAddress(w.Address, nil, "", false, false, true))),
-			template.HTML(utils.FormatClCurrency(w.Amount, reqCurrency, 6, true, false, false, true)),
+			utils.FormatEpoch(utils.EpochOfSlot(w.Slot)),
+			utils.FormatBlockSlot(w.Slot),
+			utils.FormatTimestamp(utils.SlotToTime(w.Slot).Unix()),
+			utils.FormatAddress(w.Address, nil, "", false, false, true),
+			utils.FormatClCurrency(w.Amount, reqCurrency, 6, true, false, false, true),
 		})
 	}
 
@@ -1853,7 +1853,7 @@ func incomeToTableData(epoch uint64, income *itypes.ValidatorEpochIncome, withdr
 		utils.FormatEpoch(epoch),
 		utils.FormatBalanceChangeFormatted(&rewards, currency, income),
 		template.HTML(""),
-		template.HTML(events),
+		events,
 	}
 }
 

--- a/handlers/withdrawals.go
+++ b/handlers/withdrawals.go
@@ -197,13 +197,13 @@ func WithdrawalsTableData(draw uint64, search string, length, start uint64, orde
 	tableData := make([][]interface{}, len(withdrawals))
 	for i, w := range withdrawals {
 		tableData[i] = []interface{}{
-			template.HTML(fmt.Sprintf("%v", utils.FormatEpoch(utils.EpochOfSlot(w.Slot)))),
-			template.HTML(fmt.Sprintf("%v", utils.FormatBlockSlot(w.Slot))),
+			utils.FormatEpoch(utils.EpochOfSlot(w.Slot)),
+			utils.FormatBlockSlot(w.Slot),
 			template.HTML(fmt.Sprintf("%v", w.Index)),
-			template.HTML(fmt.Sprintf("%v", utils.FormatValidator(w.ValidatorIndex))),
-			template.HTML(fmt.Sprintf("%v", utils.FormatTimestamp(utils.SlotToTime(w.Slot).Unix()))),
-			template.HTML(fmt.Sprintf("%v", utils.FormatAddressWithLimits(w.Address, names[string(w.Address)], false, "address", visibleDigitsForHash+5, 18, true))),
-			template.HTML(fmt.Sprintf("%v", utils.FormatAmount(new(big.Int).Mul(new(big.Int).SetUint64(w.Amount), big.NewInt(1e9)), formatCurrency, 6))),
+			utils.FormatValidator(w.ValidatorIndex),
+			utils.FormatTimestamp(utils.SlotToTime(w.Slot).Unix()),
+			utils.FormatAddressWithLimits(w.Address, names[string(w.Address)], false, "address", visibleDigitsForHash+5, 18, true),
+			utils.FormatAmount(new(big.Int).Mul(new(big.Int).SetUint64(w.Amount), big.NewInt(1e9)), formatCurrency, 6),
 		}
 	}
 
@@ -363,12 +363,12 @@ func BLSTableData(draw uint64, search string, length, start uint64, orderBy, ord
 	tableData := make([][]interface{}, len(blsChange))
 	for i, bls := range blsChange {
 		tableData[i] = []interface{}{
-			template.HTML(fmt.Sprintf("%v", utils.FormatEpoch(utils.EpochOfSlot(bls.Slot)))),
-			template.HTML(fmt.Sprintf("%v", utils.FormatBlockSlot(bls.Slot))),
-			template.HTML(fmt.Sprintf("%v", utils.FormatValidator(bls.Validatorindex))),
-			template.HTML(fmt.Sprintf("%v", utils.FormatHashWithCopy(bls.Signature))),
-			template.HTML(fmt.Sprintf("%v", utils.FormatHashWithCopy(bls.BlsPubkey))),
-			template.HTML(fmt.Sprintf("%v", utils.FormatAddressWithLimits(bls.Address, names[string(bls.Address)], false, "address", visibleDigitsForHash+5, 18, true))),
+			utils.FormatEpoch(utils.EpochOfSlot(bls.Slot)),
+			utils.FormatBlockSlot(bls.Slot),
+			utils.FormatValidator(bls.Validatorindex),
+			utils.FormatHashWithCopy(bls.Signature),
+			utils.FormatHashWithCopy(bls.BlsPubkey),
+			utils.FormatAddressWithLimits(bls.Address, names[string(bls.Address)], false, "address", visibleDigitsForHash+5, 18, true),
 		}
 	}
 


### PR DESCRIPTION
Removal of 38 useless casting over 6 files:

* from `template.HTML` to `template.HTML`, typically `template.HTML(utils.FormatXxxx(...))`
* from `template.HTML` to `string` to `template.HTML`, typically `template.HTML(fmt.Sprintf("%v", utils.FormatXxxx(...)))`

The first case is just a matter of writing.
The second case, which occurred often, executed `Sprintf()` uselessly so the workload of the server will decrease and response times will increase _in theory_*.

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at ad122be</samp>

Refactored various handlers and database functions to use plain string formatting instead of HTML. This improves code readability, performance, and security. Removed `html/template` dependency from `db` package.

\* probably unnoticeable, but still, it is good to remove useless work