### PR TITLE
refactor: use the built-in max/min to simplify the code

### DIFF
--- a/services/stats.go
+++ b/services/stats.go
@@ -223,16 +223,12 @@ func getValidatorActivationChurnLimit(validatorCount, epoch uint64) (uint64, err
 
 // getValidatorChurnLimit returns the rate at which validators can leave the system
 func getValidatorChurnLimit(validatorCount uint64) (uint64, error) {
-	min := utils.Config.Chain.ClConfig.MinPerEpochChurnLimit
+	minVal := utils.Config.Chain.ClConfig.MinPerEpochChurnLimit
 
 	adaptable := uint64(0)
 	if validatorCount > 0 {
 		adaptable = validatorCount / utils.Config.Chain.ClConfig.ChurnLimitQuotient
 	}
 
-	if min > adaptable {
-		return min, nil
-	}
-
-	return adaptable, nil
+	return max(minVal, adaptable), nil
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1676,20 +1676,6 @@ func RemoveRoundBracketsIncludingContent(input string) string {
 	return result
 }
 
-func Int64Min(x, y int64) int64 {
-	if x < y {
-		return x
-	}
-	return y
-}
-
-func Int64Max(x, y int64) int64 {
-	if x > y {
-		return x
-	}
-	return y
-}
-
 // Prompt asks for a string value using the label. For comand line interactions.
 func CmdPrompt(label string) string {
 	var s string


### PR DESCRIPTION
Use the built-in max/min from the standard library in Go 1.21 to simplify the code.