### PR TITLE
fix: enforce a maximum LIMIT of 2000

### DIFF
--- a/handlers/api.go
+++ b/handlers/api.go
@@ -1849,22 +1849,11 @@ func ApiValidatorByEth1Address(w http.ResponseWriter, r *http.Request) {
 	limitQuery := q.Get("limit")
 	offsetQuery := q.Get("offset")
 
-	limit, err := strconv.ParseInt(limitQuery, 10, 64)
-	if err != nil {
+	limit := parseUintWithDefault(limitQuery, 2000)
+	offset := parseUintWithDefault(offsetQuery, 0)
+
+	if limit > 2000 {
 		limit = 2000
-	}
-
-	offset, err := strconv.ParseInt(offsetQuery, 10, 64)
-	if err != nil {
-		offset = 0
-	}
-
-	if offset < 0 {
-		offset = 0
-	}
-
-	if limit > (2000+offset) || limit <= 0 || limit <= offset {
-		limit = 2000 + offset
 	}
 
 	vars := mux.Vars(r)


### PR DESCRIPTION
# Fix pagination by enforcing a maximum LIMIT of 2000

### Description
Previously, the API allowed arbitrary limit values, which could cause unintended behavior in pagination. Specifically, the existing logic adjusted limit dynamically based on offset, leading to inconsistencies when retrieving paginated results. This fix ensures that limit is strictly capped at 2000, allowing for predictable pagination behavior while preventing excessive database load.

### Changes
* Enforce limit to be at most 2000, preventing unpredictable query results.
* Remove the dynamic adjustment of limit based on offset to ensure proper pagination.
* Retain validation for negative or invalid limit values.

Why this fix is needed:
1.	Ensures that pagination works correctly by keeping a fixed limit.
2.	Prevents excessive resource consumption due to large limit values.
3.	Avoids inconsistencies caused by limit changing dynamically based on offset.