### PR TITLE
feat(sql): add Pectra v1 and v2 tables and indexes

### DIFF
--- a/db/migrations/20250822112108_add_pectra_v2_tables.sql
+++ b/db/migrations/20250822112108_add_pectra_v2_tables.sql
@@ -1,0 +1,122 @@
+-- +goose Up
+-- Pectra (Electra) upgrade database schema changes
+
+-- +goose StatementBegin
+SELECT 'adding committeebits column to blocks_attestations table';
+ALTER TABLE blocks_attestations ADD COLUMN IF NOT EXISTS committeebits bytea;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+SELECT 'creating blocks_deposit_requests_v2 table';
+CREATE TABLE IF NOT EXISTS blocks_deposit_requests_v2 (
+    slot_processed INT NOT NULL,
+    index_processed INT NOT NULL,
+    block_processed_root bytea NOT NULL,
+    pubkey bytea NOT NULL,
+    withdrawal_credentials bytea NOT NULL,
+    amount BIGINT NOT NULL,
+    signature bytea NOT NULL,
+    status VARCHAR(20) NOT NULL DEFAULT 'pending',
+    created_at TIMESTAMP DEFAULT NOW(),
+    PRIMARY KEY (slot_processed, index_processed)
+);
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+SELECT 'creating blocks_withdrawal_requests_v2 table';
+CREATE TABLE IF NOT EXISTS blocks_withdrawal_requests_v2 (
+    slot_processed INT NOT NULL,
+    index_processed INT NOT NULL,
+    block_processed_root bytea NOT NULL,
+    source_address bytea NOT NULL,
+    validator_pubkey bytea NOT NULL,
+    amount BIGINT NOT NULL,
+    status VARCHAR(20) NOT NULL DEFAULT 'pending',
+    created_at TIMESTAMP DEFAULT NOW(),
+    PRIMARY KEY (slot_processed, index_processed)
+);
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+SELECT 'creating blocks_consolidation_requests_v2 table';
+CREATE TABLE IF NOT EXISTS blocks_consolidation_requests_v2 (
+    slot_processed INT NOT NULL,
+    index_processed INT NOT NULL,
+    block_processed_root bytea NOT NULL,
+    source_pubkey bytea NOT NULL,
+    target_pubkey bytea NOT NULL,
+    amount_consolidated BIGINT NOT NULL DEFAULT 0,
+    status VARCHAR(20) NOT NULL DEFAULT 'pending',
+    created_at TIMESTAMP DEFAULT NOW(),
+    PRIMARY KEY (slot_processed, index_processed)
+);
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+SELECT 'creating blocks_switch_to_compounding_requests_v2 table';
+CREATE TABLE IF NOT EXISTS blocks_switch_to_compounding_requests_v2 (
+    slot_processed INT NOT NULL,
+    index_processed INT NOT NULL,
+    block_processed_root bytea NOT NULL,
+    validator_pubkey bytea NOT NULL,
+    status VARCHAR(20) NOT NULL DEFAULT 'pending',
+    created_at TIMESTAMP DEFAULT NOW(),
+    PRIMARY KEY (slot_processed, index_processed)
+);
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+SELECT 'creating indexes for blocks_deposit_requests_v2';
+CREATE INDEX IF NOT EXISTS idx_blocks_deposit_requests_v2_pubkey ON blocks_deposit_requests_v2 (pubkey);
+CREATE INDEX IF NOT EXISTS idx_blocks_deposit_requests_v2_status ON blocks_deposit_requests_v2 (status);
+CREATE INDEX IF NOT EXISTS idx_blocks_deposit_requests_v2_slot ON blocks_deposit_requests_v2 (slot_processed);
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+SELECT 'creating indexes for blocks_withdrawal_requests_v2';
+CREATE INDEX IF NOT EXISTS idx_blocks_withdrawal_requests_v2_pubkey ON blocks_withdrawal_requests_v2 (validator_pubkey);
+CREATE INDEX IF NOT EXISTS idx_blocks_withdrawal_requests_v2_address ON blocks_withdrawal_requests_v2 (source_address);
+CREATE INDEX IF NOT EXISTS idx_blocks_withdrawal_requests_v2_status ON blocks_withdrawal_requests_v2 (status);
+CREATE INDEX IF NOT EXISTS idx_blocks_withdrawal_requests_v2_slot ON blocks_withdrawal_requests_v2 (slot_processed);
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+SELECT 'creating indexes for blocks_consolidation_requests_v2';
+CREATE INDEX IF NOT EXISTS idx_blocks_consolidation_requests_v2_source_pubkey ON blocks_consolidation_requests_v2 (source_pubkey);
+CREATE INDEX IF NOT EXISTS idx_blocks_consolidation_requests_v2_target_pubkey ON blocks_consolidation_requests_v2 (target_pubkey);
+CREATE INDEX IF NOT EXISTS idx_blocks_consolidation_requests_v2_status ON blocks_consolidation_requests_v2 (status);
+CREATE INDEX IF NOT EXISTS idx_blocks_consolidation_requests_v2_slot ON blocks_consolidation_requests_v2 (slot_processed);
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+SELECT 'creating indexes for blocks_switch_to_compounding_requests_v2';
+CREATE INDEX IF NOT EXISTS idx_blocks_switch_to_compounding_requests_v2_pubkey ON blocks_switch_to_compounding_requests_v2 (validator_pubkey);
+CREATE INDEX IF NOT EXISTS idx_blocks_switch_to_compounding_requests_v2_status ON blocks_switch_to_compounding_requests_v2 (status);
+CREATE INDEX IF NOT EXISTS idx_blocks_switch_to_compounding_requests_v2_slot ON blocks_switch_to_compounding_requests_v2 (slot_processed);
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+SELECT 'dropping blocks_switch_to_compounding_requests_v2 table';
+DROP TABLE IF EXISTS blocks_switch_to_compounding_requests_v2;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+SELECT 'dropping blocks_consolidation_requests_v2 table';
+DROP TABLE IF EXISTS blocks_consolidation_requests_v2;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+SELECT 'dropping blocks_withdrawal_requests_v2 table';
+DROP TABLE IF EXISTS blocks_withdrawal_requests_v2;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+SELECT 'dropping blocks_deposit_requests_v2 table';
+DROP TABLE IF EXISTS blocks_deposit_requests_v2;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+SELECT 'removing committeebits column from blocks_attestations table';
+ALTER TABLE blocks_attestations DROP COLUMN IF EXISTS committeebits;
+-- +goose StatementEnd

