### PR TITLE
(BIDS-2674) Use the InternalState instead of the EventEpoch

### DIFF
--- a/services/notifications.go
+++ b/services/notifications.go
@@ -47,7 +47,7 @@ func notificationCollector() {
 		latestFinalizedEpoch := LatestFinalizedEpoch()
 
 		if latestFinalizedEpoch < 4 {
-			logger.Errorf("pausing notifications until at least 4 epochs have been exported into the db")
+			logger.Errorf("pausing notifications until at least 5 epochs have been exported into the db")
 			time.Sleep(time.Minute)
 			continue
 		}
@@ -1675,9 +1675,9 @@ func (n *validatorIsOfflineNotification) GetEpoch() uint64 {
 func (n *validatorIsOfflineNotification) GetInfo(includeUrl bool) string {
 	if n.IsOffline {
 		if includeUrl {
-			return fmt.Sprintf(`Validator <a href="https://%[3]v/validator/%[1]v">%[1]v</a> is offline since epoch <a href="https://%[3]v/epoch/%[2]v">%[2]v</a>).`, n.ValidatorIndex, n.EventEpoch, utils.Config.Frontend.SiteDomain)
+			return fmt.Sprintf(`Validator <a href="https://%[3]v/validator/%[1]v">%[1]v</a> is offline since epoch <a href="https://%[3]v/epoch/%[2]s">%[2]s</a>).`, n.ValidatorIndex, n.InternalState, utils.Config.Frontend.SiteDomain)
 		} else {
-			return fmt.Sprintf(`Validator %v is offline since epoch %v.`, n.ValidatorIndex, n.EventEpoch)
+			return fmt.Sprintf(`Validator %v is offline since epoch %s.`, n.ValidatorIndex, n.InternalState)
 		}
 	} else {
 		if includeUrl {


### PR DESCRIPTION
This PR is based on https://github.com/gobitfly/eth2-beaconchain-explorer/pull/2801 with the changes I suggested.