### PR TITLE
Fix txFee calculation in dencun

### DIFF
--- a/db/statistics.go
+++ b/db/statistics.go
@@ -1616,7 +1616,7 @@ func WriteExecutionChartSeriesForDay(day int64) error {
 				// totalMinerTips = totalMinerTips.Add(tipFee.Mul(gasUsed))
 				txFees = baseFee.Mul(gasUsed).Add(tipFee.Mul(gasUsed))
 				totalTxSavings = totalTxSavings.Add(maxFee.Mul(gasUsed).Sub(baseFee.Mul(gasUsed).Add(tipFee.Mul(gasUsed))))
-
+			// TODO: Handle type 3?
 			default:
 				logger.Fatalf("error unknown tx type %v hash: %x", tx.Status, tx.Hash)
 			}


### PR DESCRIPTION
Unfamiliar with the codebase, but just found out that the transaction reward in dencun fork (seen in devnet-12) is wrong. Most likely because the new tx type `3` is not being handled properly. Its being handled as type `0` or `1` and it should be handled as type `2`.

Example, in slot 317601 of devnet-12:
* 1) The reported tx fee is `5039999999706000` see [here](https://dencun-devnet-12.beaconcha.in/slot/317601).
* 2) But the tx fee is in reality `4284000000000000`, which is the reward that is really sent to the [fee recipient](https://dencun-devnet-12.beaconcha.in/address/0xf97e180c050e5ab072211ad2c213eb5aee4df134#blocks)

What is reported i)
![imagen](https://github.com/gobitfly/eth2-beaconchain-explorer/assets/8811422/e01c9d0c-8848-4a6a-a524-053c5bb8800c)

What in reality the fee recipient gets ii)
![imagen](https://github.com/gobitfly/eth2-beaconchain-explorer/assets/8811422/c4c9c341-2810-4650-87f6-1f3881337249)

Unfinished PR but this should fix it.

