### PR TITLE
Add Lantern Finance to list of staking services

### DIFF
--- a/templates/stakingServices.html
+++ b/templates/stakingServices.html
@@ -478,6 +478,20 @@
                     </td>
                   </tr>
                   <tr>
+                    <td data-column="Service"><a href="https://www.lantern.finance/">Lantern Finance</a></td>
+                    <td data-column="No Supermajority client" style="text-align: center;">❌</td>
+                    <td data-column="Validator key owner">Service</td>
+                    <td data-column="Withdrawal key owner">Service</td>
+                    <td data-column="Pool token">No</td>
+                    <td data-column="3rd Party Software">No</td>
+                    <td data-column="Min. Stake">Any Amount</td>
+                    <td data-column="Fee">15% of rewards</td>
+                    <td data-column="Open Source"><a href="https://github.com/lanternfi">No</a></td>
+                    <td data-column="Social">
+                      <i class="fab fa-discord ml-1 mr-1"></i><a href="https://twitter.com/LanternFi" target="_blank"><i class="fab fa-twitter ml-1 mr-1"></i></a><i class="fab fa-telegram ml-1 mr-1"></i><a href="support@lantern.finance" target="_blank"><i class="fa fa-mail-bulk ml-1 mr-1"></i></a>
+                    </td>
+                  </tr>
+                  <tr>
                     <td data-column="Service"><a href="https://www.launchnodes.com/">Launchnodes</a></td>
                     <td data-column="No Supermajority client" style="text-align: center;">❌</td>
                     <td data-column="Validator key owner">User</td>


### PR DESCRIPTION
Add Lantern Finance to list of staking services.  Lantern is a US-based staking service provider. 

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at a831b96</samp>

Add Lantern Finance to the list of staking services in `templates/stakingServices.html`. This is part of a pull request that updates the staking services data for the Eth2 explorer website.
