### PR TITLE
fix: remove rudimental support column value for reth client

### DIFF
--- a/templates/ethClientsServices.html
+++ b/templates/ethClientsServices.html
@@ -137,7 +137,6 @@
                     <td data-column="Social media">
                       <a href="https://t.me/paradigm_reth" target="_blank"><i class="fab fa-telegram ml-1 mr-1"></i></a>
                     </td>
-                    <td data-column="Support">N/A</td>
                     {{ if $.User.Authenticated }}
                       <td><input id="reth-checkbox" type="checkbox" data-toggle="toggle" {{ if .Reth.IsUserSubscribed }}checked{{ end }} onchange="updateUserSubscription('reth-checkbox', 'eth_client_update', 'reth')" /></td>
                     {{ end }}


### PR DESCRIPTION
There's a value specified for seems to be rudimental column support for Reth client that is breaking the layout at https://beaconcha.in/user/ethClients

![image](https://github.com/user-attachments/assets/dccce184-4e25-4687-949d-068d9bb30a42)