### PR TITLE
(NOBIDS) Fix debug level for eth.store

### DIFF
--- a/exporter/ethstore.go
+++ b/exporter/ethstore.go
@@ -210,7 +210,6 @@ func (ese *EthStoreExporter) prepareExportDayTx(tx *sqlx.Tx, day string) error {
 
 func (ese *EthStoreExporter) getStoreDay(day string) (*ethstore.Day, map[uint64]*ethstore.Day, error) {
 	logger.Infof("retrieving eth.store for day %v", day)
-	ethstore.SetDebugLevel(1000)
 	return ethstore.Calculate(context.Background(), ese.BNAddress, ese.ENAddress, day, 1, ethstore.RECEIPTS_MODE_SINGLE)
 }
 


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 0885031</samp>

Remove unnecessary debug level setting in `ethstore` package. This improves the performance and readability of the `exporter/ethstore.go` file.