--- a/db/migrations/20250822112109_add_pectra_v1_tables.sql
+++ b/db/migrations/20250822112109_add_pectra_v1_tables.sql
@@ -1,0 +1,148 @@
+-- +goose Up
+-- Missing Pectra (Electra) v1 tables
+
+-- +goose StatementBegin
+SELECT 'creating blocks_exit_requests table';
+CREATE TABLE IF NOT EXISTS blocks_exit_requests (
+    block_slot INT NOT NULL,
+    block_index INT NOT NULL,
+    block_root bytea NOT NULL DEFAULT '',
+    validator_pubkey bytea NOT NULL,
+    status VARCHAR(20) NOT NULL DEFAULT 'pending',
+    reject_reason VARCHAR(255),
+    block_processed_root bytea,
+    slot_processed INT,
+    created_at TIMESTAMP DEFAULT NOW(),
+    PRIMARY KEY (block_slot, block_index)
+);
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+SELECT 'creating blocks_switch_to_compounding_requests table';
+CREATE TABLE IF NOT EXISTS blocks_switch_to_compounding_requests (
+    block_slot INT NOT NULL,
+    block_index INT NOT NULL,
+    block_root bytea NOT NULL DEFAULT '',
+    validator_pubkey bytea NOT NULL,
+    request_index INT NOT NULL,
+    address bytea,
+    status VARCHAR(20) NOT NULL DEFAULT 'pending',
+    created_at TIMESTAMP DEFAULT NOW(),
+    PRIMARY KEY (block_slot, block_index)
+);
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+SELECT 'creating indexes for blocks_exit_requests';
+CREATE INDEX IF NOT EXISTS idx_blocks_exit_requests_validator_pubkey ON blocks_exit_requests (validator_pubkey);
+CREATE INDEX IF NOT EXISTS idx_blocks_exit_requests_status ON blocks_exit_requests (status);
+CREATE INDEX IF NOT EXISTS idx_blocks_exit_requests_slot ON blocks_exit_requests (block_slot);
+CREATE INDEX IF NOT EXISTS idx_blocks_exit_requests_block_processed_root ON blocks_exit_requests (block_processed_root);
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+SELECT 'creating indexes for blocks_switch_to_compounding_requests';
+CREATE INDEX IF NOT EXISTS idx_blocks_switch_to_compounding_requests_validator_pubkey ON blocks_switch_to_compounding_requests (validator_pubkey);
+CREATE INDEX IF NOT EXISTS idx_blocks_switch_to_compounding_requests_status ON blocks_switch_to_compounding_requests (status);
+CREATE INDEX IF NOT EXISTS idx_blocks_switch_to_compounding_requests_slot ON blocks_switch_to_compounding_requests (block_slot);
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+SELECT 'creating blocks_withdrawal_requests table';
+CREATE TABLE IF NOT EXISTS blocks_withdrawal_requests (
+    block_slot INT NOT NULL,
+    block_index INT NOT NULL,
+    block_root bytea NOT NULL DEFAULT '',
+    request_index INT NOT NULL,
+    source_address bytea,
+    validator_pubkey bytea NOT NULL,
+    amount BIGINT NOT NULL,
+    status VARCHAR(20) NOT NULL DEFAULT 'pending',
+    created_at TIMESTAMP DEFAULT NOW(),
+    PRIMARY KEY (block_slot, block_index)
+);
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+SELECT 'creating eth1_consolidation_requests table';
+CREATE TABLE IF NOT EXISTS eth1_consolidation_requests (
+    tx_hash bytea NOT NULL,
+    tx_index INT NOT NULL,
+    itx_index INT NOT NULL,
+    block_number BIGINT NOT NULL,
+    block_ts TIMESTAMP NOT NULL,
+    from_address bytea NOT NULL,
+    fee BIGINT NOT NULL,
+    source_address bytea NOT NULL,
+    source_pubkey bytea NOT NULL,
+    target_pubkey bytea NOT NULL,
+    PRIMARY KEY (tx_hash, tx_index, itx_index)
+);
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+SELECT 'creating indexes for blocks_withdrawal_requests';
+CREATE INDEX IF NOT EXISTS idx_blocks_withdrawal_requests_validator_pubkey ON blocks_withdrawal_requests (validator_pubkey);
+CREATE INDEX IF NOT EXISTS idx_blocks_withdrawal_requests_source_address ON blocks_withdrawal_requests (source_address);
+CREATE INDEX IF NOT EXISTS idx_blocks_withdrawal_requests_status ON blocks_withdrawal_requests (status);
+CREATE INDEX IF NOT EXISTS idx_blocks_withdrawal_requests_slot ON blocks_withdrawal_requests (block_slot);
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+SELECT 'creating eth1_withdrawal_requests table';
+CREATE TABLE IF NOT EXISTS eth1_withdrawal_requests (
+    tx_hash bytea NOT NULL,
+    tx_index INT NOT NULL,
+    itx_index INT NOT NULL,
+    block_number BIGINT NOT NULL,
+    block_ts TIMESTAMP NOT NULL,
+    from_address bytea NOT NULL,
+    fee BIGINT NOT NULL,
+    source_address bytea NOT NULL,
+    validator_pubkey bytea NOT NULL,
+    amount BIGINT NOT NULL,
+    PRIMARY KEY (tx_hash, tx_index, itx_index)
+);
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+SELECT 'creating indexes for eth1_consolidation_requests';
+CREATE INDEX IF NOT EXISTS idx_eth1_consolidation_requests_source_pubkey ON eth1_consolidation_requests (source_pubkey);
+CREATE INDEX IF NOT EXISTS idx_eth1_consolidation_requests_target_pubkey ON eth1_consolidation_requests (target_pubkey);
+CREATE INDEX IF NOT EXISTS idx_eth1_consolidation_requests_block_number ON eth1_consolidation_requests (block_number);
+CREATE INDEX IF NOT EXISTS idx_eth1_consolidation_requests_block_ts ON eth1_consolidation_requests (block_ts);
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+SELECT 'creating indexes for eth1_withdrawal_requests';
+CREATE INDEX IF NOT EXISTS idx_eth1_withdrawal_requests_validator_pubkey ON eth1_withdrawal_requests (validator_pubkey);
+CREATE INDEX IF NOT EXISTS idx_eth1_withdrawal_requests_source_address ON eth1_withdrawal_requests (source_address);
+CREATE INDEX IF NOT EXISTS idx_eth1_withdrawal_requests_block_number ON eth1_withdrawal_requests (block_number);
+CREATE INDEX IF NOT EXISTS idx_eth1_withdrawal_requests_block_ts ON eth1_withdrawal_requests (block_ts);
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+SELECT 'dropping eth1_withdrawal_requests table';
+DROP TABLE IF EXISTS eth1_withdrawal_requests;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+SELECT 'dropping eth1_consolidation_requests table';
+DROP TABLE IF EXISTS eth1_consolidation_requests;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+SELECT 'dropping blocks_withdrawal_requests table';
+DROP TABLE IF EXISTS blocks_withdrawal_requests;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+SELECT 'dropping blocks_switch_to_compounding_requests table';
+DROP TABLE IF EXISTS blocks_switch_to_compounding_requests;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+SELECT 'dropping blocks_exit_requests table';
+DROP TABLE IF EXISTS blocks_exit_requests;
+-- +goose StatementEnd


