### PR TITLE
Fix SQL update query

### DIFF
--- a/cmd/misc/main.go
+++ b/cmd/misc/main.go
@@ -1863,7 +1863,7 @@ func UpdateValidatorStatisticsSyncData(day uint64, client rpc.Client, dryRun boo
 				UPDATE validator_stats set
 				participated_sync = $1,
 				missed_sync = $2,
-				orphaned_sync = $3,
+				orphaned_sync = $3
 				WHERE day = $4 AND validatorindex = $5`,
 				data.ParticipatedSync,
 				data.MissedSync,


### PR DESCRIPTION
This PR fixes SQL update query in `misc` tool, command: `export-sync-committee-validator-stats`.

Full command: 
```sh
./misc -command=export-sync-committee-validator-stats -config=./configs/misc.config.yml -dry-run=false`
```

Debug log:
```sh
INFO[0000] exporting statistics for day 0 (epoch 0 to 224) 
INFO[0000] getting exported state for day 0             
INFO[0000] processing statistics for validators 0-13999 
INFO[0000] gathering sync duties                         day=0 endPeriod=0 firstEpoch=0 lastEpoch=224 module=db startPeriod=0
INFO[0000] retrieved committee members for period 0      day=0 endPeriod=0 firstEpoch=0 lastEpoch=224 module=db startPeriod=0
INFO[0000] gathering sync duties completed, took 72.883112ms  day=0 endPeriod=0 firstEpoch=0 lastEpoch=224 module=db startPeriod=0
INFO[0000] statistics data collection for day 0 completed 
INFO[0000] updating statistics data into the validator_stats table 512 | 14000 
ERRO[0001] error exporting stats for day 0               _file=main.go _function=main.exportSyncCommitteeValidatorStats _line=1761 errInfo_0="error during statistics data insert: ~error~" errType="*errors.errorString" error="commit unexpectedly resulted in rollback"
INFO[0001] finished all exporting stats for days 0 - 197, took 852.452473ms 
INFO[0001] REMEMBER: To execute export-stats-totals now to update the totals 
INFO[0001] command executed successfully
```

Database log:
```
ERROR:  syntax error at or near "WHERE" at character 111
```
