### PR TITLE
(NOBIDS) fix scam token detection

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1387,9 +1387,10 @@ func FormatTokenSymbol(symbol string) string {
 }
 
 func isMaliciousToken(symbol string) bool {
-	urls := xurls.Relaxed.FindAllString(symbol, -1)
-	isConfusable := confusables.IsDangerous(symbol, []string{"latin"})
-	return len(urls) > 0 || isConfusable || strings.ToUpper(symbol) == "ETH"
+	containsUrls := len(xurls.Relaxed.FindAllString(symbol, -1)) > 0
+	isConfusable := len(confusables.IsConfusable(symbol, false, []string{"LATIN", "COMMON"})) > 0
+	isMixedScript := confusables.IsMixedScript(symbol, nil)
+	return containsUrls || isConfusable || isMixedScript || strings.ToUpper(symbol) == "ETH"
 }
 
 func ReverseSlice[S ~[]E, E any](s S) {


### PR DESCRIPTION
Previously we used `confusables.IsDangerous` to detect tokens with weird token symbols. If you look into the code of that function, you'll see it checks `isConfusable && isMixedScript`, i.e. whether the string is confusable with Latin letters AND uses symbols from multiple scripts. If the token symbol entirely consists of symbols in another script (e.g. https://beaconcha.in/token/0xb4db731771601654322c1a469e747a69363813e7 is "ЕТН", which is actually from the Cyrillic script) this detection failed.

With this PR, we will now check `isConfusable || isMixedScript`, which will detect this token as sus.