### PR DESCRIPTION


The current codebase is missing some DB migration SQL, causing errors:
```
time="2025-08-22T06:18:45Z" level=error msg="error getting validator data" _file=validator.go _function=github.com/gobitfly/eth2-beaconchain-explorer/handlers.Validator _line=1155 errType="*errors.errorString" error="error retrieving blocks_switch_to_compounding_requests of validator 51909: ERROR: relation \"blocks_switch_to_compounding_requests\" does not exist (SQLSTATE 42P01)"
time="2025-08-22T06:18:47Z" level=error msg="error executing template" error="error retrieving block deposit data: ERROR: relation \"blocks_exit_requests\" does not exist (SQLSTATE 42P01)" error type="*errors.errorString" file=slot.go function=Slot info=GetSlotPageData module=handlers route=/slot/126a32cb3e1722ec10129e1e0397e0e8f932abe62bf6293759a378540231f7c0
time="2025-08-22T06:18:48Z" level=error msg="error executing template" error="error retrieving block deposit data: ERROR: relation \"blocks_exit_requests\" does not exist (SQLSTATE 42P01)" error type="*errors.errorString" file=slot.go function=Slot info=GetSlotPageData module=handlers route=/slot/fc65376d438ca57d0532bbaccc138b25b98b42bcfdee30b25ddf831f3247b734
time="2025-08-22T06:18:48Z" level=error msg="error executing template" error="error retrieving block deposit data: ERROR: relation \"blocks_exit_requests\" does not exist (SQLSTATE 42P01)" error type="*errors.errorString" file=slot.go function=Slot info=GetSlotPageData module=handlers route=/slot/7742f576cfd51642dc75fce79934ce32cc3fce45af9208dcf9d654c856d873f9
time="2025-08-22T06:18:49Z" level=error msg="error executing template" error="error retrieving block deposit data: ERROR: relation \"blocks_exit_requests\" does not exist (SQLSTATE 42P01)" error type="*errors.errorString" file=slot.go function=Slot info=GetSlotPageData module=handlers route=/slot/3824057
time="2025-08-22T06:18:50Z" level=error msg="error executing template" error="error retrieving block deposit data: ERROR: relation \"blocks_exit_requests\" does not exist (SQLSTATE 42P01)" error type="*errors.errorString" file=slot.go function=Slot info=GetSlotPageData module=handlers route=/slot/7a34575c693c4056941e6a16fd45503c69aabd8781ffdc1cf4dfc18e775d6af4



```