### PR TITLE
fix: show ens-name when the url contains the ens-name

### DIFF
--- a/handlers/ens.go
+++ b/handlers/ens.go
@@ -53,6 +53,7 @@ func GetEnsDomain(search string) (*types.EnsDomainResponse, error) {
 
 		if address, err := cache.TieredCache.GetStringWithLocalTimeout(cacheKey, time.Minute); err == nil && len(address) > 0 {
 			data.Address = address
+			data.Domain = search
 			return data, nil
 		}
 


### PR DESCRIPTION
BEDS-1556

