### PR TITLE
(NOBIDS) Cause "no resolver" to remove ens entry

### DIFF
--- a/db/ens.go
+++ b/db/ens.go
@@ -503,7 +503,7 @@ func validateEnsName(client *ethclient.Client, name string, alreadyChecked *EnsC
 
 	addr, err := go_ens.Resolve(client, name)
 	if err != nil {
-		if err.Error() == "unregistered name" || err.Error() == "no address" {
+		if err.Error() == "unregistered name" || err.Error() == "no address" || err.Error() == "no resolver" {
 			// the given name is not available anymore, we can remove it from the db (if it is there)
 			err = removeEnsName(client, name)
 			if err != nil {


### PR DESCRIPTION
This PR causes the "no resolver" error thrown by `go_ens.Resolve` to simply remove the ens from the db instead of causing an error.