### PR TITLE
Documentation Improvements

### DIFF
--- a/local-deployment/README.md
+++ b/local-deployment/README.md
@@ -85,7 +85,7 @@ Above, we have started / stopped the local chain + the explorer manually. The `r
 # Exit validators
 Exiting individual validators can be done using the provided `exit_validator.sh` script. Requires [https://github.com/wealdtech/ethdo](ethdo) to be available on the path.
 ```
-bash exit_validators.sh -i validator_index -m "memonic" -b "http://bn_api_host:bn_api_port"
+bash exit_validators.sh -i validator_index -m "mnemonic" -b "http://bn_api_host:bn_api_port"
 ```
 
 # Enabling withdrawals

--- a/static/highlight/DIGESTS.md
+++ b/static/highlight/DIGESTS.md
@@ -1,6 +1,6 @@
 ## Subresource Integrity
 
-If you are loading Highlight.js via CDN you may wish to use [Subresource Integrity](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity) to guarantee that you are using a legimitate build of the library.
+If you are loading Highlight.js via CDN you may wish to use [Subresource Integrity](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity) to guarantee that you are using a legitimate build of the library.
 
 To do this you simply need to add the `integrity` attribute for each JavaScript file you download via CDN. These digests are used by the browser to confirm the files downloaded have not been modified.
 


### PR DESCRIPTION
## Changes Made

### 1. File: `local-deployment/README.md`
- **Line 88:**
  - Old: `mnemonic`
  - New: `mnemonic`
  - Reason: Corrects typographical error in script command for validator exit operations

### 2. File: `static/highlight/DIGESTS.md`
- **Line 2:**
  - Old: `legimitate`
  - New: `legitimate`
  - Reason: Corrects spelling error in documentation