### PR TITLE
Add notransaction fix

### DIFF
--- a/db/migrations/20241120092635_add_validatorindex_slot_index_withdrawals_table.sql
+++ b/db/migrations/20241120092635_add_validatorindex_slot_index_withdrawals_table.sql
@@ -1,11 +1,12 @@
+-- +goose NO TRANSACTION
 -- +goose Up
--- +goose StatementBegin
 SELECT 'creating idx_blocks_withdrawals_validatorindex_slot';
+-- +goose StatementBegin
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_blocks_withdrawals_validatorindex_slot ON blocks_withdrawals (validatorindex, block_slot DESC);
 -- +goose StatementEnd
 
 -- +goose Down
--- +goose StatementBegin
 SELECT 'dropping idx_blocks_withdrawals_validatorindex_slot';
+-- +goose StatementBegin
 DROP INDEX CONCURRENTLY IF EXISTS idx_blocks_withdrawals_validatorindex_slot;
 -- +goose StatementEnd

--- a/db/migrations/20250112125552_add_idx_blocks_status_depositscountgt0.sql
+++ b/db/migrations/20250112125552_add_idx_blocks_status_depositscountgt0.sql
@@ -1,13 +1,13 @@
 -- +goose NO TRANSACTION
 
 -- +goose Up
--- +goose StatementBegin
 SELECT 'creating idx_blocks_status_depositscountgt0';
+-- +goose StatementBegin
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_blocks_status_depositscountgt0 ON blocks (status, (depositscount > 0)) where depositscount > 0;
 -- +goose StatementEnd
 
 -- +goose Down
--- +goose StatementBegin
 SELECT 'dropping idx_blocks_status_depositscountgt0';
+-- +goose StatementBegin
 DROP INDEX CONCURRENTLY IF EXISTS idx_blocks_status_depositscountgt0;
 -- +goose StatementEnd


### PR DESCRIPTION
Disable transaction around `CREATE INDEX CONCURRENTLY` statements

See https://github.com/pressly/goose/issues/292  and #2307 