### PR TITLE
fix: account for consolidation when writing `validator_stats`

### DIFF
--- a/types/exporter.go
+++ b/types/exporter.go
@@ -678,4 +678,9 @@ type ValidatorStatsTableDbRow struct {
 	MEVPerformance7d   decimal.Decimal `db:"-"`
 	MEVPerformance31d  decimal.Decimal `db:"-"`
 	MEVPerformance365d decimal.Decimal `db:"-"`
+
+	IncomingConsolidationCount  int64
+	OutgoingConsolidationCount  int64
+	IncomingConsolidationAmount int64
+	OutgoingConsolidationAmount int64
 }


### PR DESCRIPTION
- Fixes consolidations being counted torwards CL Rewards
- Treats incoming and outgoing consolidations as deposits and withdrawals respectively
